### PR TITLE
fix(lint): resolve clippy warnings, TOML formatting, and trailing whitespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,14 @@ globset = "0.4"
 symlink = "0.1"
 minijinja = "2.18"
 walkdir = "2"
-tokio = { version = "1.50", features = ["rt", "rt-multi-thread", "macros", "fs", "process", "sync"] }
+tokio = { version = "1.50", features = [
+  "rt",
+  "rt-multi-thread",
+  "macros",
+  "fs",
+  "process",
+  "sync",
+] }
 indicatif = "0.18"
 toml = { version = "1.0", features = ["parse", "display"] }
 git2 = "0.20"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
   <a href="https://github.com/noirbizarre/over/actions/workflows/ci.yml">
     <img src="https://github.com/noirbizarre/over/actions/workflows/ci.yml/badge.svg" alt="👮 CI"/>
   </a>
-  <a href="https://codecov.io/gh/noirbizarre/over" > 
-    <img src="https://codecov.io/gh/noirbizarre/over/graph/badge.svg?token=XkB3PcbQer"/> 
+  <a href="https://codecov.io/gh/noirbizarre/over" >
+    <img src="https://codecov.io/gh/noirbizarre/over/graph/badge.svg?token=XkB3PcbQer"/>
   </a>
 </p>
 

--- a/prek.toml
+++ b/prek.toml
@@ -28,21 +28,19 @@ hooks = [
 
 [[repos]]
 repo = "local"
-hooks = [
-  {
-    id = "cargo-fmt",
-    name = "cargo fmt",
-    language = "system",
-    types = ["file", "rust"],
-    pass_filenames = true,
-    entry = "cargo fmt --all --",
-  },
-  {
-    id = "cargo-clippy",
-    name = "cargo clippy",
-    language = "system",
-    types = ["file", "rust"],
-    pass_filenames = false,
-    entry = "cargo clippy --all-targets --all-features -- -Dclippy::all",
-  },
-]
+
+[[repos.hooks]]
+id = "cargo-fmt"
+name = "cargo fmt"
+language = "system"
+types = ["file", "rust"]
+pass_filenames = true
+entry = "cargo fmt --all --"
+
+[[repos.hooks]]
+id = "cargo-clippy"
+name = "cargo clippy"
+language = "system"
+types = ["file", "rust"]
+pass_filenames = false
+entry = "cargo clippy --all-targets --all-features -- -Dclippy::all"

--- a/src/cli/git_over/mount.rs
+++ b/src/cli/git_over/mount.rs
@@ -834,7 +834,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("url".into())),
+            entry.get(serde_yml::Value::String("url".into())),
             Some(&serde_yml::Value::String(
                 "https://github.com/user/repo.git".into()
             )),
@@ -859,7 +859,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("branch".into())),
+            entry.get(serde_yml::Value::String("branch".into())),
             Some(&serde_yml::Value::String("main".into())),
         );
     }
@@ -881,7 +881,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("tag".into())),
+            entry.get(serde_yml::Value::String("tag".into())),
             Some(&serde_yml::Value::String("v1.0.0".into())),
         );
     }
@@ -903,7 +903,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("rev".into())),
+            entry.get(serde_yml::Value::String("rev".into())),
             Some(&serde_yml::Value::String("abc123".into())),
         );
     }
@@ -925,7 +925,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("recurse_submodules".into())),
+            entry.get(serde_yml::Value::String("recurse_submodules".into())),
             Some(&serde_yml::Value::Bool(true)),
         );
     }
@@ -947,7 +947,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("worktree".into())),
+            entry.get(serde_yml::Value::String("worktree".into())),
             Some(&serde_yml::Value::Bool(true)),
         );
     }
@@ -977,12 +977,12 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let wt = entry
-            .get(&serde_yml::Value::String("worktrees".into()))
+            .get(serde_yml::Value::String("worktrees".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            wt.get(&serde_yml::Value::String("feature".into())),
+            wt.get(serde_yml::Value::String("feature".into())),
             Some(&serde_yml::Value::String("feature-branch".into())),
         );
     }
@@ -1015,23 +1015,23 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let remotes_map = entry
-            .get(&serde_yml::Value::String("remotes".into()))
+            .get(serde_yml::Value::String("remotes".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         let upstream = remotes_map
-            .get(&serde_yml::Value::String("upstream".into()))
+            .get(serde_yml::Value::String("upstream".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            upstream.get(&serde_yml::Value::String("url".into())),
+            upstream.get(serde_yml::Value::String("url".into())),
             Some(&serde_yml::Value::String(
                 "https://github.com/upstream/repo.git".into()
             )),
         );
         assert_eq!(
-            upstream.get(&serde_yml::Value::String("fetch".into())),
+            upstream.get(serde_yml::Value::String("fetch".into())),
             Some(&serde_yml::Value::String(
                 "+refs/heads/*:refs/remotes/upstream/*".into()
             )),
@@ -1058,16 +1058,16 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let config_map = entry
-            .get(&serde_yml::Value::String("config".into()))
+            .get(serde_yml::Value::String("config".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            config_map.get(&serde_yml::Value::String("user.name".into())),
+            config_map.get(serde_yml::Value::String("user.name".into())),
             Some(&serde_yml::Value::String("Test User".into())),
         );
         assert_eq!(
-            config_map.get(&serde_yml::Value::String("user.email".into())),
+            config_map.get(serde_yml::Value::String("user.email".into())),
             Some(&serde_yml::Value::String("test@example.com".into())),
         );
     }
@@ -1097,10 +1097,10 @@ mod tests {
 
     #[test]
     fn test_yaml_value_to_toml_float() {
-        let v = serde_yml::Value::Number(serde_yml::Number::from(3.14));
+        let v = serde_yml::Value::Number(serde_yml::Number::from(2.72));
         let result = yaml_value_to_toml(&v).unwrap();
         match result {
-            toml::Value::Float(f) => assert!((f - 3.14).abs() < f64::EPSILON),
+            toml::Value::Float(f) => assert!((f - 2.72).abs() < f64::EPSILON),
             _ => panic!("expected float"),
         }
     }
@@ -1400,7 +1400,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("per_worktree_config".into())),
+            entry.get(serde_yml::Value::String("per_worktree_config".into())),
             Some(&serde_yml::Value::Bool(false)),
         );
     }
@@ -1423,7 +1423,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(&serde_yml::Value::String("per_worktree_config".into())),
+            entry.get(serde_yml::Value::String("per_worktree_config".into())),
             None,
         );
     }
@@ -1459,26 +1459,26 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let wt = entry
-            .get(&serde_yml::Value::String("worktrees".into()))
+            .get(serde_yml::Value::String("worktrees".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         let feat = wt
-            .get(&serde_yml::Value::String("feat".into()))
+            .get(serde_yml::Value::String("feat".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            feat.get(&serde_yml::Value::String("branch".into())),
+            feat.get(serde_yml::Value::String("branch".into())),
             Some(&serde_yml::Value::String("feature".into())),
         );
         let cfg = feat
-            .get(&serde_yml::Value::String("config".into()))
+            .get(serde_yml::Value::String("config".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            cfg.get(&serde_yml::Value::String("user.email".into())),
+            cfg.get(serde_yml::Value::String("user.email".into())),
             Some(&serde_yml::Value::String("dev@test.com".into())),
         );
     }
@@ -1513,17 +1513,17 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let remotes_map = entry
-            .get(&serde_yml::Value::String("remotes".into()))
+            .get(serde_yml::Value::String("remotes".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         let upstream = remotes_map
-            .get(&serde_yml::Value::String("upstream".into()))
+            .get(serde_yml::Value::String("upstream".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            upstream.get(&serde_yml::Value::String("push".into())),
+            upstream.get(serde_yml::Value::String("push".into())),
             Some(&serde_yml::Value::String(
                 "+refs/heads/*:refs/heads/*".into()
             )),
@@ -1560,17 +1560,17 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let remotes_map = entry
-            .get(&serde_yml::Value::String("remotes".into()))
+            .get(serde_yml::Value::String("remotes".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         let upstream = remotes_map
-            .get(&serde_yml::Value::String("upstream".into()))
+            .get(serde_yml::Value::String("upstream".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            upstream.get(&serde_yml::Value::String("tagopt".into())),
+            upstream.get(serde_yml::Value::String("tagopt".into())),
             Some(&serde_yml::Value::String("--no-tags".into())),
         );
     }
@@ -1607,17 +1607,17 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let remotes_map = entry
-            .get(&serde_yml::Value::String("remotes".into()))
+            .get(serde_yml::Value::String("remotes".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         let upstream = remotes_map
-            .get(&serde_yml::Value::String("upstream".into()))
+            .get(serde_yml::Value::String("upstream".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            upstream.get(&serde_yml::Value::String("prune".into())),
+            upstream.get(serde_yml::Value::String("prune".into())),
             Some(&serde_yml::Value::String("true".into())),
         );
     }
@@ -1643,12 +1643,12 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         let wt_cfg = entry
-            .get(&serde_yml::Value::String("worktree_config".into()))
+            .get(serde_yml::Value::String("worktree_config".into()))
             .unwrap()
             .as_mapping()
             .unwrap();
         assert_eq!(
-            wt_cfg.get(&serde_yml::Value::String("core.sparseCheckout".into())),
+            wt_cfg.get(serde_yml::Value::String("core.sparseCheckout".into())),
             Some(&serde_yml::Value::String("true".into())),
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,11 +92,6 @@ mod tests {
     #[test]
     fn test_short_path_empty_string() {
         let result = short_path("");
-        let h = home();
-        if h.is_empty() {
-            assert_eq!(result, "");
-        } else {
-            assert_eq!(result, "");
-        }
+        assert_eq!(result, "");
     }
 }


### PR DESCRIPTION
Fix all issues reported by `prek -qa`:

- Remove needless borrows in serde_yml mapping lookups flagged by clippy
- Avoid using an approximate PI constant in a float conversion test
- Simplify a redundant if/else with identical branches in the `short_path` test
- Convert multi-line inline tables in `prek.toml` to `[[repos.hooks]]` syntax so taplo can parse them
- Strip trailing whitespace from `README.md`