### PR TITLE
fix(ci): make tests cross-platform compatible for Windows

### DIFF
--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -1116,7 +1116,7 @@ mod tests {
     #[test]
     fn test_short_name() {
         let action = EnsureGitRepository::new(
-            PathBuf::from("/tmp/test"),
+            PathBuf::from("test"),
             GitRepoConfig {
                 url: "https://github.com/user/my-repo.git".to_string(),
                 branch: None,
@@ -1138,7 +1138,7 @@ mod tests {
     #[test]
     fn test_short_name_no_git_suffix() {
         let action = EnsureGitRepository::new(
-            PathBuf::from("/tmp/test"),
+            PathBuf::from("test"),
             GitRepoConfig {
                 url: "https://github.com/user/my-repo".to_string(),
                 branch: None,

--- a/src/cli/git_over/mod.rs
+++ b/src/cli/git_over/mod.rs
@@ -355,7 +355,7 @@ mod tests {
         let over_repo = Repository::new(td.path().to_path_buf());
         let overlay = over_repo.get("overlay").unwrap();
 
-        let repo_dir = PathBuf::from("/tmp/elsewhere");
+        let repo_dir = PathBuf::from("elsewhere");
         let result = repo_relative_path(&overlay, td.path(), &repo_dir);
         assert!(result.is_err());
     }

--- a/src/cli/git_over/status.rs
+++ b/src/cli/git_over/status.rs
@@ -225,6 +225,9 @@ mod tests {
     use rstest::rstest;
     use std::path::PathBuf;
 
+    #[allow(unused_imports)]
+    use symlink::symlink_file;
+
     // ── is_overlay_descriptor ────────────────────────────────────────────
 
     #[rstest]
@@ -291,7 +294,7 @@ mod tests {
         worktree_dir.create_dir_all().unwrap();
         let link_path = worktree_dir.path().join("config.txt");
 
-        std::os::unix::fs::symlink(overlay_file.path(), &link_path).unwrap();
+        symlink::symlink_file(overlay_file.path(), &link_path).unwrap();
 
         let overlay_root_canonical = overlay_dir.path().canonicalize().unwrap();
         assert!(is_symlink_to(
@@ -319,7 +322,7 @@ mod tests {
         let link_path = worktree_dir.path().join("config.txt");
 
         // Symlink to a file NOT in the overlay
-        std::os::unix::fs::symlink(other_file.path(), &link_path).unwrap();
+        symlink::symlink_file(other_file.path(), &link_path).unwrap();
 
         let overlay_root_canonical = overlay_dir.path().canonicalize().unwrap();
         assert!(!is_symlink_to(
@@ -343,7 +346,7 @@ mod tests {
         worktree_dir.create_dir_all().unwrap();
         let link_path = worktree_dir.path().join("dotfile");
 
-        std::os::unix::fs::symlink(overlay_file.path(), &link_path).unwrap();
+        symlink::symlink_file(overlay_file.path(), &link_path).unwrap();
 
         let overlay_root_canonical = overlay_dir.path().canonicalize().unwrap();
         // overlay_file is under overlay_root, so relative path matching should work

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -365,9 +365,14 @@ mod tests {
 
     #[test]
     fn test_resolve_target_path_absolute() {
+        #[cfg(unix)]
+        let abs_path = "/tmp/overlay-test";
+        #[cfg(windows)]
+        let abs_path = "C:\\overlay-test";
+
         assert_eq!(
-            resolve_target_path("/tmp/overlay-test").unwrap(),
-            PathBuf::from("/tmp/overlay-test")
+            resolve_target_path(abs_path).unwrap(),
+            PathBuf::from(abs_path)
         );
     }
 

--- a/src/exec/context.rs
+++ b/src/exec/context.rs
@@ -197,7 +197,12 @@ mod tests {
     use indicatif::{MultiProgress, ProgressBar};
 
     fn dummy_repo() -> Repository {
-        Repository::new(PathBuf::from("/tmp/over-test-repo"))
+        #[cfg(unix)]
+        let repo_path = PathBuf::from("/tmp/over-test-repo");
+        #[cfg(windows)]
+        let repo_path = PathBuf::from("C:\\over-test-repo");
+
+        Repository::new(repo_path)
     }
 
     fn make_overlay() -> (TempDir, Overlay) {
@@ -228,13 +233,18 @@ mod tests {
 
     #[test]
     fn builder_sets_flags() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/home/test");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\home\\test");
+
         let ctx = Context::builder()
             .dry_run(true)
             .debug(true)
             .verbose(true)
             .force(true)
             .no_prompt(true)
-            .root(PathBuf::from("/home/test"))
+            .root(root_path.clone())
             .repository(dummy_repo())
             .build();
 
@@ -243,16 +253,21 @@ mod tests {
         assert!(ctx.verbose);
         assert!(ctx.force);
         assert!(ctx.no_prompt);
-        assert_eq!(ctx.root, PathBuf::from("/home/test"));
-        assert_eq!(ctx.repository.root, PathBuf::from("/tmp/over-test-repo"));
+        assert_eq!(ctx.root, root_path);
+        assert_eq!(ctx.repository.root, dummy_repo().root);
     }
 
     #[test]
     fn builder_partial_flags() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/tmp");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\tmp");
+
         let ctx = Context::builder()
             .dry_run(true)
             .verbose(true)
-            .root(PathBuf::from("/tmp"))
+            .root(root_path)
             .build();
 
         assert!(ctx.dry_run);
@@ -264,10 +279,15 @@ mod tests {
 
     #[test]
     fn with_overlay_preserves_other_fields() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/home/test");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\home\\test");
+
         let ctx = Context::builder()
             .dry_run(true)
             .verbose(true)
-            .root(PathBuf::from("/home/test"))
+            .root(root_path.clone())
             .repository(dummy_repo())
             .build();
 
@@ -276,7 +296,7 @@ mod tests {
 
         assert!(new_ctx.dry_run);
         assert!(new_ctx.verbose);
-        assert_eq!(new_ctx.root, PathBuf::from("/home/test"));
+        assert_eq!(new_ctx.root, root_path);
         assert!(new_ctx.overlay.is_some());
         // Original should be unchanged
         assert!(ctx.overlay.is_none());
@@ -284,8 +304,13 @@ mod tests {
 
     #[test]
     fn with_progress_sets_progress_bar() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/tmp");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\tmp");
+
         let ctx = Context::builder()
-            .root(PathBuf::from("/tmp"))
+            .root(root_path)
             .repository(dummy_repo())
             .build();
         let pb = ProgressBar::hidden();
@@ -299,8 +324,13 @@ mod tests {
 
     #[test]
     fn with_multiprogress_sets_multi() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/tmp");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\tmp");
+
         let ctx = Context::builder()
-            .root(PathBuf::from("/tmp"))
+            .root(root_path)
             .repository(dummy_repo())
             .build();
         let mp = MultiProgress::new();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -124,7 +124,7 @@ fn add_nonexistent_file_fails() -> TestResult {
     cmd.arg("--home").arg(repo.path());
     cmd.args([
         "add",
-        "/tmp/nonexistent_file_xyz.txt",
+        "nonexistent_file_xyz.txt",
         "-o",
         "dev",
         "--root",
@@ -237,10 +237,13 @@ fn show_overlay_with_target() -> TestResult {
     let tmp = TempDir::new()?;
     let ov = tmp.path().join("myoverlay");
     fs::create_dir_all(&ov)?;
-    fs::write(
-        ov.join("over.toml"),
-        b"target = \"/home/user\"\ndescription = \"My test overlay\"",
-    )?;
+    let target_path = tmp.path().join("target_user");
+    let target_str = target_path.to_string_lossy().to_string();
+    let toml_content = format!(
+        "target = \"{}\"\ndescription = \"My test overlay\"",
+        target_str
+    );
+    fs::write(ov.join("over.toml"), toml_content.as_bytes())?;
 
     Command::cargo_bin("over")?
         .arg("--home")
@@ -249,7 +252,7 @@ fn show_overlay_with_target() -> TestResult {
         .assert()
         .success()
         .stdout(contains("myoverlay"))
-        .stdout(contains("/home/user"))
+        .stdout(contains(&target_str))
         .stdout(contains("My test overlay"));
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Replace `std::os::unix::fs::symlink` with cross-platform `symlink::symlink_file` in `status.rs` tests (P0 compile failure on Windows)
- Add `#[cfg(unix)]`/`#[cfg(windows)]` guards for hardcoded `/tmp` and `/home` paths in test assertions across 5 files
- Fix integration test `show_overlay_with_target` to use dynamic temp paths instead of hardcoded Unix paths

## Files changed

- `src/cli/git_over/status.rs` — cross-platform symlink creation in tests
- `src/cli/new.rs` — platform-aware absolute path test
- `src/exec/context.rs` — platform-aware dummy repo and root paths
- `src/actions/git/mod.rs` — remove `/tmp` prefix from unused path arg
- `src/cli/git_over/mod.rs` — remove `/tmp` prefix from unused path arg
- `tests/cli.rs` — platform-independent nonexistent file and target path tests