### PR TITLE
refactor(templates): centralize MiniJinja template environment

### DIFF
--- a/src/actions/symlink.rs
+++ b/src/actions/symlink.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context as AnyhowContext, Result};
 use async_trait::async_trait;
-use minijinja::Environment;
+
 use serde::{Deserialize, Serialize};
 use symlink::{remove_symlink_dir, remove_symlink_file, symlink_dir, symlink_file};
 
@@ -229,13 +229,12 @@ pub fn discover_symlinks(overlay_root: &Path) -> Result<Vec<(String, SymlinkConf
 }
 
 pub fn render_symlink_target(template: &str, overlays: &HashMap<String, String>) -> Result<String> {
-    let env = Environment::new();
     let env_vars: HashMap<String, String> = std::env::vars().collect();
     let mut state = HashMap::new();
     state.insert("env", env_vars);
     state.insert("overlays", overlays.clone());
 
-    env.render_str(template, &state)
+    crate::exec::templates::render_string(template, &state)
         .with_context(|| format!("failed to render symlink target template '{}'", template))
 }
 

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,5 +1,6 @@
 mod action;
 mod context;
+pub mod templates;
 
 pub use action::Action;
 pub use context::{Context, Ctx};

--- a/src/exec/templates.rs
+++ b/src/exec/templates.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use minijinja::Environment;
+use serde::Serialize;
+
+/// Create a shared MiniJinja `Environment` with all registered filters and functions.
+///
+/// This is the single extension point for custom template capabilities
+/// such as encryption (2.3) and secret manager integration (2.4).
+pub fn create_env<'a>() -> Environment<'a> {
+    // Register custom filters/functions here when needed
+    Environment::new()
+}
+
+/// Render a template string against the given serializable context.
+pub fn render_string(template: &str, ctx: &impl Serialize) -> Result<String> {
+    let env = create_env();
+    Ok(env.render_str(template, ctx)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn render_string_basic() {
+        let mut ctx = HashMap::new();
+        ctx.insert("name", "world");
+        let result = render_string("Hello, {{ name }}!", &ctx).unwrap();
+        assert_eq!(result, "Hello, world!");
+    }
+
+    #[test]
+    fn render_string_no_variables() {
+        let ctx = HashMap::<String, String>::new();
+        let result = render_string("plain text", &ctx).unwrap();
+        assert_eq!(result, "plain text");
+    }
+
+    #[test]
+    fn render_string_invalid_template() {
+        let ctx = HashMap::<String, String>::new();
+        let result = render_string("{{ invalid", &ctx);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_string_nested_context() {
+        let mut inner = HashMap::new();
+        inner.insert("key", "value");
+        let mut ctx = HashMap::new();
+        ctx.insert("nested", inner);
+        let result = render_string("{{ nested.key }}", &ctx).unwrap();
+        assert_eq!(result, "value");
+    }
+
+    #[test]
+    fn create_env_returns_functional_environment() {
+        let env = create_env();
+        let mut ctx = HashMap::new();
+        ctx.insert("x", "42");
+        let result = env.render_str("val={{ x }}", &ctx).unwrap();
+        assert_eq!(result, "val=42");
+    }
+}

--- a/src/lint/checks.rs
+++ b/src/lint/checks.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use globset::GlobBuilder;
-use minijinja::Environment;
 
 use crate::actions::symlink::{LinkType, discover_symlinks};
 use crate::overlays::Overlay;
@@ -252,9 +251,8 @@ fn check_symlinks(overlay: &Overlay) -> Vec<Diagnostic> {
                 format!("symlink `{name}`: `target` is empty"),
             ));
         } else {
-            let env = Environment::new();
             let test_state = std::collections::HashMap::<String, String>::new();
-            if let Err(e) = env.render_str(&config.target, &test_state) {
+            if let Err(e) = crate::exec::templates::render_string(&config.target, &test_state) {
                 diagnostics.push(Diagnostic::error(
                     &overlay.name,
                     format!("symlink `{name}`: invalid template in `target`: {e}"),

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -8,8 +8,6 @@ use config::{Config, File, FileFormat, FileSourceFile};
 use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 
-use minijinja::Environment;
-
 use crate::actions::git::config::{GitRepoConfig, deserialize_git_field};
 use crate::actions::install::InstallConfig;
 use crate::actions::{self, EnsureDir, EnsureSymlink};
@@ -151,13 +149,14 @@ impl Overlay {
     }
 
     pub fn resolve_target(&self, ctx: &exec::Context) -> Result<PathBuf> {
-        let env = Environment::new();
-        let path = PathBuf::from(env.render_str(self.target.as_str(), ctx).with_context(|| {
-            format!(
-                "failed to render target template '{}' for overlay '{}'",
-                self.target, self.name
-            )
-        })?);
+        let path = PathBuf::from(
+            exec::templates::render_string(self.target.as_str(), ctx).with_context(|| {
+                format!(
+                    "failed to render target template '{}' for overlay '{}'",
+                    self.target, self.name
+                )
+            })?,
+        );
 
         let path_str = path.to_string_lossy();
         Ok(match path_str.as_ref() {


### PR DESCRIPTION
## Summary

Create a shared `exec::templates` module with `create_env()` and `render_string()` as the single extension point for MiniJinja template rendering. Refactor the three existing call sites (overlay target resolution, symlink target rendering, and lint template validation) to use the centralized functions instead of creating inline `Environment::new()` instances.

This lays the groundwork for registering custom filters and functions needed by file templating, encryption, and secret manager integration.

Closes #60