### PR TITLE
feat(list): implement --tree view for overlay listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "serde_yml",
  "symlink",
  "tempfile",
+ "termtree 1.0.0",
  "tokio",
  "toml",
  "tracing",
@@ -1287,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
- "termtree",
+ "termtree 0.5.1",
 ]
 
 [[package]]
@@ -1663,6 +1664,12 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "termtree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ globset = "0.4"
 symlink = "0.1"
 minijinja = "2.19"
 walkdir = "2"
+termtree = "1.0"
 tokio = { version = "1.51", features = [
   "rt",
   "rt-multi-thread",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ It is inspired by tools like GNU Stow and Chezmoi but focuses on a Git-centric w
 
 ## Usage
 
+### Listing Overlays
+
+List all overlays in the repository:
+
+```sh
+over list
+```
+
+Display overlays as a tree, grouped by their directory hierarchy:
+
+```sh
+over list --tree
+```
+
+Example output:
+
+```
+.over
+├── git
+├── shell
+│   ├── bash
+│   └── zsh
+└── vim
+```
+
+The `list` command also has a short alias `ls`, and the tree flag can be shortened to `-t`:
+
+```sh
+over ls -t
+```
+
 ### Shell Completions
 
 Generate shell completion scripts with:

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,4 +1,8 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
 use clap::Args;
+use termtree::Tree;
 
 use crate::cli::CLI;
 use crate::overlays::Repository;
@@ -17,13 +21,67 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     }
 
     let home = cli.resolve_home()?;
-    let repo = Repository::new(home);
+    let repo = Repository::new(home.clone());
+    let overlays = repo.overlays()?;
 
-    for overlay in repo.overlays()? {
-        println!("{}", overlay.name);
+    if args.tree {
+        let root_label = root_label(&home);
+        let tree = build_tree(&root_label, overlays.iter().map(|o| o.name.as_str()));
+        print!("{tree}");
+    } else {
+        for overlay in &overlays {
+            println!("{}", overlay.name);
+        }
     }
 
     Ok(())
+}
+
+/// Derive the root node label from the home path (its directory name).
+fn root_label(home: &Path) -> String {
+    home.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| home.display().to_string())
+}
+
+/// A node in the intermediate tree structure used to group overlay name segments.
+#[derive(Default)]
+struct TreeNode {
+    children: BTreeMap<String, TreeNode>,
+}
+
+impl TreeNode {
+    /// Insert path segments into the tree, creating intermediate nodes as needed.
+    fn insert(&mut self, segments: &[&str]) {
+        if segments.is_empty() {
+            return;
+        }
+        let child = self.children.entry(segments[0].to_owned()).or_default();
+        if segments.len() > 1 {
+            child.insert(&segments[1..]);
+        }
+    }
+
+    /// Convert this node into a `termtree::Tree` with the given label.
+    fn into_tree(self, label: String) -> Tree<String> {
+        let mut tree = Tree::new(label);
+        for (name, child) in self.children {
+            tree.push(child.into_tree(name));
+        }
+        tree
+    }
+}
+
+/// Build a `termtree::Tree` from overlay names split on `/`.
+///
+/// Intermediate segments that are not themselves overlays become branch nodes.
+/// Overlay names are inserted in sorted order because `BTreeMap` keeps keys sorted.
+fn build_tree<'a>(root_label: &str, names: impl Iterator<Item = &'a str>) -> Tree<String> {
+    let mut root = TreeNode::default();
+    for name in names {
+        root.insert(&name.split('/').collect::<Vec<_>>());
+    }
+    root.into_tree(root_label.to_owned())
 }
 
 #[cfg(test)]
@@ -31,6 +89,7 @@ mod tests {
     use super::*;
     use assert_fs::TempDir;
     use clap::Parser;
+    use pretty_assertions::assert_eq;
     use std::fs;
     use std::path::PathBuf;
 
@@ -104,29 +163,71 @@ mod tests {
         let result = execute(&cli, &params).await;
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn build_tree_flat_overlays() {
+        let tree = build_tree(".over", ["git", "shell", "vim"].into_iter());
+        let output = tree.to_string();
+        let expected = "\
+.over
+├── git
+├── shell
+└── vim
+";
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn build_tree_nested_overlays() {
+        let tree = build_tree(
+            ".over",
+            ["git", "shell/bash", "shell/zsh", "vim"].into_iter(),
+        );
+        let output = tree.to_string();
+        let expected = "\
+.over
+├── git
+├── shell
+│   ├── bash
+│   └── zsh
+└── vim
+";
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn build_tree_deeply_nested() {
+        let tree = build_tree(
+            ".over",
+            ["apps/dev/editor", "apps/dev/terminal", "apps/browser"].into_iter(),
+        );
+        let output = tree.to_string();
+        let expected = "\
+.over
+└── apps
+    ├── browser
+    └── dev
+        ├── editor
+        └── terminal
+";
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn build_tree_empty() {
+        let tree = build_tree(".over", std::iter::empty());
+        let output = tree.to_string();
+        assert_eq!(output, ".over\n");
+    }
+
+    #[test]
+    fn build_tree_single_overlay() {
+        let tree = build_tree(".over", ["solo"].into_iter());
+        let output = tree.to_string();
+        let expected = "\
+.over
+└── solo
+";
+        assert_eq!(output, expected);
+    }
 }
-
-// use termtree::Tree;
-
-// use std::path::Path;
-// use std::{env, fs, io};
-
-// fn label<P: AsRef<Path>>(p: P) -> String {
-//     p.as_ref().file_name().unwrap().to_str().unwrap().to_owned()
-// }
-
-// fn tree<P: AsRef<Path>>(p: P) -> io::Result<Tree<String>> {
-//     let result = fs::read_dir(&p)?.filter_map(|e| e.ok()).fold(
-//         Tree::root(label(p.as_ref().canonicalize()?)),
-//         |mut root, entry| {
-//             let dir = entry.metadata().unwrap();
-//             if dir.is_dir() {
-//                 root.push(tree(entry.path()).unwrap());
-//             } else {
-//                 root.push(Tree::root(label(entry.path())));
-//             }
-//             root
-//         },
-//     );
-//     Ok(result)
-// }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -230,4 +230,16 @@ mod tests {
 ";
         assert_eq!(output, expected);
     }
+
+    #[test]
+    fn root_label_uses_directory_name() {
+        let label = root_label(Path::new("/home/user/.over"));
+        assert_eq!(label, ".over");
+    }
+
+    #[test]
+    fn root_label_falls_back_to_full_path() {
+        let label = root_label(Path::new("/"));
+        assert_eq!(label, "/");
+    }
 }


### PR DESCRIPTION
Implement the `--tree` flag for `over list` to display overlays as a directory-like tree using box-drawing characters.

Overlay names (which use `/` separators for nesting) are parsed into a hierarchical tree structure, with intermediate segments rendered as grouping nodes. Uses the `termtree` crate for rendering.

Also adds documentation for `over list` and `over list --tree` to the README.

Closes #59