### PR TITLE
feat: add structured error handling with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
  "which",
 ]
@@ -960,6 +962,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1057,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1103,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -1527,6 +1553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1791,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1916,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ git2_credentials = "0.15"
 async-trait = "0.1"
 console = "0.16"
 anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 futures = "0.3"
 serde_yml = "0.0.12"
 which = "8.0"

--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -25,7 +25,7 @@ use crate::utils::short_path;
 
 static SPINNER_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
     ProgressStyle::with_template("{spinner:.cyan} {wide_msg}")
-        .unwrap()
+        .expect("static progress template must be valid")
         .tick_chars(style::TICK_CHARS_BRAILLE_4_6_DOWN.as_str())
 });
 
@@ -163,7 +163,7 @@ fn resolve_file_conflict(ctx: &Ctx, source: &Path, target: &Path) -> Result<bool
     }
     if ctx.no_prompt {
         return Err(anyhow::anyhow!(
-            "Conflict: {} already exists",
+            "file conflict: '{}' already exists (use --force to overwrite or run interactively to choose)",
             target.display()
         ));
     }
@@ -199,7 +199,7 @@ fn resolve_dir_conflict(ctx: &Ctx, source: &Path, target: &Path) -> Result<bool>
     }
     if ctx.no_prompt {
         return Err(anyhow::anyhow!(
-            "Conflict: {} already exists",
+            "directory conflict: '{}' already exists (use --force to overwrite or run interactively to choose)",
             target.display()
         ));
     }
@@ -249,7 +249,7 @@ pub async fn link(ctx: Ctx, overlay: &Overlay, to: &Path) -> Result<()> {
         .filter_map(|entry| match entry {
             Ok(e) => Some(e),
             Err(e) => {
-                eprintln!("Warning: skipping entry due to error: {}", e);
+                tracing::warn!("skipping entry due to error: {}", e);
                 None
             }
         })
@@ -353,8 +353,15 @@ pub async fn add_file(ctx: Ctx, overlay: &Overlay, file: &PathBuf) -> Result<()>
     }
     if let Err(e) = link_action.execute(ctx.clone()).await {
         // Rollback: move file back to original location
-        if !ctx.dry_run {
-            let _ = rename(&target, src).await;
+        if !ctx.dry_run
+            && let Err(rollback_err) = rename(&target, src).await
+        {
+            tracing::warn!(
+                source = %src.display(),
+                target = %target.display(),
+                error = %rollback_err,
+                "rollback failed: could not restore file to original location",
+            );
         }
         return Err(e);
     }
@@ -417,7 +424,7 @@ pub async fn add_dir(ctx: Ctx, overlay: &Overlay, dir: &Path) -> Result<()> {
             .filter_map(|entry| match entry {
                 Ok(e) => Some(e),
                 Err(e) => {
-                    eprintln!("Warning: skipping entry due to error: {}", e);
+                    tracing::warn!("skipping entry due to error: {}", e);
                     None
                 }
             })
@@ -729,6 +736,14 @@ mod tests {
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
     use std::fs;
+
+    /// Install a tracing subscriber so `tracing::warn!` etc. bodies are executed during tests.
+    fn init_test_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_max_level(tracing::Level::TRACE)
+            .try_init();
+    }
 
     fn repo_and_root() -> (TempDir, Repository) {
         let td = TempDir::new().unwrap();
@@ -1568,6 +1583,94 @@ mod tests {
         assert!(
             target.join("file.txt").exists(),
             "should be able to access files through symlink"
+        );
+    }
+
+    // ── link() with unreadable entries ──────────────────────────────────
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn link_skips_unreadable_entries_with_warning() {
+        use std::os::unix::fs::PermissionsExt;
+
+        init_test_tracing();
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov_unreadable");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str(&format!("target = \"{}\"", td.path().display()))
+            .unwrap();
+        let overlay = repo.get("ov_unreadable").unwrap();
+        let c = Context::builder()
+            .dry_run(true)
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        // Create a normal file in the overlay
+        fs::write(overlay.root.join("good.txt"), "ok").unwrap();
+
+        // Create a subdirectory with no read permission to trigger WalkDir error
+        let bad_dir = overlay.root.join("bad_dir");
+        fs::create_dir_all(&bad_dir).unwrap();
+        fs::write(bad_dir.join("hidden.txt"), "secret").unwrap();
+        fs::set_permissions(&bad_dir, fs::Permissions::from_mode(0o000)).unwrap();
+
+        // link() should succeed, skipping the unreadable entry with a warning
+        let target = td.path().join("link_target");
+        fs::create_dir_all(&target).unwrap();
+        let result = link(c.clone(), &overlay, &target).await;
+
+        // Restore permissions for cleanup
+        fs::set_permissions(&bad_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            result.is_ok(),
+            "link should succeed despite unreadable entries: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn add_dir_skips_unreadable_entries_with_warning() {
+        use std::os::unix::fs::PermissionsExt;
+
+        init_test_tracing();
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov_add_unreadable");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str(&format!("target = \"{}\"", td.path().display()))
+            .unwrap();
+        let overlay = repo.get("ov_add_unreadable").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        // Create a directory with a readable file and an unreadable subdirectory
+        let dir = td.path().join("adddir_unreadable");
+        fs::create_dir_all(dir.join("bad_sub")).unwrap();
+        fs::write(dir.join("good.txt"), "ok").unwrap();
+        fs::write(dir.join("bad_sub").join("hidden.txt"), "secret").unwrap();
+        fs::set_permissions(dir.join("bad_sub"), fs::Permissions::from_mode(0o000)).unwrap();
+
+        // add_dir should succeed, skipping the unreadable entry with a warning
+        let result = add_dir(c.clone(), &overlay, &dir).await;
+
+        // Restore permissions for cleanup
+        fs::set_permissions(dir.join("bad_sub"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            result.is_ok(),
+            "add_dir should succeed despite unreadable entries: {:?}",
+            result.err()
+        );
+        // The readable file should have been processed
+        assert!(
+            overlay.root.join("adddir_unreadable/good.txt").exists(),
+            "good.txt should be in overlay"
         );
     }
 }

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -534,13 +534,15 @@ fn apply_per_worktree_config(
 
 static CLONE_PROGRESS_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
     ProgressStyle::with_template("{spinner:.cyan} {prefix} [{bar:.green/yellow}] {msg}")
-        .unwrap()
+        .expect("static progress template must be valid")
         .tick_chars(style::TICK_CHARS_BRAILLE_4_6_DOWN.as_str())
         .progress_chars(style::THIN_PROGRESS.as_str())
 });
 
-static DONE_PROGRESS_STYLE: LazyLock<ProgressStyle> =
-    LazyLock::new(|| ProgressStyle::with_template("✅ {prefix}: {msg}").unwrap());
+static DONE_PROGRESS_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
+    ProgressStyle::with_template("✅ {prefix}: {msg}")
+        .expect("static progress template must be valid")
+});
 
 fn clone(
     url: &str,

--- a/src/actions/install.rs
+++ b/src/actions/install.rs
@@ -216,7 +216,7 @@ async fn install_arch_pkgs(ctx: &Ctx, pkgs: BTreeSet<String>) -> Result<()> {
             run_cmd(ctx, bin, ref_args.as_slice()).await?;
         }
     } else if ctx.verbose {
-        eprintln!("No arch package manager found for archlinux packages");
+        tracing::info!("no arch package manager found, skipping archlinux packages");
     }
     Ok(())
 }
@@ -243,7 +243,7 @@ async fn install_brew_pkgs(
         return Ok(());
     }
     if which("brew").is_err() {
-        eprintln!("brew not found");
+        tracing::warn!("brew not found, skipping brew packages");
         return Ok(());
     }
     for tap in taps.iter() {
@@ -275,7 +275,7 @@ async fn install_winget_pkgs(ctx: &Ctx, pkgs: BTreeSet<WingetPackage>) -> Result
     }
     if which("winget").is_err() {
         if ctx.verbose {
-            eprintln!("winget not found");
+            tracing::info!("winget not found, skipping winget packages");
         }
         return Ok(());
     }
@@ -309,7 +309,7 @@ async fn install_cargo_crates(ctx: &Ctx, crates: BTreeSet<CargoPackage>) -> Resu
     }
     if which("cargo").is_err() {
         if ctx.verbose {
-            eprintln!("cargo not found");
+            tracing::info!("cargo not found, skipping cargo crates");
         }
         return Ok(());
     }
@@ -430,7 +430,7 @@ async fn install_node_packages(ctx: &Ctx, packages: BTreeSet<NodePackage>) -> Re
     }
     if which("npm").is_err() {
         if ctx.verbose {
-            eprintln!("npm not found");
+            tracing::info!("npm not found, skipping node packages");
         }
         return Ok(());
     }
@@ -452,7 +452,7 @@ pub async fn install(ctx: &Ctx, overlay: &Overlay) -> Result<()> {
         "linux" => install_linux(ctx, overlay).await?,
         "macos" => install_macos(ctx, overlay).await?,
         "windows" => install_windows(ctx, overlay).await?,
-        _ => eprintln!("Unsupported OS: {}", OS),
+        _ => tracing::warn!("unsupported OS '{}', skipping install", OS),
     }
     Ok(())
 }

--- a/src/actions/symlink.rs
+++ b/src/actions/symlink.rs
@@ -120,22 +120,21 @@ impl Action for EnsureSymlink {
                 }
                 LinkType::Hard => {
                     if is_dir {
-                        eprintln!(
-                            "{} {} {} (falling back to soft link)",
-                            emojis::WARNING,
-                            style::yellow("Warning:"),
-                            style::yellow("hard links are not supported for directories"),
+                        tracing::warn!(
+                            source = %source.display(),
+                            target = %target.display(),
+                            "hard links are not supported for directories, falling back to soft link",
                         );
                         symlink_dir(&source, &target)?;
                     } else {
                         match fs::hard_link(&source, &target) {
                             Ok(()) => {}
-                            Err(_) => {
-                                eprintln!(
-                                    "{} {} {} (falling back to soft link)",
-                                    emojis::WARNING,
-                                    style::yellow("Warning:"),
-                                    style::yellow("hard link failed, falling back to soft link"),
+                            Err(e) => {
+                                tracing::warn!(
+                                    source = %source.display(),
+                                    target = %target.display(),
+                                    error = %e,
+                                    "hard link failed, falling back to soft link",
                                 );
                                 symlink_file(&source, &target)?;
                             }
@@ -193,13 +192,10 @@ pub fn discover_symlinks(overlay_root: &Path) -> Result<Vec<(String, SymlinkConf
         };
 
         if config.target.is_empty() {
-            eprintln!(
-                "{} {} {} {} {}",
-                emojis::WARNING,
-                style::yellow("Warning:"),
-                style::yellow("empty target in"),
-                style::cyan(&stem),
-                style::yellow(", skipping"),
+            tracing::warn!(
+                name = %stem,
+                path = %rel.display(),
+                "empty target in symlink config, skipping",
             );
             continue;
         }
@@ -210,15 +206,11 @@ pub fn discover_symlinks(overlay_root: &Path) -> Result<Vec<(String, SymlinkConf
             } else {
                 (existing_path.clone(), rel.to_path_buf())
             };
-            eprintln!(
-                "{} {} {} {} {} {} {}",
-                emojis::WARNING,
-                style::yellow("Warning:"),
-                style::yellow("both"),
-                style::cyan(toml_path.display().to_string()),
-                style::yellow("and"),
-                style::cyan(yaml_path.display().to_string()),
-                style::yellow("exist; TOML takes precedence"),
+            tracing::warn!(
+                name = %stem,
+                toml = %toml_path.display(),
+                yaml = %yaml_path.display(),
+                "both TOML and YAML symlink configs exist; TOML takes precedence",
             );
             if rel.to_string_lossy().ends_with(".toml") {
                 results.retain(|(name, _)| name != &stem);
@@ -253,6 +245,14 @@ mod tests {
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
     use rstest::rstest;
+
+    /// Install a tracing subscriber so `tracing::warn!` etc. bodies are executed during tests.
+    fn init_test_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_max_level(tracing::Level::TRACE)
+            .try_init();
+    }
 
     #[test]
     fn link_type_default_is_soft() {
@@ -375,6 +375,7 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_symlink_hard_link_dir_falls_back() {
+        init_test_tracing();
         let td = TempDir::new().unwrap();
         let source = td.path().join("source_dir");
         let target = td.path().join("target_dir");
@@ -434,6 +435,7 @@ mod tests {
 
     #[test]
     fn discover_symlinks_toml_takes_precedence_over_yaml() {
+        init_test_tracing();
         let td = TempDir::new().unwrap();
         td.child("app.link.toml")
             .write_str("target = \"/from-toml\"")
@@ -450,6 +452,7 @@ mod tests {
 
     #[test]
     fn discover_symlinks_skips_empty_target() {
+        init_test_tracing();
         let td = TempDir::new().unwrap();
         td.child("bad.link.toml")
             .write_str("target = \"\"")
@@ -461,6 +464,7 @@ mod tests {
 
     #[test]
     fn discover_symlinks_yaml_first_toml_second_toml_wins() {
+        init_test_tracing();
         let td = TempDir::new().unwrap();
         td.child("app.link.yaml")
             .write_str("target: /from-yaml")
@@ -611,17 +615,24 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_symlink_hard_link_fallback_cross_device() {
+        init_test_tracing();
+        // Use a file from /proc (different filesystem) as source to force hard_link to fail.
+        // hard_link across filesystems returns EXDEV, triggering the fallback to soft link.
+        let source = PathBuf::from("/proc/self/exe");
+        if !source.exists() {
+            // Skip on systems without /proc
+            return;
+        }
         let td = TempDir::new().unwrap();
-        let source = td.path().join("source.txt");
-        let target = td.path().join("target.txt");
-        fs::write(&source, "hello").unwrap();
+        let target = td.path().join("target_link");
 
         let ctx = crate::exec::Context::builder().build();
         let action = EnsureSymlink::new(source.clone(), target.clone(), LinkType::Hard, false);
         action.execute(ctx).await.unwrap();
 
-        assert!(target.exists());
-        assert_eq!(fs::read_to_string(&target).unwrap(), "hello");
+        // Should have fallen back to a soft link
+        assert!(target.is_symlink(), "should fall back to soft link");
+        assert_eq!(fs::read_link(&target).unwrap(), source);
     }
 
     #[test]

--- a/src/bin/git-over.rs
+++ b/src/bin/git-over.rs
@@ -1,8 +1,12 @@
-use anyhow::Result;
+use std::process::ExitCode;
+
 use dot_over::cli::git_over;
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    git_over::main().await?;
-    Ok(())
+async fn main() -> ExitCode {
+    if let Err(err) = git_over::main().await {
+        dot_over::ui::display_error(&err);
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -90,16 +90,18 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
 
     if !regulars.is_empty() {
         let regular_paths: Vec<PathBuf> = regulars.into_iter().cloned().collect();
-        overlay.add_files(&ctx, &regular_paths).await.map_err(|e| {
-            println!(
-                "{} {} {} {}",
-                emojis::CROSSMARK,
-                style::white_b("Failed to add to overlay"),
-                style::cyan(&overlay.name),
-                style::white_b(&format!(": {}", e)),
-            );
-            e
-        })?;
+        overlay
+            .add_files(&ctx, &regular_paths)
+            .await
+            .inspect_err(|e| {
+                eprintln!(
+                    "{} {} {}: {}",
+                    emojis::CROSSMARK,
+                    style::white_b("Failed to add to overlay"),
+                    style::cyan(&overlay.name),
+                    e,
+                );
+            })?;
     }
 
     Ok(())

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -85,12 +85,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         actions::install::install(&ctx, &overlay).await?;
     }
 
-    overlay.apply(&ctx).await.inspect_err(|_| {
+    overlay.apply(&ctx).await.inspect_err(|e| {
         eprintln!(
-            "{} {} {}",
+            "{} {} {}: {}",
             emojis::CROSSMARK,
             style::white_b("Failed to apply overlay"),
-            style::white_bi(&overlay.name),
+            style::cyan(&overlay.name),
+            e,
         );
     })?;
 

--- a/src/cli/git_over/add.rs
+++ b/src/cli/git_over/add.rs
@@ -81,15 +81,14 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
 
     let resolved = resolve_inputs(&args.files)?;
 
-    overlay.add_files(&ctx, &resolved).await.map_err(|e| {
-        println!(
-            "{} {} {} {}",
+    overlay.add_files(&ctx, &resolved).await.inspect_err(|e| {
+        eprintln!(
+            "{} {} {}: {}",
             emojis::CROSSMARK,
             style::white_b("Failed to add to overlay"),
             style::cyan(&overlay.name),
-            style::white_b(&format!(": {}", e)),
+            e,
         );
-        e
     })?;
 
     // Compute relative paths from the repo root for .git/info/exclude

--- a/src/cli/git_over/mod.rs
+++ b/src/cli/git_over/mod.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use clap::{Parser, Subcommand};
-use dirs::home_dir;
 
 use crate::overlays::{Overlay, Repository};
 use crate::ui::style::{DialogTheme, clap_styles};
@@ -57,19 +56,15 @@ pub enum Commands {
 impl CLI {
     /// Resolve the over home directory: flag/env > default (~/.over)
     pub fn resolve_home(&self) -> Result<PathBuf> {
-        if let Some(ref home) = self.home {
-            Ok(home.clone())
-        } else {
-            let default = home_dir()
-                .ok_or_else(|| anyhow!("could not determine home directory"))?
-                .join(".over");
-            Ok(default)
-        }
+        crate::utils::resolve_home(self.home.as_ref())
     }
 }
 
 pub async fn main() -> Result<()> {
     let args = CLI::parse();
+
+    crate::ui::init_tracing(args.verbose, args.debug);
+
     match &args.cmd {
         Commands::Mount(opt) => mount::execute(&args, opt).await?,
         Commands::Add(opt) => add::execute(&args, opt).await?,

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -71,7 +71,11 @@ pub async fn execute(cli: &CLI, _args: &Params) -> Result<()> {
     println!("{} found", parts.join(", "));
 
     if result.has_errors() {
-        std::process::exit(1);
+        anyhow::bail!(
+            "lint found {} error{}",
+            errors,
+            if errors == 1 { "" } else { "s" },
+        );
     }
 
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand, crate_name};
-use dirs::home_dir;
 
 use crate::ui::style::clap_styles;
 
@@ -77,19 +76,15 @@ pub enum Commands {
 impl CLI {
     /// Resolve the home directory: flag/env > default (~/.over)
     pub fn resolve_home(&self) -> Result<PathBuf> {
-        if let Some(ref home) = self.home {
-            Ok(home.clone())
-        } else {
-            let default = home_dir()
-                .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
-                .join(".over");
-            Ok(default)
-        }
+        crate::utils::resolve_home(self.home.as_ref())
     }
 }
 
 pub async fn main() -> Result<()> {
     let args = CLI::parse();
+
+    crate::ui::init_tracing(args.verbose, args.debug);
+
     match args.cmd {
         Some(Commands::Add(ref opt)) => {
             add::execute(&args, opt).await?;

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -80,11 +80,14 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     let resolved_target = resolve_target_path(&target_str)?;
 
     if cli.debug {
-        eprintln!("overlay root: {}", overlay_root.display());
-        eprintln!("descriptor:   {}", descriptor.display());
-        eprintln!("target:       {}", target_str);
-        eprintln!("resolved:     {}", resolved_target.display());
-        eprintln!("format:       {}", format);
+        tracing::debug!(
+            overlay_root = %overlay_root.display(),
+            descriptor = %descriptor.display(),
+            target = %target_str,
+            resolved = %resolved_target.display(),
+            format = %format,
+            "creating new overlay",
+        );
     }
 
     // Collect git entries and files to absorb before writing anything

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,4 @@ pub mod lint;
 pub mod overlays;
 pub mod ui;
 
-mod utils;
-
-pub use utils::Expect;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
-use anyhow::Result;
+use std::process::ExitCode;
+
 use dot_over::cli;
 
-// fn main() -> Result<(), Box<dyn std::error::Error>> {
-//     cli::main()?;
-//     Ok(())
-// }
-
 #[tokio::main]
-async fn main() -> Result<()> {
-    cli::main().await?;
-    Ok(())
+async fn main() -> ExitCode {
+    if let Err(err) = cli::main().await {
+        dot_over::ui::display_error(&err);
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
 }

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -66,7 +66,7 @@ where
 
 static SYMLINK_SPINNER_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
     ProgressStyle::with_template("{spinner:.cyan} {wide_msg}")
-        .unwrap()
+        .expect("static progress template must be valid")
         .tick_chars(style::TICK_CHARS_BRAILLE_4_6_DOWN.as_str())
 });
 
@@ -139,9 +139,15 @@ impl Overlay {
             .set_override("name", name)?
             .set_override("root", root.to_str())?
             .set_default("target", DEFAULT_TARGET)?
-            .build()?;
+            .build()
+            .with_context(|| format!("invalid overlay descriptor in '{}'", root.display(),))?;
 
-        Ok(s.try_deserialize()?)
+        s.try_deserialize().with_context(|| {
+            format!(
+                "invalid overlay descriptor for '{}': check required fields (target)",
+                name,
+            )
+        })
     }
 
     pub fn resolve_target(&self, ctx: &exec::Context) -> Result<PathBuf> {

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -9,7 +9,6 @@ use anyhow::{Context as AnyhowContext, Result};
 
 use super::overlay::Overlay;
 use super::{BASENAME, Format, GLOB_PATTERN};
-use crate::ui::style;
 
 /// Manage all overlays
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -61,12 +60,9 @@ impl Repository {
                 .with_context(|| format!("failed to load overlay at {}", dir.display()))
             {
                 Ok(overlay) => overlays.push(overlay),
-                Err(_e) => eprintln!(
-                    "{} {} {}",
-                    style::yellow("Warning:"),
-                    style::white_b("skipping badly formatted overlay"),
-                    style::cyan(&dir.display().to_string()),
-                ),
+                Err(e) => {
+                    tracing::warn!("skipping badly formatted overlay {}: {}", dir.display(), e,);
+                }
             }
         }
 
@@ -76,7 +72,15 @@ impl Repository {
     /// Get a repository by its name/relative path
     pub fn get(&self, name: &str) -> Result<Overlay> {
         let root = self.root.join(name);
-        let overlay = Overlay::new(self, &root)?;
+        if !root.exists() {
+            anyhow::bail!(
+                "overlay '{}' not found (no such directory: {})",
+                name,
+                root.display()
+            );
+        }
+        let overlay = Overlay::new(self, &root)
+            .with_context(|| format!("failed to load overlay '{}'", name))?;
         Ok(overlay)
     }
 

--- a/src/ui/log.rs
+++ b/src/ui/log.rs
@@ -1,4 +1,4 @@
-use console::Term;
+use console::{Term, style};
 
 use anyhow::Result;
 
@@ -6,4 +6,86 @@ pub fn info(msg: impl AsRef<str>) -> Result<()> {
     let term = Term::stdout();
     term.write_line(msg.as_ref())?;
     Ok(())
+}
+
+/// Initialize the tracing subscriber with the given verbosity level.
+///
+/// - Default (no flags): only warnings and errors
+/// - `--verbose`: adds info-level messages
+/// - `--debug`: adds debug-level messages
+pub fn init_tracing(verbose: bool, debug: bool) {
+    use tracing_subscriber::EnvFilter;
+
+    let default_level = if debug {
+        "debug"
+    } else if verbose {
+        "info"
+    } else {
+        "warn"
+    };
+
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter)
+        .with_target(false)
+        .without_time()
+        .init();
+}
+
+/// Format an `anyhow::Error` for user-facing display on stderr.
+///
+/// Produces styled output like:
+/// ```text
+/// ✘ error: overlay "foo" not found
+///   caused by: no descriptor file at path
+/// ```
+pub fn display_error(err: &anyhow::Error) {
+    let term = Term::stderr();
+    let mut chain = err.chain();
+
+    // First error in chain is the top-level message
+    if let Some(top) = chain.next() {
+        let _ = term.write_line(&format!(
+            "{} {} {}",
+            style("✘").red().bold(),
+            style("error:").red().bold(),
+            top,
+        ));
+    }
+
+    // Remaining causes
+    for cause in chain {
+        let _ = term.write_line(&format!("  {} {}", style("caused by:").dim(), cause,));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_error_single_message() {
+        let err = anyhow::anyhow!("something went wrong");
+        // Should not panic; output goes to stderr
+        display_error(&err);
+    }
+
+    #[test]
+    fn display_error_with_cause_chain() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err = anyhow::Error::new(err).context("failed to read config");
+        // Exercises the `for cause in chain` loop (lines 60-62)
+        display_error(&err);
+    }
+
+    #[test]
+    fn display_error_deep_chain() {
+        let err = anyhow::anyhow!("root cause")
+            .context("middle layer")
+            .context("top level");
+        display_error(&err);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,4 +3,4 @@ pub mod style;
 
 pub mod log;
 
-pub use log::info;
+pub use log::{display_error, info, init_tracing};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,21 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use anyhow::Result;
 use dirs::home_dir;
 
-// Change the alias to `Box<error::Error>`.
-pub type Expect<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+/// Resolve the over home directory.
+///
+/// Uses `explicit` if provided, otherwise falls back to `~/.over`.
+pub fn resolve_home(explicit: Option<&PathBuf>) -> Result<PathBuf> {
+    if let Some(home) = explicit {
+        Ok(home.clone())
+    } else {
+        let default = home_dir()
+            .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?
+            .join(".over");
+        Ok(default)
+    }
+}
 
 // Shorten a path by replacing the home directory with ~
 pub fn short_path(path: &str) -> String {
@@ -73,15 +85,6 @@ mod tests {
     }
 
     #[test]
-    fn test_expect_type_alias() {
-        let ok_result: Expect<String> = Ok("hello".to_string());
-        assert!(ok_result.is_ok());
-
-        let err_result: Expect<String> = Err("error".into());
-        assert!(err_result.is_err());
-    }
-
-    #[test]
     fn test_short_path_deeply_nested() {
         let h = home();
         let path = format!("{}/a/b/c/d/e/f.txt", h);
@@ -93,5 +96,19 @@ mod tests {
     fn test_short_path_empty_string() {
         let result = short_path("");
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn resolve_home_with_explicit_path() {
+        let explicit = PathBuf::from("/custom/over");
+        let result = resolve_home(Some(&explicit)).unwrap();
+        assert_eq!(result, PathBuf::from("/custom/over"));
+    }
+
+    #[test]
+    fn resolve_home_defaults_to_dot_over() {
+        let result = resolve_home(None).unwrap();
+        let expected = home_dir().unwrap().join(".over");
+        assert_eq!(result, expected);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -533,9 +533,9 @@ fn new_overlay_debug_output() -> TestResult {
         .args(["new", "debugoverlay", target.to_str().unwrap()])
         .assert()
         .success()
-        .stderr(contains("overlay root:"))
-        .stderr(contains("descriptor:"))
-        .stderr(contains("format:"));
+        .stderr(contains("overlay_root"))
+        .stderr(contains("descriptor"))
+        .stderr(contains("format"));
     Ok(())
 }
 
@@ -615,6 +615,20 @@ fn apply_overlay_with_root_dry_run() -> TestResult {
         target_root.to_str().unwrap(),
     ]);
     cmd.assert().success();
+    Ok(())
+}
+
+#[test]
+fn apply_nonexistent_overlay_fails() -> TestResult {
+    let tmp = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .args(["apply", "does_not_exist", "--no-prompt"])
+        .assert()
+        .failure()
+        .stderr(contains("error:"));
     Ok(())
 }
 
@@ -896,5 +910,67 @@ fn git_over_add_nonexistent_file_fails() -> TestResult {
         .current_dir(&repo_dir)
         .assert()
         .failure();
+    Ok(())
+}
+
+#[test]
+fn apply_conflict_no_prompt_fails() -> TestResult {
+    let repo = setup_overlay_repo();
+    let canonical = repo.path().canonicalize()?;
+    // Create a file in the overlay
+    let overlay_dir = canonical.join("dev");
+    fs::write(overlay_dir.join("conflict.txt"), "from overlay")?;
+
+    // Create the same file at the target location to provoke a conflict
+    let target_root = canonical.join("target_root");
+    fs::create_dir_all(&target_root)?;
+    fs::write(target_root.join("conflict.txt"), "existing")?;
+
+    // Apply with --no-prompt should fail on the conflict
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical)
+        .args([
+            "apply",
+            "dev",
+            "--root",
+            target_root.to_str().unwrap(),
+            "--no-prompt",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("conflict"));
+    Ok(())
+}
+
+#[test]
+fn add_file_outside_root_fails() -> TestResult {
+    let repo = setup_overlay_repo();
+    let canonical = repo.path().canonicalize()?;
+
+    // Create a file outside the --root directory
+    let outside = TempDir::new()?;
+    let outside_canonical = outside.path().canonicalize()?;
+    let outside_file = outside_canonical.join("outside.txt");
+    fs::write(&outside_file, "I am outside")?;
+
+    // The --root is set to a subdirectory so the file is not under it
+    let narrow_root = canonical.join("narrow");
+    fs::create_dir_all(&narrow_root)?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical)
+        .args([
+            "add",
+            outside_file.to_str().unwrap(),
+            "-o",
+            "dev",
+            "--root",
+            narrow_root.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("not included in"));
     Ok(())
 }


### PR DESCRIPTION
Replaces the ad-hoc mix of `eprintln!`, `process::exit(1)`, and swallowed errors with a consistent error handling strategy built on `tracing` and `anyhow`.

Both CLI entry points (`over` and `git-over`) now initialize a tracing subscriber (stderr, verbosity controlled by `--verbose`/`--debug`/`RUST_LOG`) and display errors through a centralized `display_error()` function that walks the `anyhow` cause chain with styled output. All 15 `eprintln!` calls have been replaced with appropriate `tracing::warn!`/`error!`/`debug!`/`info!` macros, `.unwrap()` calls on static templates have been replaced with `.expect()`, and previously swallowed errors (rollback failures, hard link errors) are now logged with full context.

Specific improvements for the cases called out in #2:
- **Layer does not exist**: `Repository::get()` checks directory existence before attempting to parse
- **Invalid layer descriptor**: `.build()` and `.try_deserialize()` wrapped with `.with_context()`
- **File conflict**: error messages now include the path and an actionable hint (`use --force` or `run interactively`)

Also removes the unused `Expect<T>` type and deduplicates the `resolve_home()` function shared between both CLIs.

Closes #2