### PR TITLE
feat(cli): add shell completion generation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +457,7 @@ dependencies = [
  "assert_fs",
  "async-trait",
  "clap",
+ "clap_complete",
  "config",
  "console 0.16.3",
  "dialoguer 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ libz-sys = { version = "1.1", optional = true }
 features = ["derive", "env", "unicode", "cargo", "color"]
 version = "4.6"
 
+[dependencies.clap_complete]
+version = "4.6"
+
 [dependencies.config]
 default-features = false
 features = ["yaml", "toml"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@ Over is a dotfiles manager allowing you to define file overlays in Git repositor
 It is inspired by tools like GNU Stow and Chezmoi but focuses on a Git-centric workflow with flexible configuration and installation capabilities.
 
 
+## Usage
+
+### Shell Completions
+
+Generate shell completion scripts with:
+
+```sh
+over completion <shell>
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`.
+
+#### Examples
+
+```sh
+# Bash (add to ~/.bashrc)
+over completion bash >> ~/.bashrc
+
+# Zsh (add to ~/.zshrc)
+over completion zsh >> ~/.zshrc
+
+# Fish
+over completion fish > ~/.config/fish/completions/over.fish
+
+# PowerShell (add to profile)
+over completion powershell >> $PROFILE
+```
+
+
 ## Root Configuration
 
 `over` supports a root configuration file at `~/.over/over.toml` (or `over.yaml`/`over.yml`). This file controls global preferences that apply across all overlays.

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -21,24 +21,25 @@ pub async fn execute(_cli: &CLI, args: &Params) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use clap::CommandFactory;
-    use clap_complete::{Shell, generate};
+    use clap::Parser;
+    use clap_complete::Shell;
     use rstest::rstest;
 
     use crate::cli::CLI;
 
     #[rstest]
-    #[case::bash(Shell::Bash)]
-    #[case::zsh(Shell::Zsh)]
-    #[case::fish(Shell::Fish)]
-    #[case::powershell(Shell::PowerShell)]
-    #[case::elvish(Shell::Elvish)]
-    fn generate_completions(#[case] shell: Shell) {
-        let mut cmd = CLI::command();
-        let mut buf = Vec::new();
-        generate(shell, &mut cmd, "over", &mut buf);
-        let output = String::from_utf8(buf).unwrap();
-        assert!(!output.is_empty());
-        assert!(output.contains("over"));
+    #[case::bash("bash", Shell::Bash)]
+    #[case::zsh("zsh", Shell::Zsh)]
+    #[case::fish("fish", Shell::Fish)]
+    #[case::powershell("powershell", Shell::PowerShell)]
+    #[case::elvish("elvish", Shell::Elvish)]
+    fn parse_shell_argument(#[case] input: &str, #[case] expected: Shell) {
+        let args = CLI::parse_from(["over", "completion", input]);
+        match args.cmd {
+            Some(crate::cli::Commands::Completion(params)) => {
+                assert_eq!(params.shell, expected);
+            }
+            other => panic!("expected Completion variant, got {other:?}"),
+        }
     }
 }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,0 +1,44 @@
+use std::io;
+
+use anyhow::Result;
+use clap::Args;
+use clap_complete::{Shell, generate};
+
+use crate::cli::CLI;
+
+#[derive(Args, Debug)]
+pub struct Params {
+    /// Shell to generate completions for
+    shell: Shell,
+}
+
+pub async fn execute(_cli: &CLI, args: &Params) -> Result<()> {
+    use clap::CommandFactory;
+    let mut cmd = CLI::command();
+    generate(args.shell, &mut cmd, "over", &mut io::stdout());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+    use clap_complete::{Shell, generate};
+    use rstest::rstest;
+
+    use crate::cli::CLI;
+
+    #[rstest]
+    #[case::bash(Shell::Bash)]
+    #[case::zsh(Shell::Zsh)]
+    #[case::fish(Shell::Fish)]
+    #[case::powershell(Shell::PowerShell)]
+    #[case::elvish(Shell::Elvish)]
+    fn generate_completions(#[case] shell: Shell) {
+        let mut cmd = CLI::command();
+        let mut buf = Vec::new();
+        generate(shell, &mut cmd, "over", &mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(!output.is_empty());
+        assert!(output.contains("over"));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ use crate::ui::style::clap_styles;
 mod add;
 mod apply;
 pub(crate) mod common;
+mod completion;
 pub mod git_over;
 mod lint;
 mod list;
@@ -66,6 +67,9 @@ pub enum Commands {
     #[clap(name = "lint", about = "Check overlays for configuration issues")]
     Lint(lint::Params),
 
+    #[clap(name = "completion", about = "Generate shell completion scripts")]
+    Completion(completion::Params),
+
     #[clap(
         name = "status",
         about = "Get the current repository/directory overlays status"
@@ -102,6 +106,9 @@ pub async fn main() -> Result<()> {
         }
         Some(Commands::Lint(ref opt)) => {
             lint::execute(&args, opt).await?;
+        }
+        Some(Commands::Completion(ref opt)) => {
+            completion::execute(&args, opt).await?;
         }
         Some(Commands::Show(ref opt)) => {
             show::execute(&args, opt).await?;
@@ -221,6 +228,12 @@ mod tests {
     fn cli_status_subcommand() {
         let args = CLI::parse_from(["over", "status"]);
         assert!(matches!(args.cmd, Some(Commands::Status)));
+    }
+
+    #[test]
+    fn cli_completion_subcommand() {
+        let args = CLI::parse_from(["over", "completion", "bash"]);
+        assert!(matches!(args.cmd, Some(Commands::Completion(_))));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -974,3 +974,54 @@ fn add_file_outside_root_fails() -> TestResult {
         .stderr(contains("not included in"));
     Ok(())
 }
+
+#[test]
+fn completion_bash() -> TestResult {
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.args(["completion", "bash"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("_over"))
+        .stdout(contains("COMPREPLY"));
+    Ok(())
+}
+
+#[test]
+fn completion_zsh() -> TestResult {
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.args(["completion", "zsh"]);
+    cmd.assert().success().stdout(contains("#compdef over"));
+    Ok(())
+}
+
+#[test]
+fn completion_fish() -> TestResult {
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.args(["completion", "fish"]);
+    cmd.assert().success().stdout(contains("complete -c over"));
+    Ok(())
+}
+
+#[test]
+fn completion_powershell() -> TestResult {
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.args(["completion", "powershell"]);
+    cmd.assert().success().stdout(contains("over"));
+    Ok(())
+}
+
+#[test]
+fn completion_elvish() -> TestResult {
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.args(["completion", "elvish"]);
+    cmd.assert().success().stdout(contains("over"));
+    Ok(())
+}
+
+#[test]
+fn completion_invalid_shell() -> TestResult {
+    let mut cmd = Command::cargo_bin("over")?;
+    cmd.args(["completion", "invalid"]);
+    cmd.assert().failure();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add `over completion <shell>` command that generates shell completion scripts for bash, zsh, fish, powershell, and elvish using `clap_complete`.

Closes #58