### PR TITLE
perf(docker): optimize build time with cargo-chef and native arm64 runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,12 +11,20 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker:
-    name: 📦 Build & Push
-    runs-on: ubuntu-latest
+  build:
+    name: 📦 Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout sources
@@ -38,6 +46,63 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: 🏷️ Merge manifests
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -46,13 +111,13 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
-# ── Stage 1: Build ───────────────────────────────────────────────────────────
-FROM rust:bookworm AS builder
+# ── Stage 1: Chef base ──────────────────────────────────────────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-bookworm AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
@@ -10,19 +10,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Cache dependencies by building them first
+# ── Stage 2: Planner ────────────────────────────────────────────────────────
+FROM chef AS planner
+
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir -p src && echo 'fn main() {}' > src/main.rs \
-    && mkdir -p src/bin && echo 'fn main() {}' > src/bin/git-over.rs \
-    && cargo build --release --features vendored \
-    && rm -rf src
+COPY src ./src
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Build the actual application
+# ── Stage 3: Builder ────────────────────────────────────────────────────────
+FROM chef AS builder
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --features vendored --recipe-path recipe.json
+
 COPY . .
-RUN touch src/main.rs src/bin/git-over.rs \
-    && cargo build --release --features vendored
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release --features vendored
 
-# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+# ── Stage 4: Runtime ────────────────────────────────────────────────────────
 FROM gcr.io/distroless/cc-debian12
 
 COPY --from=builder /app/target/release/over /usr/local/bin/over


### PR DESCRIPTION
## Summary

- **Eliminate QEMU emulation** for arm64 by splitting multi-platform builds into parallel jobs on native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64)
- **Replace manual dependency caching** (dummy `main.rs` trick) with `cargo-chef` for robust, reliable layer caching
- **Add BuildKit cache mounts** for cargo registry/git and per-platform GHA cache scopes to prevent cache thrashing

## Changes

### `Dockerfile`
Refactored from 2-stage to 4-stage build:
1. `chef` — base image with cmake/pkg-config (`lukemathwalker/cargo-chef:latest-rust-bookworm`)
2. `planner` — generates `recipe.json` dependency fingerprint
3. `builder` — `cargo chef cook` builds deps (cached layer), then builds the app
4. runtime — unchanged (distroless)

### `.github/workflows/docker.yml`
Restructured into two jobs:
1. `build` — matrix job running on native runners per platform (parallel)
2. `merge` — creates multi-arch manifest from per-platform digests

## Expected Impact

| Metric | Before | After |
|---|---|---|
| arm64 build | ~30-60 min (QEMU) | ~5-10 min (native) |
| Platform builds | Sequential | Parallel |
| Dep cache on source-only changes | Fragile | Reliable (cargo-chef) |
| **Estimated total wall-clock** | **~40-70 min** | **~5-10 min** |