### PR TITLE
refactor(yaml): migrate from serde_yml to noyalib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,11 +470,11 @@ dependencies = [
  "indicatif",
  "libz-sys",
  "minijinja",
+ "noyalib",
  "predicates",
  "pretty_assertions",
  "rstest",
  "serde",
- "serde_yml",
  "symlink",
  "tempfile",
  "termtree 1.0.0",
@@ -777,6 +777,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,16 +1037,6 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -1114,6 +1116,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "noyalib"
+version = "0.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665102745aff776f400df932eaabb91860795fd6cff70ed9fc12c9298160e5eb"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itoa",
+ "libm",
+ "memchr",
+ "rustc-hash",
+ "ryu",
+ "serde",
+ "serde_core",
+ "serde_ignored",
+ "smallvec",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1437,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,21 +1572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 futures = "0.3"
-serde_yml = "0.0.12"
+noyalib = { version = "0.0.24", features = ["compat-serde-yaml"] }
 which = "8.0"
 libz-sys = { version = "1.1", optional = true }
 

--- a/src/actions/git/config.rs
+++ b/src/actions/git/config.rs
@@ -337,9 +337,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use noyalib::compat::serde_yaml as serde_yml;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+
+    use super::*;
 
     // ── Simple form ──────────────────────────────────────────────────────
 

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -661,11 +661,9 @@ impl CloneState {
         }
         let network_pct = (100 * stats.received_objects) / stats.total_objects;
         let index_pct = (100 * stats.indexed_objects) / stats.total_objects;
-        let co_pct = if self.progress.total > 0 {
-            (100 * self.progress.current) / self.progress.total
-        } else {
-            0
-        };
+        let co_pct = (100 * self.progress.current)
+            .checked_div(self.progress.total)
+            .unwrap_or(0);
         bar.set_length(u64::try_from(stats.total_objects)?);
         bar.set_position(u64::try_from(stats.indexed_objects)?);
         let kbytes = stats.received_bytes / 1024;

--- a/src/actions/symlink.rs
+++ b/src/actions/symlink.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context as AnyhowContext, Result};
 use async_trait::async_trait;
 
+use noyalib::compat::serde_yaml as serde_yml;
 use serde::{Deserialize, Serialize};
 use symlink::{remove_symlink_dir, remove_symlink_file, symlink_dir, symlink_file};
 

--- a/src/cli/git_over/mount.rs
+++ b/src/cli/git_over/mount.rs
@@ -5,6 +5,7 @@ use anyhow::{Result, anyhow};
 use clap::Args;
 use dialoguer::{FuzzySelect, MultiSelect};
 use dirs::home_dir;
+use noyalib::compat::serde_yaml as serde_yml;
 
 use crate::actions::git::config::{GitConfig, GitRepoConfig, RemoteConfig, WorktreeEntry};
 use crate::overlays::{self, Format, Repository};
@@ -465,46 +466,28 @@ fn find_descriptor(overlay_root: &Path) -> (PathBuf, Format) {
 /// Build a git entry as a generic map suitable for both TOML and YAML serialization.
 fn build_git_entry(config: &GitRepoConfig) -> serde_yml::Mapping {
     let mut entry = serde_yml::Mapping::new();
-    entry.insert(
-        serde_yml::Value::String("url".into()),
-        serde_yml::Value::String(config.url.clone()),
-    );
+    entry.insert("url", serde_yml::Value::String(config.url.clone()));
 
     if let Some(ref branch) = config.branch {
-        entry.insert(
-            serde_yml::Value::String("branch".into()),
-            serde_yml::Value::String(branch.clone()),
-        );
+        entry.insert("branch", serde_yml::Value::String(branch.clone()));
     }
     if let Some(ref tag) = config.tag {
-        entry.insert(
-            serde_yml::Value::String("tag".into()),
-            serde_yml::Value::String(tag.clone()),
-        );
+        entry.insert("tag", serde_yml::Value::String(tag.clone()));
     }
     if let Some(ref rev) = config.rev {
-        entry.insert(
-            serde_yml::Value::String("rev".into()),
-            serde_yml::Value::String(rev.clone()),
-        );
+        entry.insert("rev", serde_yml::Value::String(rev.clone()));
     }
     if config.recurse_submodules {
-        entry.insert(
-            serde_yml::Value::String("recurse_submodules".into()),
-            serde_yml::Value::Bool(true),
-        );
+        entry.insert("recurse_submodules", serde_yml::Value::Bool(true));
     }
     if config.worktree {
-        entry.insert(
-            serde_yml::Value::String("worktree".into()),
-            serde_yml::Value::Bool(true),
-        );
+        entry.insert("worktree", serde_yml::Value::Bool(true));
     }
     // Only emit per_worktree_config when it differs from the default
     // (default is true when worktree is true, false otherwise)
     if config.per_worktree_config != config.worktree {
         entry.insert(
-            serde_yml::Value::String("per_worktree_config".into()),
+            "per_worktree_config",
             serde_yml::Value::Bool(config.per_worktree_config),
         );
     }
@@ -514,107 +497,59 @@ fn build_git_entry(config: &GitRepoConfig) -> serde_yml::Mapping {
             if wt_entry.config.is_some() {
                 // Detailed form: { branch: "...", config: { ... } }
                 let mut wt_detail = serde_yml::Mapping::new();
-                wt_detail.insert(
-                    serde_yml::Value::String("branch".into()),
-                    serde_yml::Value::String(wt_entry.branch.clone()),
-                );
+                wt_detail.insert("branch", serde_yml::Value::String(wt_entry.branch.clone()));
                 if let Some(ref wt_config) = wt_entry.config {
                     let mut config_map = serde_yml::Mapping::new();
                     for (key, value) in &wt_config.entries {
-                        config_map.insert(
-                            serde_yml::Value::String(key.clone()),
-                            serde_yml::Value::String(value.clone()),
-                        );
+                        config_map.insert(key.clone(), serde_yml::Value::String(value.clone()));
                     }
-                    wt_detail.insert(
-                        serde_yml::Value::String("config".into()),
-                        serde_yml::Value::Mapping(config_map),
-                    );
+                    wt_detail.insert("config", serde_yml::Value::Mapping(config_map));
                 }
-                wt.insert(
-                    serde_yml::Value::String(name.clone()),
-                    serde_yml::Value::Mapping(wt_detail),
-                );
+                wt.insert(name.clone(), serde_yml::Value::Mapping(wt_detail));
             } else {
                 // Simple form: just the branch name
                 wt.insert(
-                    serde_yml::Value::String(name.clone()),
+                    name.clone(),
                     serde_yml::Value::String(wt_entry.branch.clone()),
                 );
             }
         }
-        entry.insert(
-            serde_yml::Value::String("worktrees".into()),
-            serde_yml::Value::Mapping(wt),
-        );
+        entry.insert("worktrees", serde_yml::Value::Mapping(wt));
     }
     if let Some(ref remotes) = config.remotes {
         let mut remotes_map = serde_yml::Mapping::new();
         for (name, remote_cfg) in remotes {
             let mut remote_entry = serde_yml::Mapping::new();
-            remote_entry.insert(
-                serde_yml::Value::String("url".into()),
-                serde_yml::Value::String(remote_cfg.url.clone()),
-            );
+            remote_entry.insert("url", serde_yml::Value::String(remote_cfg.url.clone()));
             if let Some(ref fetch) = remote_cfg.fetch {
-                remote_entry.insert(
-                    serde_yml::Value::String("fetch".into()),
-                    serde_yml::Value::String(fetch.clone()),
-                );
+                remote_entry.insert("fetch", serde_yml::Value::String(fetch.clone()));
             }
             if let Some(ref push) = remote_cfg.push {
-                remote_entry.insert(
-                    serde_yml::Value::String("push".into()),
-                    serde_yml::Value::String(push.clone()),
-                );
+                remote_entry.insert("push", serde_yml::Value::String(push.clone()));
             }
             if let Some(ref tagopt) = remote_cfg.tagopt {
-                remote_entry.insert(
-                    serde_yml::Value::String("tagopt".into()),
-                    serde_yml::Value::String(tagopt.clone()),
-                );
+                remote_entry.insert("tagopt", serde_yml::Value::String(tagopt.clone()));
             }
             for (k, v) in &remote_cfg.extras {
-                remote_entry.insert(
-                    serde_yml::Value::String(k.clone()),
-                    serde_yml::Value::String(v.clone()),
-                );
+                remote_entry.insert(k.clone(), serde_yml::Value::String(v.clone()));
             }
-            remotes_map.insert(
-                serde_yml::Value::String(name.clone()),
-                serde_yml::Value::Mapping(remote_entry),
-            );
+            remotes_map.insert(name.clone(), serde_yml::Value::Mapping(remote_entry));
         }
-        entry.insert(
-            serde_yml::Value::String("remotes".into()),
-            serde_yml::Value::Mapping(remotes_map),
-        );
+        entry.insert("remotes", serde_yml::Value::Mapping(remotes_map));
     }
     if let Some(ref git_config) = config.config {
         let mut config_map = serde_yml::Mapping::new();
         for (key, value) in &git_config.entries {
-            config_map.insert(
-                serde_yml::Value::String(key.clone()),
-                serde_yml::Value::String(value.clone()),
-            );
+            config_map.insert(key.clone(), serde_yml::Value::String(value.clone()));
         }
-        entry.insert(
-            serde_yml::Value::String("config".into()),
-            serde_yml::Value::Mapping(config_map),
-        );
+        entry.insert("config", serde_yml::Value::Mapping(config_map));
     }
     if let Some(ref wt_config) = config.worktree_config {
         let mut config_map = serde_yml::Mapping::new();
         for (key, value) in &wt_config.entries {
-            config_map.insert(
-                serde_yml::Value::String(key.clone()),
-                serde_yml::Value::String(value.clone()),
-            );
+            config_map.insert(key.clone(), serde_yml::Value::String(value.clone()));
         }
-        entry.insert(
-            serde_yml::Value::String("worktree_config".into()),
-            serde_yml::Value::Mapping(config_map),
-        );
+        entry.insert("worktree_config", serde_yml::Value::Mapping(config_map));
     }
     entry
 }
@@ -701,24 +636,17 @@ fn update_descriptor_yaml(
         .as_mapping_mut()
         .ok_or_else(|| anyhow!("{} root is not a mapping", descriptor_path.display()))?;
 
-    let git_key = serde_yml::Value::String("git".into());
-    if !root.contains_key(&git_key) {
-        root.insert(
-            git_key.clone(),
-            serde_yml::Value::Mapping(serde_yml::Mapping::new()),
-        );
+    if !root.contains_key("git") {
+        root.insert("git", serde_yml::Value::Mapping(serde_yml::Mapping::new()));
     }
 
     let git_map = root
-        .get_mut(&git_key)
+        .get_mut("git")
         .and_then(|v| v.as_mapping_mut())
         .ok_or_else(|| anyhow!("git section is not a mapping"))?;
 
     let entry = build_git_entry(config);
-    git_map.insert(
-        serde_yml::Value::String(rel_path.to_string()),
-        serde_yml::Value::Mapping(entry),
-    );
+    git_map.insert(rel_path.to_string(), serde_yml::Value::Mapping(entry));
 
     let output = serde_yml::to_string(&doc)
         .map_err(|e| anyhow!("failed to serialize {}: {}", descriptor_path.display(), e))?;
@@ -731,12 +659,8 @@ fn update_descriptor_yaml(
 fn yaml_mapping_to_toml(mapping: &serde_yml::Mapping) -> Result<toml::Value> {
     let mut table = toml::map::Map::new();
     for (k, v) in mapping {
-        let key = k
-            .as_str()
-            .ok_or_else(|| anyhow!("non-string key in git entry"))?
-            .to_string();
         let value = yaml_value_to_toml(v)?;
-        table.insert(key, value);
+        table.insert(k.clone(), value);
     }
     Ok(toml::Value::Table(table))
 }
@@ -748,10 +672,8 @@ fn yaml_value_to_toml(v: &serde_yml::Value) -> Result<toml::Value> {
         serde_yml::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 Ok(toml::Value::Integer(i))
-            } else if let Some(f) = n.as_f64() {
-                Ok(toml::Value::Float(f))
             } else {
-                Err(anyhow!("unsupported number in git entry"))
+                Ok(toml::Value::Float(n.as_f64()))
             }
         }
         serde_yml::Value::Mapping(m) => yaml_mapping_to_toml(m),
@@ -834,7 +756,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(serde_yml::Value::String("url".into())),
+            entry.get("url"),
             Some(&serde_yml::Value::String(
                 "https://github.com/user/repo.git".into()
             )),
@@ -859,7 +781,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(serde_yml::Value::String("branch".into())),
+            entry.get("branch"),
             Some(&serde_yml::Value::String("main".into())),
         );
     }
@@ -881,7 +803,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(serde_yml::Value::String("tag".into())),
+            entry.get("tag"),
             Some(&serde_yml::Value::String("v1.0.0".into())),
         );
     }
@@ -903,7 +825,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(serde_yml::Value::String("rev".into())),
+            entry.get("rev"),
             Some(&serde_yml::Value::String("abc123".into())),
         );
     }
@@ -925,7 +847,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(serde_yml::Value::String("recurse_submodules".into())),
+            entry.get("recurse_submodules"),
             Some(&serde_yml::Value::Bool(true)),
         );
     }
@@ -946,10 +868,7 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        assert_eq!(
-            entry.get(serde_yml::Value::String("worktree".into())),
-            Some(&serde_yml::Value::Bool(true)),
-        );
+        assert_eq!(entry.get("worktree"), Some(&serde_yml::Value::Bool(true)),);
     }
 
     #[test]
@@ -976,13 +895,9 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let wt = entry
-            .get(serde_yml::Value::String("worktrees".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let wt = entry.get("worktrees").unwrap().as_mapping().unwrap();
         assert_eq!(
-            wt.get(serde_yml::Value::String("feature".into())),
+            wt.get("feature"),
             Some(&serde_yml::Value::String("feature-branch".into())),
         );
     }
@@ -1014,24 +929,16 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let remotes_map = entry
-            .get(serde_yml::Value::String("remotes".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
-        let upstream = remotes_map
-            .get(serde_yml::Value::String("upstream".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let remotes_map = entry.get("remotes").unwrap().as_mapping().unwrap();
+        let upstream = remotes_map.get("upstream").unwrap().as_mapping().unwrap();
         assert_eq!(
-            upstream.get(serde_yml::Value::String("url".into())),
+            upstream.get("url"),
             Some(&serde_yml::Value::String(
                 "https://github.com/upstream/repo.git".into()
             )),
         );
         assert_eq!(
-            upstream.get(serde_yml::Value::String("fetch".into())),
+            upstream.get("fetch"),
             Some(&serde_yml::Value::String(
                 "+refs/heads/*:refs/remotes/upstream/*".into()
             )),
@@ -1057,17 +964,13 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let config_map = entry
-            .get(serde_yml::Value::String("config".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let config_map = entry.get("config").unwrap().as_mapping().unwrap();
         assert_eq!(
-            config_map.get(serde_yml::Value::String("user.name".into())),
+            config_map.get("user.name"),
             Some(&serde_yml::Value::String("Test User".into())),
         );
         assert_eq!(
-            config_map.get(serde_yml::Value::String("user.email".into())),
+            config_map.get("user.email"),
             Some(&serde_yml::Value::String("test@example.com".into())),
         );
     }
@@ -1108,10 +1011,7 @@ mod tests {
     #[test]
     fn test_yaml_value_to_toml_mapping() {
         let mut m = serde_yml::Mapping::new();
-        m.insert(
-            serde_yml::Value::String("key".into()),
-            serde_yml::Value::String("value".into()),
-        );
+        m.insert("key", serde_yml::Value::String("value".into()));
         let result = yaml_value_to_toml(&serde_yml::Value::Mapping(m)).unwrap();
         match result {
             toml::Value::Table(t) => {
@@ -1136,19 +1036,10 @@ mod tests {
     #[test]
     fn test_yaml_mapping_to_toml_nested() {
         let mut inner = serde_yml::Mapping::new();
-        inner.insert(
-            serde_yml::Value::String("nested_key".into()),
-            serde_yml::Value::Bool(true),
-        );
+        inner.insert("nested_key", serde_yml::Value::Bool(true));
         let mut outer = serde_yml::Mapping::new();
-        outer.insert(
-            serde_yml::Value::String("str".into()),
-            serde_yml::Value::String("hello".into()),
-        );
-        outer.insert(
-            serde_yml::Value::String("inner".into()),
-            serde_yml::Value::Mapping(inner),
-        );
+        outer.insert("str", serde_yml::Value::String("hello".into()));
+        outer.insert("inner", serde_yml::Value::Mapping(inner));
 
         let result = yaml_mapping_to_toml(&outer).unwrap();
         match result {
@@ -1162,16 +1053,6 @@ mod tests {
             }
             _ => panic!("expected table"),
         }
-    }
-
-    #[test]
-    fn test_yaml_mapping_to_toml_non_string_key_errors() {
-        let mut m = serde_yml::Mapping::new();
-        m.insert(
-            serde_yml::Value::Number(serde_yml::Number::from(42)),
-            serde_yml::Value::String("val".into()),
-        );
-        assert!(yaml_mapping_to_toml(&m).is_err());
     }
 
     // ── find_descriptor ─────────────────────────────────────────────────
@@ -1400,7 +1281,7 @@ mod tests {
         };
         let entry = build_git_entry(&config);
         assert_eq!(
-            entry.get(serde_yml::Value::String("per_worktree_config".into())),
+            entry.get("per_worktree_config"),
             Some(&serde_yml::Value::Bool(false)),
         );
     }
@@ -1422,10 +1303,7 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        assert_eq!(
-            entry.get(serde_yml::Value::String("per_worktree_config".into())),
-            None,
-        );
+        assert_eq!(entry.get("per_worktree_config"), None,);
     }
 
     // ── build_git_entry: worktrees with config (detailed form) ──────────
@@ -1458,27 +1336,15 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let wt = entry
-            .get(serde_yml::Value::String("worktrees".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
-        let feat = wt
-            .get(serde_yml::Value::String("feat".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let wt = entry.get("worktrees").unwrap().as_mapping().unwrap();
+        let feat = wt.get("feat").unwrap().as_mapping().unwrap();
         assert_eq!(
-            feat.get(serde_yml::Value::String("branch".into())),
+            feat.get("branch"),
             Some(&serde_yml::Value::String("feature".into())),
         );
-        let cfg = feat
-            .get(serde_yml::Value::String("config".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let cfg = feat.get("config").unwrap().as_mapping().unwrap();
         assert_eq!(
-            cfg.get(serde_yml::Value::String("user.email".into())),
+            cfg.get("user.email"),
             Some(&serde_yml::Value::String("dev@test.com".into())),
         );
     }
@@ -1512,18 +1378,10 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let remotes_map = entry
-            .get(serde_yml::Value::String("remotes".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
-        let upstream = remotes_map
-            .get(serde_yml::Value::String("upstream".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let remotes_map = entry.get("remotes").unwrap().as_mapping().unwrap();
+        let upstream = remotes_map.get("upstream").unwrap().as_mapping().unwrap();
         assert_eq!(
-            upstream.get(serde_yml::Value::String("push".into())),
+            upstream.get("push"),
             Some(&serde_yml::Value::String(
                 "+refs/heads/*:refs/heads/*".into()
             )),
@@ -1559,18 +1417,10 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let remotes_map = entry
-            .get(serde_yml::Value::String("remotes".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
-        let upstream = remotes_map
-            .get(serde_yml::Value::String("upstream".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let remotes_map = entry.get("remotes").unwrap().as_mapping().unwrap();
+        let upstream = remotes_map.get("upstream").unwrap().as_mapping().unwrap();
         assert_eq!(
-            upstream.get(serde_yml::Value::String("tagopt".into())),
+            upstream.get("tagopt"),
             Some(&serde_yml::Value::String("--no-tags".into())),
         );
     }
@@ -1606,18 +1456,10 @@ mod tests {
             worktree_config: None,
         };
         let entry = build_git_entry(&config);
-        let remotes_map = entry
-            .get(serde_yml::Value::String("remotes".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
-        let upstream = remotes_map
-            .get(serde_yml::Value::String("upstream".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let remotes_map = entry.get("remotes").unwrap().as_mapping().unwrap();
+        let upstream = remotes_map.get("upstream").unwrap().as_mapping().unwrap();
         assert_eq!(
-            upstream.get(serde_yml::Value::String("prune".into())),
+            upstream.get("prune"),
             Some(&serde_yml::Value::String("true".into())),
         );
     }
@@ -1642,13 +1484,9 @@ mod tests {
             worktree_config: Some(GitConfig { entries }),
         };
         let entry = build_git_entry(&config);
-        let wt_cfg = entry
-            .get(serde_yml::Value::String("worktree_config".into()))
-            .unwrap()
-            .as_mapping()
-            .unwrap();
+        let wt_cfg = entry.get("worktree_config").unwrap().as_mapping().unwrap();
         assert_eq!(
-            wt_cfg.get(serde_yml::Value::String("core.sparseCheckout".into())),
+            wt_cfg.get("core.sparseCheckout"),
             Some(&serde_yml::Value::String("true".into())),
         );
     }

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -24,7 +24,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
 
     println!("{}", style::white_b(&overlay.name));
     println!("  root:   {}", short_path(&overlay.root.to_string_lossy()));
-    println!("  target: {}", &overlay.target);
+    println!("  target: {}", overlay.target);
     if let Some(desc) = &overlay.description {
         println!("  desc:   {}", desc);
     }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -22,12 +22,12 @@ pub async fn execute(cli: &CLI) -> Result<()> {
         for overlay in &overlays {
             let desc = overlay.description.as_deref().unwrap_or("");
             if desc.is_empty() {
-                println!("    {} -> {}", style::cyan(&overlay.name), &overlay.target);
+                println!("    {} -> {}", style::cyan(&overlay.name), overlay.target);
             } else {
                 println!(
                     "    {} -> {} ({})",
                     style::cyan(&overlay.name),
-                    &overlay.target,
+                    overlay.target,
                     desc,
                 );
             }

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use config::ConfigError;
 use globset::GlobBuilder;
+use noyalib::compat::serde_yaml as serde_yml;
 use walkdir::WalkDir;
 
 use crate::overlays::{BASENAME, EXTENSIONS, GLOB_PATTERN, Overlay, Repository};
@@ -322,10 +323,7 @@ fn prevalidate_descriptor(dir: &Path, overlay_name: &str) -> Vec<Diagnostic> {
                     return diagnostics;
                 };
                 match value {
-                    serde_yml::Value::Mapping(map) => map
-                        .keys()
-                        .filter_map(|k| k.as_str().map(|s| s.to_string()))
-                        .collect(),
+                    serde_yml::Value::Mapping(map) => map.keys().cloned().collect(),
                     _ => return diagnostics,
                 }
             }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -103,7 +103,7 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.prompt_prefix,
+                self.prompt_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -113,20 +113,20 @@ impl Theme for DialogTheme {
                 f,
                 "{} {}",
                 self.hint_style.apply_to("(y/n)"),
-                &self.prompt_suffix
+                self.prompt_suffix
             ),
             Some(true) => write!(
                 f,
                 "{} {} {}",
                 self.hint_style.apply_to("(y/n)"),
-                &self.prompt_suffix,
+                self.prompt_suffix,
                 self.defaults_style.apply_to("yes")
             ),
             Some(false) => write!(
                 f,
                 "{} {} {}",
                 self.hint_style.apply_to("(y/n)"),
-                &self.prompt_suffix,
+                self.prompt_suffix,
                 self.defaults_style.apply_to("no")
             ),
         }
@@ -158,7 +158,7 @@ impl Theme for DialogTheme {
                 write!(f, "{}", style.apply_to(selection))
             }
             None => {
-                write!(f, "{}", &self.success_suffix)
+                write!(f, "{}", self.success_suffix)
             }
         }
     }
@@ -169,12 +169,12 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.prompt_prefix,
+                self.prompt_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
 
-        write!(f, "{}", &self.prompt_suffix)
+        write!(f, "{}", self.prompt_suffix)
     }
 
     /// Formats a select prompt after selection.
@@ -188,7 +188,7 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.success_prefix,
+                self.success_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -196,7 +196,7 @@ impl Theme for DialogTheme {
         write!(
             f,
             "{} {}",
-            &self.success_suffix,
+            self.success_suffix,
             self.values_style.apply_to(sel)
         )
     }
@@ -212,7 +212,7 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.prompt_prefix,
+                self.prompt_prefix,
                 self.prompt_style.apply_to(prompt),
             )?;
         }
@@ -222,9 +222,9 @@ impl Theme for DialogTheme {
                 f,
                 "{} {}",
                 self.hint_style.apply_to(format!("({})", default)),
-                &self.prompt_suffix,
+                self.prompt_suffix,
             ),
-            None => write!(f, "{}", &self.prompt_suffix),
+            None => write!(f, "{}", self.prompt_suffix),
         }
     }
 
@@ -239,7 +239,7 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.success_prefix,
+                self.success_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -247,7 +247,7 @@ impl Theme for DialogTheme {
         write!(
             f,
             "{} {}",
-            &self.success_suffix,
+            self.success_suffix,
             self.values_style.apply_to(sel)
         )
     }
@@ -258,12 +258,12 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.prompt_prefix,
+                self.prompt_prefix,
                 self.prompt_style.apply_to(prompt),
             )?;
         }
 
-        write!(f, "{}", &self.prompt_suffix)
+        write!(f, "{}", self.prompt_suffix)
     }
 
     /// Formats a multi-select prompt after selection.
@@ -277,7 +277,7 @@ impl Theme for DialogTheme {
             write!(
                 f,
                 "{} {} ",
-                &self.success_prefix,
+                self.success_prefix,
                 self.prompt_style.apply_to(prompt)
             )?;
         }
@@ -285,7 +285,7 @@ impl Theme for DialogTheme {
         write!(
             f,
             "{} {}",
-            &self.success_suffix,
+            self.success_suffix,
             self.values_style.apply_to(selections.join(", "))
         )
     }


### PR DESCRIPTION
## Summary

Migrates YAML handling from the unmaintained `serde_yml` crate to `noyalib`'s `compat-serde-yaml` feature — a maintained, pure-Rust, YAML-1.2-compliant backend recommended by `serde_yml`'s own migration guide.

`serde_yml` was flagged by RUSTSEC-2025-0068 (unsound C-FFI `libyaml` emitter) and its final release is a deprecation shim pointing to maintained alternatives.

## Changes

- Swapped the `serde_yml` dependency for `noyalib = { features = ["compat-serde-yaml"] }`.
- Most call sites migrate via a single `use noyalib::compat::serde_yaml as serde_yml;` alias.
- `noyalib`'s `Mapping` is `String`-keyed (unlike `serde_yml`'s `Value`-keyed mapping), so the git-overlay descriptor read/write code (`build_git_entry`, `update_descriptor_yaml`, `yaml_mapping_to_toml`) was updated to use plain string keys, which also removed a couple of now-unreachable error branches.
- Also fixed a handful of pre-existing `clippy::all` violations (unrelated to the migration) that were blocking the pre-commit hook on this branch.

Closes #89