### PR TITLE
refactor: fix code consistency, clippy warnings, and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Repository Purpose: Rust CLI (bin `over`) managing git-based file overlays. Keep
 Build/Test:
 - Full build: `cargo build` (or `mise run build`)
 - Format: `cargo fmt --all` (or `mise run fmt`)
-- Lint: `cargo clippy --all-targets --all-features -- -Dclippy:all` (or `mise run lint`)
+- Lint: `cargo clippy --all-targets --all-features -- -Dclippy::all` (or `mise run lint`)
 - Test all: `cargo nextest run` (or `mise run test`)
 - Single test: `cargo nextest run --test <file> -- <name::path>` or fallback `cargo test <name>`
 - Coverage: `cargo llvm-cov nextest` (or `mise run cover`)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto
+        threshold: 10%

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use async_trait::async_trait;
 use config::{GitRepoConfig, ROOT_PATH};
 use futures::future::join_all;
@@ -225,8 +225,6 @@ impl Action for EnsureGitRepository {
         Ok(())
     }
 }
-
-use anyhow::Context as AnyhowContext;
 
 /// Checkout a specific tag or rev on a non-bare repo.
 fn checkout_ref(repo: &Repository, config: &GitRepoConfig) -> Result<()> {
@@ -621,7 +619,7 @@ struct CloneStats {
     received_bytes: usize,
 }
 
-impl CloneStats {
+impl From<Progress<'_>> for CloneStats {
     fn from(stats: Progress) -> Self {
         Self {
             total_objects: stats.total_objects(),

--- a/src/actions/install.rs
+++ b/src/actions/install.rs
@@ -128,7 +128,7 @@ async fn run_cmd(ctx: &Ctx, program: &str, args: &[&str]) -> Result<()> {
     Ok(())
 }
 
-async fn run_scripts(ctx: &Ctx, scripts: &Vec<String>) -> Result<()> {
+async fn run_scripts(ctx: &Ctx, scripts: &[String]) -> Result<()> {
     for script in scripts {
         run_cmd(ctx, "sh", &["-c", script.as_str()]).await?;
     }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -8,10 +8,10 @@ use crate::cli::CLI;
 use crate::cli::common::resolve_inputs;
 use crate::exec::Context;
 use crate::overlays::Repository;
-use crate::ui::{emojis, style};
+use crate::ui::emojis;
+use crate::ui::style::{self, DialogTheme};
 use anyhow::{Result, anyhow};
 use dialoguer::FuzzySelect;
-use dialoguer::theme::ColorfulTheme;
 use dirs::home_dir;
 
 #[derive(Args, Debug)]
@@ -51,7 +51,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             if overlays.is_empty() {
                 return Err(anyhow!("no overlays found in repository"));
             }
-            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+            let selection = FuzzySelect::with_theme(&DialogTheme::default())
                 .with_prompt("Choose the target overlay")
                 .default(0)
                 .items(&overlays[..])
@@ -116,7 +116,7 @@ fn add_symlink(
 
     let default_target = compute_default_target(&link_target, &overlay.root, home);
 
-    let target: String = Input::with_theme(&ColorfulTheme::default())
+    let target: String = Input::with_theme(&DialogTheme::default())
         .with_prompt(format!(
             "Target for {}",
             style::cyan(symlink_path.display())

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -3,13 +3,13 @@ use std::path::PathBuf;
 use anyhow::{Result, anyhow};
 use clap::Args;
 use dialoguer::FuzzySelect;
-use dialoguer::theme::ColorfulTheme;
 use dirs::home_dir;
 
 use crate::actions;
 use crate::cli::CLI;
 use crate::exec::Context;
 use crate::overlays::Repository;
+use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 #[derive(Args, Debug)]
 pub struct Params {
@@ -52,7 +52,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             if overlays.is_empty() {
                 return Err(anyhow!("no overlays found in repository"));
             }
-            let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+            let selection = FuzzySelect::with_theme(&DialogTheme::default())
                 .with_prompt("Choose the overlay to apply")
                 .default(0)
                 .items(&overlays[..])

--- a/src/cli/git_over/mod.rs
+++ b/src/cli/git_over/mod.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use dirs::home_dir;
 
 use crate::overlays::{Overlay, Repository};
-use crate::ui::style::clap_styles;
+use crate::ui::style::{DialogTheme, clap_styles};
 
 mod add;
 mod mount;
@@ -215,7 +215,7 @@ pub fn resolve_overlay(
         return Err(anyhow!("no overlays found in repository"));
     }
 
-    let selection = dialoguer::FuzzySelect::with_theme(&dialoguer::theme::ColorfulTheme::default())
+    let selection = dialoguer::FuzzySelect::with_theme(&DialogTheme::default())
         .with_prompt("Choose the target overlay")
         .default(0)
         .items(&overlays[..])

--- a/src/cli/git_over/mount.rs
+++ b/src/cli/git_over/mount.rs
@@ -3,12 +3,12 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use clap::Args;
-use dialoguer::theme::ColorfulTheme;
 use dialoguer::{FuzzySelect, MultiSelect};
 use dirs::home_dir;
 
 use crate::actions::git::config::{GitConfig, GitRepoConfig, RemoteConfig, WorktreeEntry};
 use crate::overlays::{self, Format, Repository};
+use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -78,7 +78,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         if overlays.is_empty() {
             return Err(anyhow!("no overlays found in repository"));
         }
-        let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
+        let selection = FuzzySelect::with_theme(&DialogTheme::default())
             .with_prompt("Choose the target overlay")
             .default(0)
             .items(&overlays[..])
@@ -307,7 +307,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             })
             .collect();
 
-        let selections = MultiSelect::with_theme(&ColorfulTheme::default())
+        let selections = MultiSelect::with_theme(&DialogTheme::default())
             .with_prompt("Select properties to export to overlay config")
             .items(&labels)
             .defaults(&defaults)

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -139,7 +139,6 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             .repository(repo)
             .overlay(overlay.clone())
             .build();
-        let ctx = std::sync::Arc::new(ctx);
 
         overlay.add_files(&ctx, &files_to_absorb).await?;
     }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,5 +1,5 @@
 use crate::cli::CLI;
-use crate::overlays::repository::Repository;
+use crate::overlays::Repository;
 use crate::ui::style;
 use crate::utils::short_path;
 use anyhow::Result;


### PR DESCRIPTION
Addresses code consistency issues found during a systematic review of the codebase.

Key changes:
- Fix clippy flag syntax in AGENTS.md (single colon -> double colon)
- Remove double `Arc` wrapping in the `new` command
- Use `DialogTheme` consistently across all CLI modules instead of raw `ColorfulTheme`
- Convert `CloneStats::from` inherent method to idiomatic `From` trait impl
- Fix pre-existing clippy warnings (`needless_borrows_for_generic_args`, `approx_constant`, `if_same_then_else`)
- Apply `cargo fmt` and `taplo` formatting