### PR TITLE
test: add unit tests to improve coverage from 75% to 79%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Cargo.lock
 
 # Coverage report
 lcov.info
+*.lcov
 
 # Mise
 !/mise.toml

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -26,6 +26,87 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use clap::Parser;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn make_cli(home: PathBuf) -> CLI {
+        CLI::parse_from(vec!["over", "--home", home.to_str().unwrap()])
+    }
+
+    #[tokio::test]
+    async fn list_empty_repository() {
+        let tmp = TempDir::new().unwrap();
+        let cli = make_cli(tmp.path().to_path_buf());
+        let params = Params { tree: false };
+        let result = execute(&cli, &params).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_single_overlay() {
+        let tmp = TempDir::new().unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let params = Params { tree: false };
+        let result = execute(&cli, &params).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_multiple_overlays() {
+        let tmp = TempDir::new().unwrap();
+        for name in ["alpha", "beta", "gamma"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let params = Params { tree: false };
+        let result = execute(&cli, &params).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_with_tree_flag() {
+        let tmp = TempDir::new().unwrap();
+        let ov = tmp.path().join("treeov");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let params = Params { tree: true };
+        let result = execute(&cli, &params).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_skips_badly_formatted_overlay() {
+        let tmp = TempDir::new().unwrap();
+        let good = tmp.path().join("good");
+        fs::create_dir_all(&good).unwrap();
+        fs::write(good.join("over.toml"), "target = \"~\"").unwrap();
+
+        let bad = tmp.path().join("bad");
+        fs::create_dir_all(&bad).unwrap();
+        fs::write(bad.join("over.toml"), "{{invalid}}").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let params = Params { tree: false };
+        let result = execute(&cli, &params).await;
+        assert!(result.is_ok());
+    }
+}
+
 // use termtree::Tree;
 
 // use std::path::Path;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -121,3 +121,119 @@ pub async fn main() -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn resolve_home_with_flag() {
+        let args = CLI::parse_from(["over", "--home", "/tmp/test-home"]);
+        let home = args.resolve_home().unwrap();
+        assert_eq!(home, PathBuf::from("/tmp/test-home"));
+    }
+
+    #[test]
+    fn resolve_home_with_short_flag() {
+        let args = CLI::parse_from(["over", "-H", "/tmp/short-home"]);
+        let home = args.resolve_home().unwrap();
+        assert_eq!(home, PathBuf::from("/tmp/short-home"));
+    }
+
+    #[test]
+    fn resolve_home_default_uses_home_dir() {
+        // Note: if OVER_HOME env var is set, it will be used instead of default
+        let args = CLI::parse_from(["over"]);
+        let home = args.resolve_home().unwrap();
+        assert!(home.is_absolute());
+        assert!(home.ends_with(".over") || home.ends_with(".dotfiles"));
+    }
+
+    #[test]
+    fn cli_debug_flag() {
+        let args = CLI::parse_from(["over", "--debug"]);
+        assert!(args.debug);
+    }
+
+    #[test]
+    fn cli_short_debug_flag() {
+        let args = CLI::parse_from(["over", "-d"]);
+        assert!(args.debug);
+    }
+
+    #[test]
+    fn cli_verbose_flag() {
+        let args = CLI::parse_from(["over", "--verbose"]);
+        assert!(args.verbose);
+    }
+
+    #[test]
+    fn cli_short_verbose_flag() {
+        let args = CLI::parse_from(["over", "-v"]);
+        assert!(args.verbose);
+    }
+
+    #[test]
+    fn cli_no_subcommand() {
+        let args = CLI::parse_from(["over"]);
+        assert!(args.cmd.is_none());
+    }
+
+    #[test]
+    fn cli_add_subcommand() {
+        let args = CLI::parse_from(["over", "add", "file.txt", "-o", "myoverlay"]);
+        assert!(matches!(args.cmd, Some(Commands::Add(_))));
+    }
+
+    #[test]
+    fn cli_new_subcommand() {
+        let args = CLI::parse_from(["over", "new", "myoverlay", "~"]);
+        assert!(matches!(args.cmd, Some(Commands::New(_))));
+    }
+
+    #[test]
+    fn cli_list_subcommand() {
+        let args = CLI::parse_from(["over", "list"]);
+        assert!(matches!(args.cmd, Some(Commands::List(_))));
+    }
+
+    #[test]
+    fn cli_list_alias_ls() {
+        let args = CLI::parse_from(["over", "ls"]);
+        assert!(matches!(args.cmd, Some(Commands::List(_))));
+    }
+
+    #[test]
+    fn cli_show_subcommand() {
+        let args = CLI::parse_from(["over", "show", "myoverlay"]);
+        assert!(matches!(args.cmd, Some(Commands::Show(_))));
+    }
+
+    #[test]
+    fn cli_apply_subcommand() {
+        let args = CLI::parse_from(["over", "apply", "myoverlay"]);
+        assert!(matches!(args.cmd, Some(Commands::Apply(_))));
+    }
+
+    #[test]
+    fn cli_lint_subcommand() {
+        let args = CLI::parse_from(["over", "lint"]);
+        assert!(matches!(args.cmd, Some(Commands::Lint(_))));
+    }
+
+    #[test]
+    fn cli_status_subcommand() {
+        let args = CLI::parse_from(["over", "status"]);
+        assert!(matches!(args.cmd, Some(Commands::Status)));
+    }
+
+    #[test]
+    fn cli_global_flags_with_subcommand() {
+        let args = CLI::parse_from(["over", "--home", "/tmp/test", "--debug", "--verbose", "list"]);
+        assert_eq!(args.home, Some(PathBuf::from("/tmp/test")));
+        assert!(args.debug);
+        assert!(args.verbose);
+        assert!(matches!(args.cmd, Some(Commands::List(_))));
+    }
+}

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -35,3 +35,72 @@ pub async fn execute(cli: &CLI) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use clap::Parser;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn make_cli(home: PathBuf) -> CLI {
+        CLI::parse_from(vec!["over", "--home", home.to_str().unwrap()])
+    }
+
+    #[tokio::test]
+    async fn status_empty_repository() {
+        let tmp = TempDir::new().unwrap();
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn status_single_overlay_no_description() {
+        let tmp = TempDir::new().unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn status_overlay_with_description() {
+        let tmp = TempDir::new().unwrap();
+        let ov = tmp.path().join("described");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(
+            ov.join("over.toml"),
+            "target = \"~\"\ndescription = \"My described overlay\"",
+        )
+        .unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn status_multiple_overlays() {
+        let tmp = TempDir::new().unwrap();
+        for (name, has_desc) in [("first", true), ("second", false), ("third", true)] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            let content = if has_desc {
+                format!("target = \"~\"\ndescription = \"{}\"", name)
+            } else {
+                "target = \"~\"".to_string()
+            };
+            fs::write(ov.join("over.toml"), content).unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli).await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/exec/context.rs
+++ b/src/exec/context.rs
@@ -235,8 +235,8 @@ pub type Ctx = Arc<Context>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_fs::TempDir;
     use assert_fs::prelude::*;
+    use assert_fs::TempDir;
     use indicatif::{MultiProgress, ProgressBar};
 
     fn dummy_repo() -> Repository {
@@ -380,5 +380,128 @@ mod tests {
         let new_ctx = ctx.with_multiprogress(mp.clone());
         assert!(ctx.try_multiprogress().is_none());
         assert!(new_ctx.try_multiprogress().is_some());
+    }
+
+    #[test]
+    fn with_resolved_overlay_adds_entry() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/tmp");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\tmp");
+
+        let ctx = Context::builder()
+            .root(root_path)
+            .repository(dummy_repo())
+            .build();
+
+        let new_ctx = ctx.with_resolved_overlay("myoverlay".to_string(), "/target".to_string());
+        assert_eq!(
+            new_ctx.resolved_overlays.get("myoverlay"),
+            Some(&"/target".to_string())
+        );
+        assert!(ctx.resolved_overlays.is_empty());
+    }
+
+    #[test]
+    fn with_resolved_overlay_preserves_other_fields() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/tmp");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\tmp");
+
+        let ctx = Context::builder()
+            .dry_run(true)
+            .debug(true)
+            .verbose(true)
+            .force(true)
+            .no_prompt(true)
+            .root(root_path.clone())
+            .repository(dummy_repo())
+            .build();
+
+        let new_ctx = ctx.with_resolved_overlay("ov".to_string(), "/t".to_string());
+        assert!(new_ctx.dry_run);
+        assert!(new_ctx.debug);
+        assert!(new_ctx.verbose);
+        assert!(new_ctx.force);
+        assert!(new_ctx.no_prompt);
+        assert_eq!(new_ctx.root, root_path);
+    }
+
+    #[test]
+    fn progress_try_progress_returns_some() {
+        let pb = ProgressBar::hidden();
+        let progress = Progress::Progress(pb.clone());
+        assert!(progress.try_progress().is_some());
+        assert!(progress.try_multiprogress().is_none());
+    }
+
+    #[test]
+    fn progress_try_multiprogress_returns_some() {
+        let mp = MultiProgress::new();
+        let progress = Progress::MultiProgress(mp.clone());
+        assert!(progress.try_multiprogress().is_some());
+        assert!(progress.try_progress().is_none());
+    }
+
+    #[test]
+    fn try_progress_without_progress_returns_none() {
+        let ctx = Context::builder().build();
+        assert!(ctx.try_progress().is_none());
+        assert!(ctx.try_multiprogress().is_none());
+    }
+
+    #[test]
+    fn builder_with_overlay() {
+        let (_td, overlay) = make_overlay();
+        let ctx = Context::builder()
+            .repository(dummy_repo())
+            .overlay(overlay.clone())
+            .build();
+        assert!(ctx.overlay.is_some());
+        assert_eq!(ctx.overlay.as_ref().unwrap().name, overlay.name);
+    }
+
+    #[test]
+    fn builder_with_progress() {
+        let pb = ProgressBar::hidden();
+        let ctx = Context::builder()
+            .repository(dummy_repo())
+            .progress(Progress::Progress(pb))
+            .build();
+        assert!(ctx.progress.is_some());
+    }
+
+    #[test]
+    fn builder_with_resolved_overlays() {
+        let mut map = HashMap::new();
+        map.insert("ov".to_string(), "/target".to_string());
+        let map = Arc::new(map);
+        let ctx = Context::builder()
+            .repository(dummy_repo())
+            .resolved_overlays(map.clone())
+            .build();
+        assert_eq!(
+            ctx.resolved_overlays.get("ov"),
+            Some(&"/target".to_string())
+        );
+    }
+
+    #[test]
+    fn context_clone_for_overlay_update() {
+        #[cfg(unix)]
+        let root_path = PathBuf::from("/tmp");
+        #[cfg(windows)]
+        let root_path = PathBuf::from("C:\\tmp");
+
+        let ctx = Context::builder()
+            .dry_run(true)
+            .root(root_path.clone())
+            .repository(dummy_repo())
+            .build();
+
+        let cloned = ctx.clone_for_overlay_update();
+        assert!(cloned.dry_run);
+        assert_eq!(cloned.root, root_path);
     }
 }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use clap::builder::styling;
-use console::{Style, StyledObject, style};
+use console::{style, Style, StyledObject};
 use dialoguer::theme::Theme;
 use std::sync::LazyLock;
 
@@ -319,4 +319,303 @@ pub fn clap_styles() -> styling::Styles {
         .usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
         .literal(styling::AnsiColor::Blue.on_default() | styling::Effects::BOLD)
         .placeholder(styling::AnsiColor::Cyan.on_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write;
+
+    #[test]
+    fn test_white_styles_text() {
+        let styled = white("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_white_bold_styles_text() {
+        let styled = white_b("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_white_bold_italic_styles_text() {
+        let styled = white_bi("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_cyan_styles_text() {
+        let styled = cyan("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_yellow_styles_text() {
+        let styled = yellow("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_dialog_theme_default() {
+        let theme = DialogTheme::default();
+        assert_eq!(format!("{}", theme.prompt_prefix), "?");
+        assert_eq!(format!("{}", theme.prompt_suffix), "›");
+        assert_eq!(format!("{}", theme.success_prefix), "✔");
+        assert_eq!(format!("{}", theme.success_suffix), "·");
+        assert_eq!(format!("{}", theme.error_prefix), "✘");
+        assert_eq!(format!("{}", theme.active_item_prefix), "❯");
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_prompt_no_default() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt(&mut buf, "Are you sure?", None)
+            .unwrap();
+        assert!(buf.contains("Are you sure?"));
+        assert!(buf.contains("(y/n)"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_prompt_default_true() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt(&mut buf, "Continue?", Some(true))
+            .unwrap();
+        assert!(buf.contains("Continue?"));
+        assert!(buf.contains("yes"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_prompt_default_false() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt(&mut buf, "Continue?", Some(false))
+            .unwrap();
+        assert!(buf.contains("Continue?"));
+        assert!(buf.contains("no"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_prompt_empty_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme.format_confirm_prompt(&mut buf, "", None).unwrap();
+        assert!(buf.contains("(y/n)"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_selection_yes() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt_selection(&mut buf, "Are you sure?", Some(true))
+            .unwrap();
+        assert!(buf.contains("yes"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_selection_no() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt_selection(&mut buf, "Are you sure?", Some(false))
+            .unwrap();
+        assert!(!buf.contains("yes"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_selection_none() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt_selection(&mut buf, "Are you sure?", None)
+            .unwrap();
+        assert!(buf.contains("·"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_confirm_selection_empty_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_confirm_prompt_selection(&mut buf, "", Some(true))
+            .unwrap();
+        assert!(buf.contains("yes"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_select_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme.format_select_prompt(&mut buf, "Choose:").unwrap();
+        assert!(buf.contains("Choose:"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_select_prompt_empty() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme.format_select_prompt(&mut buf, "").unwrap();
+        assert!(buf.contains("›"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_select_prompt_selection() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_select_prompt_selection(&mut buf, "Choose:", "option1")
+            .unwrap();
+        assert!(buf.contains("option1"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_select_prompt_selection_empty_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_select_prompt_selection(&mut buf, "", "option1")
+            .unwrap();
+        assert!(buf.contains("option1"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_input_prompt_with_default() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_input_prompt(&mut buf, "Enter value:", Some("default"))
+            .unwrap();
+        assert!(buf.contains("(default)"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_input_prompt_no_default() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_input_prompt(&mut buf, "Enter value:", None)
+            .unwrap();
+        assert!(buf.contains("Enter value:"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_input_prompt_empty_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_input_prompt(&mut buf, "", Some("default"))
+            .unwrap();
+        assert!(buf.contains("(default)"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_input_prompt_selection() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_input_prompt_selection(&mut buf, "Enter value:", "chosen")
+            .unwrap();
+        assert!(buf.contains("chosen"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_input_prompt_selection_empty_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_input_prompt_selection(&mut buf, "", "chosen")
+            .unwrap();
+        assert!(buf.contains("chosen"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_multi_select_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_multi_select_prompt(&mut buf, "Select:")
+            .unwrap();
+        assert!(buf.contains("Select:"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_multi_select_prompt_empty() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme.format_multi_select_prompt(&mut buf, "").unwrap();
+        assert!(buf.contains("›"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_multi_select_prompt_selection() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_multi_select_prompt_selection(&mut buf, "Select:", &["a", "b"])
+            .unwrap();
+        assert!(buf.contains("a, b"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_multi_select_prompt_selection_empty_prompt() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_multi_select_prompt_selection(&mut buf, "", &["x"])
+            .unwrap();
+        assert!(buf.contains("x"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_select_prompt_item_active() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_select_prompt_item(&mut buf, "item1", true)
+            .unwrap();
+        assert!(buf.contains("item1"));
+        assert!(buf.contains("❯"));
+    }
+
+    #[test]
+    fn test_dialog_theme_format_select_prompt_item_inactive() {
+        let theme = DialogTheme::default();
+        let mut buf = String::new();
+        theme
+            .format_select_prompt_item(&mut buf, "item2", false)
+            .unwrap();
+        assert!(buf.contains("item2"));
+    }
+
+    #[test]
+    fn test_clap_styles_returns_styles() {
+        let styles = clap_styles();
+        assert!(std::mem::size_of_val(&styles) > 0);
+    }
+
+    #[test]
+    fn test_spinner_chars_constants() {
+        assert!(!TICK_CHARS_BRAILLE_4_6_DOWN.is_empty());
+        assert!(!TICK_CHARS_BRAILLE_4_6_UP.is_empty());
+        assert!(!BRAILLE_6.is_empty());
+        assert!(!THIN_PROGRESS.is_empty());
+        assert!(!THIN_DUAL_PROGRESS.is_empty());
+        assert!(!DOTS_4.is_empty());
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,4 +71,32 @@ mod tests {
     fn test_longuest_common_suffix(#[case] a: &str, #[case] b: &str, #[case] expected: &str) {
         assert_eq!(longuest_common_suffix(a, b), expected);
     }
+
+    #[test]
+    fn test_expect_type_alias() {
+        let ok_result: Expect<String> = Ok("hello".to_string());
+        assert!(ok_result.is_ok());
+
+        let err_result: Expect<String> = Err("error".into());
+        assert!(err_result.is_err());
+    }
+
+    #[test]
+    fn test_short_path_deeply_nested() {
+        let h = home();
+        let path = format!("{}/a/b/c/d/e/f.txt", h);
+        let result = short_path(&path);
+        assert_eq!(result, "~/a/b/c/d/e/f.txt");
+    }
+
+    #[test]
+    fn test_short_path_empty_string() {
+        let result = short_path("");
+        let h = home();
+        if h.is_empty() {
+            assert_eq!(result, "");
+        } else {
+            assert_eq!(result, "");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Added 69 new unit tests across 6 modules
- Coverage improved from 75.1% → 78.8% (lines), 73.3% → 77.8% (functions)
- All 426 tests pass (up from 357)

## Changes
| Module | Before | After | Tests Added |
|--------|--------|-------|-------------|
|  | 32.7% | 58.4% | CLI parsing, flags, subcommand dispatch |
|  | 34.4% | 66.0% | Empty/single/multiple overlay listing |
|  | 40.3% | 66.0% | Status display with/without descriptions |
|  | 46.3% | 66.0% | Theme formatting, style functions |
|  | 49.5% | 58.9% | Path shortening edge cases |
|  | 74.3% | 80.0% | Builder, progress, overlay resolution |

## Test Details
- **cli/mod**:  variants, CLI flag parsing, all subcommand variants
- **cli/list**: Empty repo, single overlay, multiple overlays, tree flag, skip bad overlays
- **cli/status**: Empty repo, with/without descriptions, multiple overlays
- **ui/style**: All style functions, DialogTheme formatting methods (confirm, select, input, multi-select)
- **utils**:  type alias,  edge cases
- **exec/context**: , , ,  enum