### PR TITLE
feat(apply): display overlay picker when name is omitted

### DIFF
--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use clap::Args;
+use dialoguer::FuzzySelect;
+use dialoguer::theme::ColorfulTheme;
 use dirs::home_dir;
 
 use crate::actions;
@@ -12,7 +14,7 @@ use crate::ui::{emojis, style};
 #[derive(Args, Debug)]
 pub struct Params {
     #[clap(help = "Name of the overlay to apply")]
-    name: String,
+    name: Option<String>,
 
     #[clap(short, long, help = "The target root directory (~)")]
     root: Option<PathBuf>,
@@ -43,7 +45,22 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     if cli.debug {
         println!("{:#?}", repo);
     }
-    let overlay = repo.get(&args.name)?;
+    let overlay = match &args.name {
+        Some(name) => repo.get(name)?,
+        None => {
+            let overlays = repo.overlays()?;
+            if overlays.is_empty() {
+                return Err(anyhow!("no overlays found in repository"));
+            }
+            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+                .with_prompt("Choose the overlay to apply")
+                .default(0)
+                .items(&overlays[..])
+                .interact()
+                .map_err(|e| anyhow!("overlay selection cancelled: {}", e))?;
+            overlays[selection].clone()
+        }
+    };
     if cli.debug {
         println!("{:#?}", overlay);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -53,6 +53,18 @@ fn apply_overlay_dry_run() -> TestResult {
 }
 
 #[test]
+fn apply_without_name_empty_repo_fails() -> TestResult {
+    let tmp = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.arg("--home").arg(tmp.path());
+    cmd.args(["apply", "--dry-run"]);
+    cmd.assert()
+        .failure()
+        .stderr(contains("no overlays found in repository"));
+    Ok(())
+}
+
+#[test]
 fn add_file_to_overlay_dry_run() -> TestResult {
     let repo = setup_overlay_repo();
     // create a dummy target file that would be added


### PR DESCRIPTION
## Summary

- Make the overlay `name` argument optional on `over apply`
- When no name is provided, present a `FuzzySelect` interactive picker listing all available overlays (same pattern used by `add`, `git-over mount`, etc.)
- Error cleanly when the repository has no overlays or the user cancels the selection