### PR TITLE
feat: add symlink management via .link.(toml|yaml) files

### DIFF
--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -239,6 +239,10 @@ pub async fn link(ctx: Ctx, overlay: &Overlay, to: &Path) -> Result<()> {
         .literal_separator(true)
         .build()?
         .compile_matcher();
+    let symlink_config = GlobBuilder::new("**/*.link.{toml,yaml,yml}")
+        .literal_separator(true)
+        .build()?
+        .compile_matcher();
     let files = WalkDir::new(&overlay.root)
         .min_depth(1)
         .into_iter()
@@ -249,7 +253,7 @@ pub async fn link(ctx: Ctx, overlay: &Overlay, to: &Path) -> Result<()> {
                 None
             }
         })
-        .filter(|e| !exclude.is_match(e.path()));
+        .filter(|e| !exclude.is_match(e.path()) && !symlink_config.is_match(e.path()));
 
     for file in files {
         // progress.tick();

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,6 +1,10 @@
 pub mod fs;
 pub mod git;
 pub mod install;
+pub mod symlink;
 
 pub use fs::{EnsureDir, EnsureLink};
 pub use git::EnsureGitRepository;
+pub use symlink::{
+    EnsureSymlink, LinkType, SymlinkConfig, discover_symlinks, render_symlink_target,
+};

--- a/src/actions/symlink.rs
+++ b/src/actions/symlink.rs
@@ -1,0 +1,656 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as AnyhowContext, Result};
+use async_trait::async_trait;
+use minijinja::Environment;
+use serde::{Deserialize, Serialize};
+use symlink::{remove_symlink_dir, remove_symlink_file, symlink_dir, symlink_file};
+
+use crate::exec::{Action, Ctx};
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LinkType {
+    #[default]
+    Soft,
+    Hard,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SymlinkConfig {
+    pub target: String,
+    #[serde(default)]
+    pub r#type: LinkType,
+}
+
+pub struct EnsureSymlink {
+    pub source: PathBuf,
+    pub target: PathBuf,
+    pub link_type: LinkType,
+    pub is_dir: bool,
+}
+
+impl EnsureSymlink {
+    pub fn new(source: PathBuf, target: PathBuf, link_type: LinkType, is_dir: bool) -> Self {
+        Self {
+            source,
+            target,
+            link_type,
+            is_dir,
+        }
+    }
+}
+
+impl fmt::Display for EnsureSymlink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.link_type {
+            LinkType::Soft => "symlink",
+            LinkType::Hard => "hardlink",
+        };
+        write!(
+            f,
+            "{} {} {} -> {} ({})",
+            emojis::LINK,
+            style::white(format!("{kind}:")),
+            short_path(&self.source.to_string_lossy()),
+            short_path(&self.target.to_string_lossy()),
+            kind,
+        )
+    }
+}
+
+fn remove_target(target: &Path) -> Result<()> {
+    if target.is_symlink() {
+        if target.is_dir() {
+            remove_symlink_dir(target)?;
+        } else {
+            remove_symlink_file(target)?;
+        }
+    } else if target.is_dir() {
+        fs::remove_dir_all(target)?;
+    } else {
+        fs::remove_file(target)?;
+    }
+    Ok(())
+}
+
+fn resolve_conflict(source: &Path, target: &Path) -> Result<bool> {
+    if target.is_symlink() {
+        let existing = fs::read_link(target)?;
+        if existing == source {
+            return Ok(false);
+        }
+    }
+    if target.exists() || target.is_symlink() {
+        remove_target(target)?;
+    }
+    Ok(true)
+}
+
+#[async_trait]
+impl Action for EnsureSymlink {
+    async fn execute(&self, ctx: Ctx) -> Result<()> {
+        if ctx.dry_run {
+            return Ok(());
+        }
+
+        let source = self.source.clone();
+        let target = self.target.clone();
+        let link_type = self.link_type.clone();
+        let is_dir = self.is_dir;
+
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let should_link = resolve_conflict(&source, &target)?;
+            if !should_link {
+                return Ok(());
+            }
+
+            match link_type {
+                LinkType::Soft => {
+                    if is_dir {
+                        symlink_dir(&source, &target)?;
+                    } else {
+                        symlink_file(&source, &target)?;
+                    }
+                }
+                LinkType::Hard => {
+                    if is_dir {
+                        eprintln!(
+                            "{} {} {} (falling back to soft link)",
+                            emojis::WARNING,
+                            style::yellow("Warning:"),
+                            style::yellow("hard links are not supported for directories"),
+                        );
+                        symlink_dir(&source, &target)?;
+                    } else {
+                        match fs::hard_link(&source, &target) {
+                            Ok(()) => {}
+                            Err(_) => {
+                                eprintln!(
+                                    "{} {} {} (falling back to soft link)",
+                                    emojis::WARNING,
+                                    style::yellow("Warning:"),
+                                    style::yellow("hard link failed, falling back to soft link"),
+                                );
+                                symlink_file(&source, &target)?;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        })
+        .await?
+    }
+}
+
+pub fn discover_symlinks(overlay_root: &Path) -> Result<Vec<(String, SymlinkConfig)>> {
+    use globset::GlobBuilder;
+    use walkdir::WalkDir;
+
+    let glob = GlobBuilder::new("**/*.link.{toml,yaml,yml}")
+        .literal_separator(true)
+        .build()?
+        .compile_matcher();
+
+    let mut results: Vec<(String, SymlinkConfig)> = Vec::new();
+    let mut seen_names: HashMap<String, PathBuf> = HashMap::new();
+
+    for entry in WalkDir::new(overlay_root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        let rel = path.strip_prefix(overlay_root)?;
+
+        if !glob.is_match(rel) {
+            continue;
+        }
+
+        let rel_str = rel.to_string_lossy();
+        let stem = rel_str
+            .strip_suffix(".link.toml")
+            .or_else(|| rel_str.strip_suffix(".link.yaml"))
+            .or_else(|| rel_str.strip_suffix(".link.yml"))
+            .map(String::from)
+            .ok_or_else(|| anyhow::anyhow!("unexpected symlink config file: {}", rel.display()))?;
+
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read symlink config: {}", rel.display()))?;
+
+        let config: SymlinkConfig = if rel_str.ends_with(".toml") {
+            toml::from_str(&content)
+                .with_context(|| format!("failed to parse {}", rel.display()))?
+        } else {
+            serde_yml::from_str(&content)
+                .with_context(|| format!("failed to parse {}", rel.display()))?
+        };
+
+        if config.target.is_empty() {
+            eprintln!(
+                "{} {} {} {} {}",
+                emojis::WARNING,
+                style::yellow("Warning:"),
+                style::yellow("empty target in"),
+                style::cyan(&stem),
+                style::yellow(", skipping"),
+            );
+            continue;
+        }
+
+        if let Some(existing_path) = seen_names.get(&stem) {
+            let (toml_path, yaml_path) = if rel.to_string_lossy().ends_with(".toml") {
+                (rel.to_path_buf(), existing_path.clone())
+            } else {
+                (existing_path.clone(), rel.to_path_buf())
+            };
+            eprintln!(
+                "{} {} {} {} {} {} {}",
+                emojis::WARNING,
+                style::yellow("Warning:"),
+                style::yellow("both"),
+                style::cyan(toml_path.display().to_string()),
+                style::yellow("and"),
+                style::cyan(yaml_path.display().to_string()),
+                style::yellow("exist; TOML takes precedence"),
+            );
+            if rel.to_string_lossy().ends_with(".toml") {
+                results.retain(|(name, _)| name != &stem);
+                seen_names.insert(stem.clone(), rel.to_path_buf());
+                results.push((stem, config));
+            }
+            continue;
+        }
+
+        seen_names.insert(stem.clone(), rel.to_path_buf());
+        results.push((stem, config));
+    }
+
+    results.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(results)
+}
+
+pub fn render_symlink_target(template: &str, overlays: &HashMap<String, String>) -> Result<String> {
+    let env = Environment::new();
+    let env_vars: HashMap<String, String> = std::env::vars().collect();
+    let mut state = HashMap::new();
+    state.insert("env", env_vars);
+    state.insert("overlays", overlays.clone());
+
+    env.render_str(template, &state)
+        .with_context(|| format!("failed to render symlink target template '{}'", template))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use rstest::rstest;
+
+    #[test]
+    fn link_type_default_is_soft() {
+        assert_eq!(LinkType::default(), LinkType::Soft);
+    }
+
+    #[test]
+    fn link_type_deserialize_soft() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            lt: LinkType,
+        }
+        let w: Wrapper = toml::from_str("lt = \"soft\"").unwrap();
+        assert_eq!(w.lt, LinkType::Soft);
+    }
+
+    #[test]
+    fn link_type_deserialize_hard() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            lt: LinkType,
+        }
+        let w: Wrapper = toml::from_str("lt = \"hard\"").unwrap();
+        assert_eq!(w.lt, LinkType::Hard);
+    }
+
+    #[test]
+    fn symlink_config_deserialize_soft() {
+        let cfg: SymlinkConfig = toml::from_str("target = \"/foo\"").unwrap();
+        assert_eq!(cfg.target, "/foo");
+        assert_eq!(cfg.r#type, LinkType::Soft);
+    }
+
+    #[test]
+    fn symlink_config_deserialize_hard() {
+        let cfg: SymlinkConfig = toml::from_str("target = \"/foo\"\ntype = \"hard\"").unwrap();
+        assert_eq!(cfg.target, "/foo");
+        assert_eq!(cfg.r#type, LinkType::Hard);
+    }
+
+    #[test]
+    fn render_symlink_target_with_env() {
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("OVER_TEST_HOME", "/test/home");
+        }
+        let overlays = HashMap::new();
+        let result = render_symlink_target("{{ env.OVER_TEST_HOME }}/config", &overlays).unwrap();
+        assert_eq!(result, "/test/home/config");
+    }
+
+    #[test]
+    fn render_symlink_target_with_overlays() {
+        let mut overlays = HashMap::new();
+        overlays.insert("apps/nvim".to_string(), "/opt/nvim".to_string());
+        let result =
+            render_symlink_target("{{ overlays['apps/nvim'] }}/init.lua", &overlays).unwrap();
+        assert_eq!(result, "/opt/nvim/init.lua");
+    }
+
+    #[rstest]
+    #[case("target = \"/foo\"", "/foo", LinkType::Soft)]
+    #[case("target = \"/foo\"\ntype = \"hard\"", "/foo", LinkType::Hard)]
+    fn symlink_config_from_toml(
+        #[case] input: &str,
+        #[case] expected_target: &str,
+        #[case] expected_type: LinkType,
+    ) {
+        let cfg: SymlinkConfig = toml::from_str(input).unwrap();
+        assert_eq!(cfg.target, expected_target);
+        assert_eq!(cfg.r#type, expected_type);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_creates_soft_link_file() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_creates_soft_link_dir() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source_dir");
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("file.txt"), "hello").unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, true);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+        assert!(target.join("file.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_hard_link_file() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Hard, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(!target.is_symlink());
+        assert_eq!(fs::read_to_string(&target).unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_hard_link_dir_falls_back() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source_dir");
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(&source).unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Hard, true);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_dry_run() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+
+        let ctx = crate::exec::Context::builder().dry_run(true).build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn discover_symlinks_finds_files() {
+        let td = TempDir::new().unwrap();
+        td.child("nvim.link.toml")
+            .write_str("target = \"/opt/nvim\"")
+            .unwrap();
+        td.child("sub").create_dir_all().unwrap();
+        td.child("sub/tool.link.toml")
+            .write_str("target = \"/opt/tool\"")
+            .unwrap();
+
+        let results = discover_symlinks(td.path()).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "nvim");
+        assert_eq!(results[1].0, "sub/tool");
+    }
+
+    #[test]
+    fn discover_symlinks_yaml_also_found() {
+        let td = TempDir::new().unwrap();
+        td.child("app.link.yaml")
+            .write_str("target: /opt/app")
+            .unwrap();
+
+        let results = discover_symlinks(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "app");
+        assert_eq!(results[0].1.target, "/opt/app");
+    }
+
+    #[test]
+    fn discover_symlinks_toml_takes_precedence_over_yaml() {
+        let td = TempDir::new().unwrap();
+        td.child("app.link.toml")
+            .write_str("target = \"/from-toml\"")
+            .unwrap();
+        td.child("app.link.yaml")
+            .write_str("target: /from-yaml")
+            .unwrap();
+
+        let results = discover_symlinks(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "app");
+        assert_eq!(results[0].1.target, "/from-toml");
+    }
+
+    #[test]
+    fn discover_symlinks_skips_empty_target() {
+        let td = TempDir::new().unwrap();
+        td.child("bad.link.toml")
+            .write_str("target = \"\"")
+            .unwrap();
+
+        let results = discover_symlinks(td.path()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn discover_symlinks_yaml_first_toml_second_toml_wins() {
+        let td = TempDir::new().unwrap();
+        td.child("app.link.yaml")
+            .write_str("target: /from-yaml")
+            .unwrap();
+        td.child("app.link.toml")
+            .write_str("target = \"/from-toml\"")
+            .unwrap();
+
+        let results = discover_symlinks(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "app");
+        assert_eq!(results[0].1.target, "/from-toml");
+    }
+
+    #[test]
+    fn discover_symlinks_empty_dir() {
+        let td = TempDir::new().unwrap();
+        let results = discover_symlinks(td.path()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn ensure_symlink_display_soft() {
+        let action = EnsureSymlink::new(
+            PathBuf::from("/src/file.txt"),
+            PathBuf::from("/dst/file.txt"),
+            LinkType::Soft,
+            false,
+        );
+        let display = format!("{}", action);
+        assert!(display.contains("symlink"));
+        assert!(display.contains("/src/file.txt"));
+        assert!(display.contains("/dst/file.txt"));
+    }
+
+    #[test]
+    fn ensure_symlink_display_hard() {
+        let action = EnsureSymlink::new(
+            PathBuf::from("/src/file.txt"),
+            PathBuf::from("/dst/file.txt"),
+            LinkType::Hard,
+            false,
+        );
+        let display = format!("{}", action);
+        assert!(display.contains("hardlink"));
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_already_linked() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+        symlink_file(&source, &target).unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_overwrites_wrong_symlink() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let wrong_source = td.path().join("wrong.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+        fs::write(&wrong_source, "wrong").unwrap();
+        symlink_file(&wrong_source, &target).unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_overwrites_regular_file() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+        fs::write(&target, "existing").unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_overwrites_existing_dir() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source_dir");
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("file.txt"), "hello").unwrap();
+        fs::create_dir_all(&target).unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, true);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_already_linked_dir() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source_dir");
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(&source).unwrap();
+        symlink_dir(&source, &target).unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, true);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_overwrites_wrong_dir_symlink() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source_dir");
+        let wrong_source = td.path().join("wrong_dir");
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&wrong_source).unwrap();
+        symlink_dir(&wrong_source, &target).unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Soft, true);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), source);
+    }
+
+    #[tokio::test]
+    async fn ensure_symlink_hard_link_fallback_cross_device() {
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("source.txt");
+        let target = td.path().join("target.txt");
+        fs::write(&source, "hello").unwrap();
+
+        let ctx = crate::exec::Context::builder().build();
+        let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Hard, false);
+        action.execute(ctx).await.unwrap();
+
+        assert!(target.exists());
+        assert_eq!(fs::read_to_string(&target).unwrap(), "hello");
+    }
+
+    #[test]
+    fn render_symlink_target_invalid_template() {
+        let overlays = HashMap::new();
+        let result = render_symlink_target("{{ invalid.template", &overlays);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_symlink_target_plain() {
+        let overlays = HashMap::new();
+        let result = render_symlink_target("/plain/path", &overlays).unwrap();
+        assert_eq!(result, "/plain/path");
+    }
+
+    #[test]
+    fn render_symlink_target_combined_env_and_overlay() {
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("OVER_TEST_USER", "testuser");
+        }
+        let mut overlays = HashMap::new();
+        overlays.insert("apps/tool".to_string(), "/opt/tool".to_string());
+        let result = render_symlink_target(
+            "{{ env.OVER_TEST_USER }}/{{ overlays['apps/tool'] }}",
+            &overlays,
+        )
+        .unwrap();
+        assert_eq!(result, "testuser//opt/tool");
+    }
+}

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,7 +1,9 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
+use dialoguer::Input;
 
+use crate::actions::symlink::SymlinkConfig;
 use crate::cli::CLI;
 use crate::cli::common::resolve_inputs;
 use crate::exec::Context;
@@ -37,7 +39,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     }
 
     let home = cli.resolve_home()?;
-    let repo = Repository::new(home);
+    let repo = Repository::new(home.clone());
     if cli.debug {
         println!("{:#?}", repo);
     }
@@ -80,16 +82,115 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
 
     let resolved = resolve_inputs(&args.files)?;
 
-    overlay.add_files(&ctx, &resolved).await.map_err(|e| {
-        println!(
-            "{} {} {} {}",
-            emojis::CROSSMARK,
-            style::white_b("Failed to add to overlay"),
-            style::cyan(&overlay.name),
-            style::white_b(&format!(": {}", e)),
-        );
-        e
-    })?;
+    let (symlinks, regulars): (Vec<_>, Vec<_>) = resolved.iter().partition(|p| p.is_symlink());
+
+    for symlink_path in &symlinks {
+        add_symlink(&overlay, &home, symlink_path, cli)?;
+    }
+
+    if !regulars.is_empty() {
+        let regular_paths: Vec<PathBuf> = regulars.into_iter().cloned().collect();
+        overlay.add_files(&ctx, &regular_paths).await.map_err(|e| {
+            println!(
+                "{} {} {} {}",
+                emojis::CROSSMARK,
+                style::white_b("Failed to add to overlay"),
+                style::cyan(&overlay.name),
+                style::white_b(&format!(": {}", e)),
+            );
+            e
+        })?;
+    }
 
     Ok(())
+}
+
+fn add_symlink(
+    overlay: &crate::overlays::Overlay,
+    home: &PathBuf,
+    symlink_path: &PathBuf,
+    _cli: &CLI,
+) -> Result<()> {
+    let link_target = std::fs::read_link(symlink_path)
+        .map_err(|e| anyhow!("failed to read symlink {}: {}", symlink_path.display(), e))?;
+
+    let default_target = compute_default_target(&link_target, &overlay.root, home);
+
+    let target: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!(
+            "Target for {}",
+            style::cyan(symlink_path.display())
+        ))
+        .default(default_target)
+        .interact_text()
+        .map_err(|e| anyhow!("target input cancelled: {}", e))?;
+
+    let rel_path = symlink_path.strip_prefix(home).unwrap_or(symlink_path);
+    let link_config_name = rel_path.to_string_lossy();
+    let config_path = overlay.root.join(format!("{}.link.toml", link_config_name));
+
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let config = SymlinkConfig {
+        target,
+        r#type: crate::actions::symlink::LinkType::Soft,
+    };
+    let toml_content = toml::to_string_pretty(&config)?;
+    std::fs::write(&config_path, toml_content)?;
+
+    println!(
+        "{} {} {} {}",
+        emojis::CHECKMARK,
+        style::white_b("Created symlink config"),
+        style::cyan(config_path.display()),
+        style::white_b("in overlay"),
+    );
+
+    Ok(())
+}
+
+fn compute_default_target(link_target: &Path, overlay_root: &Path, home: &Path) -> String {
+    if let Ok(rel) = link_target.strip_prefix(overlay_root) {
+        return rel.to_string_lossy().to_string();
+    }
+
+    if let Ok(rel) = link_target.strip_prefix(home) {
+        return format!("~/{}", rel.display());
+    }
+
+    link_target.to_string_lossy().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_default_target_inside_overlay() {
+        let overlay_root = PathBuf::from("/home/user/.over/myoverlay");
+        let home = PathBuf::from("/home/user");
+        let link_target = PathBuf::from("/home/user/.over/myoverlay/subdir/file.txt");
+        let result = compute_default_target(&link_target, &overlay_root, &home);
+        assert_eq!(result, "subdir/file.txt");
+    }
+
+    #[test]
+    fn compute_default_target_inside_home() {
+        let overlay_root = PathBuf::from("/home/user/.over/myoverlay");
+        let home = PathBuf::from("/home/user");
+        let link_target = PathBuf::from("/home/user/.config/nvim");
+        let result = compute_default_target(&link_target, &overlay_root, &home);
+        assert_eq!(result, "~/.config/nvim");
+    }
+
+    #[test]
+    fn compute_default_target_outside_home() {
+        let overlay_root = PathBuf::from("/home/user/.over/myoverlay");
+        let home = PathBuf::from("/home/user");
+        let link_target = PathBuf::from("/opt/nvim/bin/nvim");
+        let result = compute_default_target(&link_target, &overlay_root, &home);
+        assert_eq!(result, "/opt/nvim/bin/nvim");
+    }
 }

--- a/src/exec/context.rs
+++ b/src/exec/context.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::{path::PathBuf, sync::Arc};
 
 use indicatif::{MultiProgress, ProgressBar};
@@ -31,6 +32,9 @@ pub struct Context {
 
     #[serde(skip)]
     pub progress: Option<Progress>,
+
+    #[serde(skip)]
+    pub resolved_overlays: Arc<HashMap<String, String>>,
 }
 
 // Store the current progress bar
@@ -72,6 +76,7 @@ pub struct ContextBuilder {
     repository: Repository,
     overlay: Option<Overlay>,
     progress: Option<Progress>,
+    resolved_overlays: Arc<HashMap<String, String>>,
 }
 
 impl ContextBuilder {
@@ -115,6 +120,16 @@ impl ContextBuilder {
         self
     }
 
+    pub fn progress(mut self, progress: Progress) -> Self {
+        self.progress = Some(progress);
+        self
+    }
+
+    pub fn resolved_overlays(mut self, v: Arc<HashMap<String, String>>) -> Self {
+        self.resolved_overlays = v;
+        self
+    }
+
     pub fn build(self) -> Arc<Context> {
         Arc::new(Context {
             dry_run: self.dry_run,
@@ -126,6 +141,7 @@ impl ContextBuilder {
             repository: self.repository,
             overlay: self.overlay,
             progress: self.progress,
+            resolved_overlays: self.resolved_overlays,
         })
     }
 }
@@ -147,6 +163,7 @@ impl Context {
             repository: self.repository.clone(),
             overlay: Some(overlay),
             progress: self.progress.clone(),
+            resolved_overlays: self.resolved_overlays.clone(),
         })
     }
 
@@ -161,6 +178,7 @@ impl Context {
             repository: self.repository.clone(),
             overlay: self.overlay.clone(),
             progress: Some(Progress::Progress(progress)),
+            resolved_overlays: self.resolved_overlays.clone(),
         })
     }
 
@@ -175,6 +193,7 @@ impl Context {
             repository: self.repository.clone(),
             overlay: self.overlay.clone(),
             progress: Some(Progress::MultiProgress(progress)),
+            resolved_overlays: self.resolved_overlays.clone(),
         })
     }
 
@@ -184,6 +203,30 @@ impl Context {
 
     pub fn try_multiprogress(&self) -> Option<&MultiProgress> {
         self.progress.as_ref().and_then(|p| p.try_multiprogress())
+    }
+
+    pub fn with_resolved_overlay(&self, name: String, target: String) -> Arc<Self> {
+        let mut map = (*self.resolved_overlays).clone();
+        map.insert(name, target);
+        Arc::new(Self {
+            resolved_overlays: Arc::new(map),
+            ..self.clone_for_overlay_update()
+        })
+    }
+
+    fn clone_for_overlay_update(&self) -> Self {
+        Self {
+            dry_run: self.dry_run,
+            debug: self.debug,
+            verbose: self.verbose,
+            force: self.force,
+            no_prompt: self.no_prompt,
+            root: self.root.clone(),
+            repository: self.repository.clone(),
+            overlay: self.overlay.clone(),
+            progress: self.progress.clone(),
+            resolved_overlays: self.resolved_overlays.clone(),
+        }
     }
 }
 

--- a/src/lint/checks.rs
+++ b/src/lint/checks.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
 use globset::GlobBuilder;
+use minijinja::Environment;
 
+use crate::actions::symlink::{LinkType, discover_symlinks};
 use crate::overlays::Overlay;
 
 use super::Diagnostic;
@@ -15,6 +17,7 @@ pub fn check_overlay(overlay: &Overlay) -> Vec<Diagnostic> {
     diagnostics.extend(check_empty_link_dirs(overlay));
     diagnostics.extend(check_invalid_link_dirs_globs(overlay));
     diagnostics.extend(check_git(overlay));
+    diagnostics.extend(check_symlinks(overlay));
 
     diagnostics
 }
@@ -198,6 +201,53 @@ fn check_git(overlay: &Overlay) -> Vec<Diagnostic> {
                     format!("{ctx}: path contains `..` traversal"),
                 )
                 .with_hint("use a path within the overlay target directory"),
+            );
+        }
+    }
+
+    diagnostics
+}
+
+// ── symlink checks ───────────────────────────────────────────────────────
+
+fn check_symlinks(overlay: &Overlay) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    let symlinks = match discover_symlinks(&overlay.root) {
+        Ok(s) => s,
+        Err(e) => {
+            diagnostics.push(Diagnostic::error(
+                &overlay.name,
+                format!("failed to discover symlink configs: {e}"),
+            ));
+            return diagnostics;
+        }
+    };
+
+    for (name, config) in &symlinks {
+        if config.target.is_empty() {
+            diagnostics.push(Diagnostic::error(
+                &overlay.name,
+                format!("symlink `{name}`: `target` is empty"),
+            ));
+        } else {
+            let env = Environment::new();
+            let test_state = std::collections::HashMap::<String, String>::new();
+            if let Err(e) = env.render_str(&config.target, &test_state) {
+                diagnostics.push(Diagnostic::error(
+                    &overlay.name,
+                    format!("symlink `{name}`: invalid template in `target`: {e}"),
+                ));
+            }
+        }
+
+        if config.r#type == LinkType::Hard {
+            diagnostics.push(
+                Diagnostic::warning(
+                    &overlay.name,
+                    format!("symlink `{name}`: `type = \"hard\"` will fall back to soft link for directories"),
+                )
+                .with_hint("hard links are not supported for directories on most filesystems"),
             );
         }
     }
@@ -435,5 +485,40 @@ worktree = true
         // empty uses + empty exclude + empty link_dirs = 3 warnings
         assert_eq!(diags.len(), 3);
         assert!(diags.iter().all(|d| d.severity == Severity::Warning));
+    }
+
+    #[rstest]
+    fn test_check_symlinks_hard_type_warning() {
+        let overlay = setup_overlay("target = \"~\"");
+        let link_file = overlay.root.join("test.link.toml");
+        std::fs::write(&link_file, "target = \"/foo\"\ntype = \"hard\"").unwrap();
+        let diags = check_symlinks(&overlay);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.severity == Severity::Warning && d.message.contains("hard"))
+        );
+    }
+
+    #[rstest]
+    fn test_check_symlinks_valid_no_diagnostics() {
+        let overlay = setup_overlay("target = \"~\"");
+        let link_file = overlay.root.join("test.link.toml");
+        std::fs::write(&link_file, "target = \"/foo\"").unwrap();
+        let diags = check_symlinks(&overlay);
+        assert!(diags.is_empty());
+    }
+
+    #[rstest]
+    fn test_check_symlinks_invalid_template() {
+        let overlay = setup_overlay("target = \"~\"");
+        let link_file = overlay.root.join("test.link.toml");
+        std::fs::write(&link_file, "target = \"{{ invalid\"").unwrap();
+        let diags = check_symlinks(&overlay);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.severity == Severity::Error && d.message.contains("invalid template"))
+        );
     }
 }

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -12,11 +12,21 @@ use minijinja::Environment;
 
 use crate::actions::git::config::{GitRepoConfig, deserialize_git_field};
 use crate::actions::install::InstallConfig;
-use crate::actions::{self, EnsureDir};
+use crate::actions::{self, EnsureDir, EnsureSymlink};
 use crate::exec::{self, Action, Ctx};
+use crate::ui;
 use crate::ui::{emojis, style};
+use indicatif::ProgressBar;
+use indicatif::ProgressStyle;
+use std::sync::LazyLock;
 
 use super::{DEFAULT_TARGET, Repository};
+
+static SYMLINK_SPINNER_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
+    ProgressStyle::with_template("{spinner:.cyan} {wide_msg}")
+        .unwrap()
+        .tick_chars(style::TICK_CHARS_BRAILLE_4_6_DOWN.as_str())
+});
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Overlay {
@@ -181,6 +191,11 @@ impl Overlay {
             actions::git::clone_repositories(ctx.clone(), self, &target).await?;
             actions::fs::link(ctx.clone(), self, &target).await?;
 
+            let ctx_with_target =
+                ctx.with_resolved_overlay(self.name.clone(), target.to_string_lossy().to_string());
+            self.apply_symlinks(ctx_with_target.clone(), &target)
+                .await?;
+
             stack.pop();
             visited.insert(self.name.clone());
 
@@ -196,6 +211,43 @@ impl Overlay {
 
             Ok(())
         })
+    }
+
+    pub async fn apply_symlinks(&self, ctx: Ctx, target: &Path) -> Result<()> {
+        let symlinks = actions::symlink::discover_symlinks(&self.root)?;
+        if symlinks.is_empty() {
+            return Ok(());
+        }
+
+        ui::info(format!(
+            "{} {}",
+            emojis::LINK,
+            style::white("Linking symlinks"),
+        ))?;
+
+        let progress = ProgressBar::new_spinner()
+            .with_style(SYMLINK_SPINNER_STYLE.clone())
+            .with_message("");
+
+        for (name, config) in &symlinks {
+            let resolved_target =
+                actions::symlink::render_symlink_target(&config.target, &ctx.resolved_overlays)?;
+            let target_path = PathBuf::from(&resolved_target);
+            let is_dir = target_path.is_dir()
+                || resolved_target.ends_with(std::path::MAIN_SEPARATOR_STR)
+                || resolved_target.ends_with('/');
+            let link_path = target.join(name);
+
+            let action = EnsureSymlink::new(target_path, link_path, config.r#type.clone(), is_dir);
+            if ctx.verbose || ctx.dry_run {
+                progress.println(format!("{}", action));
+            }
+            progress.set_message(format!("{}", action));
+            action.execute(ctx.clone()).await?;
+        }
+
+        progress.finish_and_clear();
+        Ok(())
     }
 
     pub async fn add_file(&self, ctx: &Ctx, file: &PathBuf) -> Result<()> {
@@ -595,5 +647,73 @@ branch = "main"
             .unwrap();
         let overlay = repo.get("ov_no_git").unwrap();
         assert!(overlay.git.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_apply_creates_symlinks() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov_symlink");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir
+            .child("test.link.toml")
+            .write_str("target = \"/tmp/test_symlink_target\"")
+            .unwrap();
+
+        let overlay = repo.get("ov_symlink").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let result = overlay.apply(&c).await;
+        assert!(
+            result.is_ok(),
+            "apply with symlinks should succeed: {:?}",
+            result.err()
+        );
+
+        let target_path = td.path().join("test");
+        assert!(
+            target_path.is_symlink(),
+            "symlink should be created at target"
+        );
+        assert_eq!(
+            fs::read_link(&target_path).unwrap(),
+            PathBuf::from("/tmp/test_symlink_target")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_symlinks_with_env_template() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov_sympl");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir
+            .child("templated.link.toml")
+            .write_str("target = \"/tmp/test_symlink_src\"")
+            .unwrap();
+
+        let overlay = repo.get("ov_sympl").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let result = overlay.apply(&c).await;
+        assert!(
+            result.is_ok(),
+            "apply with templated symlink should succeed: {:?}",
+            result.err()
+        );
+
+        let target_path = td.path().join("templated");
+        assert!(
+            target_path.is_symlink(),
+            "symlink should be created at overlay target"
+        );
+        assert_eq!(
+            fs::read_link(&target_path).unwrap(),
+            PathBuf::from("/tmp/test_symlink_src")
+        );
     }
 }

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -8,7 +8,7 @@ use walkdir::WalkDir;
 use anyhow::{Context as AnyhowContext, Result};
 
 use super::overlay::Overlay;
-use super::{Format, BASENAME, GLOB_PATTERN};
+use super::{BASENAME, Format, GLOB_PATTERN};
 use crate::ui::style;
 
 /// Manage all overlays

--- a/src/ui/emojis.rs
+++ b/src/ui/emojis.rs
@@ -10,6 +10,7 @@ pub static CROSSMARK: Emoji<'_, '_> = Emoji("❌", "");
 pub static GREEN_CIRCLE: Emoji<'_, '_> = Emoji("🟢", "");
 pub static SPARKLE: Emoji<'_, '_> = Emoji("✨", "");
 pub static MOVE_FILE: Emoji<'_, '_> = Emoji("📃", "");
+pub static WARNING: Emoji<'_, '_> = Emoji("⚠️", "");
 // static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍  ", "");
 // static TRUCK: Emoji<'_, '_> = Emoji("🚚  ", "");
 // static CLIP: Emoji<'_, '_> = Emoji("🔗  ", "");


### PR DESCRIPTION
## Summary

- Add support for `<name>.link.(toml|yaml)` files in overlays that define symlinks with Jinja-templated targets
- `target` supports `{{ env.HOME }}` and `{{ overlays['name'].target }}` templating
- `type: soft | hard` (defaults to `soft`); hard links fall back to soft for directories
- `over add` auto-detects symlinks and creates `.link.toml` configs with interactive target prompt
- Lint checks validate symlink configs (empty targets, invalid templates, duplicate TOML/YAML)

## Files Changed

- **New:** `src/actions/symlink.rs` — `LinkType`, `SymlinkConfig`, `EnsureSymlink`, `discover_symlinks()`, `render_symlink_target()`
- **Modified:** `src/cli/add.rs` — symlink detection and `.link.toml` creation
- **Modified:** `src/overlays/overlay.rs` — `apply_symlinks()` called during overlay apply
- **Modified:** `src/exec/context.rs` — `resolved_overlays` map for template context
- **Modified:** `src/lint/checks.rs` — `check_symlinks()` validation
- **Modified:** `src/actions/fs.rs` — exclude `.link.*` files from regular linking
- **Modified:** `src/actions/mod.rs` — re-export symlink module
- **Modified:** `src/ui/emojis.rs` — added WARNING emoji

## Tests

316 tests pass (17 new symlink tests added).