### PR TITLE
fix(ci): stop Windows CI from silently swallowing test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Run tests (with coverage)
+        shell: bash
         run: |
           cargo llvm-cov nextest --profile ci
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -1342,9 +1342,12 @@ mod tests {
         let (td, repo) = repo_and_root();
         let overlay_dir = td.child("ov_display3");
         overlay_dir.create_dir_all().unwrap();
+        // Escape backslashes so Windows paths (`C:\Users\...`) don't get
+        // misparsed as TOML unicode escape sequences (`\U`, `\A`, ...).
+        let target_str = td.path().to_string_lossy().replace('\\', "\\\\");
         overlay_dir
             .child("over.toml")
-            .write_str(&format!("target = \"{}\"", td.path().display()))
+            .write_str(&format!("target = \"{}\"", target_str))
             .unwrap();
         let overlay = repo.get("ov_display3").unwrap();
         let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -1829,7 +1829,11 @@ mod tests {
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<CloneMessage>(32);
 
-        let url = format!("file://{}", source_td.path().display());
+        // Pass the local path directly rather than synthesizing a `file://`
+        // URL: naively prepending `file://` to a Windows path (backslashes,
+        // drive letter, no leading slash) produces an invalid URI that
+        // libgit2 rejects. A plain local path is accepted on every platform.
+        let url = source_td.path().to_string_lossy().to_string();
         let dst = dest_path.clone();
         let result =
             tokio::task::spawn_blocking(move || clone(&url, &dst, None, false, false, &tx))
@@ -1855,7 +1859,7 @@ mod tests {
 
         let (tx, _rx) = tokio::sync::mpsc::channel::<CloneMessage>(32);
 
-        let url = format!("file://{}", source_td.path().display());
+        let url = source_td.path().to_string_lossy().to_string();
         let dst = dest_path.clone();
         let result = tokio::task::spawn_blocking(move || clone(&url, &dst, None, true, false, &tx))
             .await
@@ -1874,7 +1878,7 @@ mod tests {
 
         let (tx, _rx) = tokio::sync::mpsc::channel::<CloneMessage>(32);
 
-        let url = format!("file://{}", source_td.path().display());
+        let url = source_td.path().to_string_lossy().to_string();
         let dst = dest_path.clone();
         let result = tokio::task::spawn_blocking(move || {
             clone(&url, &dst, Some("develop"), false, false, &tx)

--- a/src/actions/symlink.rs
+++ b/src/actions/symlink.rs
@@ -173,7 +173,9 @@ pub fn discover_symlinks(overlay_root: &Path) -> Result<Vec<(String, SymlinkConf
             continue;
         }
 
-        let rel_str = rel.to_string_lossy();
+        // Normalize to `/` so symlink names are portable identifiers that
+        // don't leak the platform's native path separator (`\` on Windows).
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
         let stem = rel_str
             .strip_suffix(".link.toml")
             .or_else(|| rel_str.strip_suffix(".link.yaml"))

--- a/src/cli/git_over/mod.rs
+++ b/src/cli/git_over/mod.rs
@@ -243,7 +243,15 @@ mod tests {
     fn test_main_repo_root_regular() {
         let (td, repo) = temp_git_repo();
         let root = main_repo_root(&repo).unwrap();
-        assert_eq!(root, td.path().canonicalize().unwrap());
+        // Canonicalize both sides: on Windows, libgit2's `workdir()` returns
+        // a forward-slash path without the `\\?\` verbatim prefix, while
+        // `Path::canonicalize()` adds that prefix, so comparing a raw
+        // `root` against a canonicalized expectation would never match even
+        // though both name the same directory.
+        assert_eq!(
+            root.canonicalize().unwrap(),
+            td.path().canonicalize().unwrap()
+        );
     }
 
     #[test]
@@ -252,7 +260,10 @@ mod tests {
         let bare_path = td.path().join(".git");
         let repo = git2::Repository::init_bare(&bare_path).unwrap();
         let root = main_repo_root(&repo).unwrap();
-        assert_eq!(root, td.path().canonicalize().unwrap());
+        assert_eq!(
+            root.canonicalize().unwrap(),
+            td.path().canonicalize().unwrap()
+        );
     }
 
     #[test]
@@ -320,7 +331,9 @@ mod tests {
         // Create a minimal overlay with target = td path
         let overlay_dir = td.child("overlay");
         overlay_dir.create_dir_all().unwrap();
-        let target_str = td.path().to_string_lossy().to_string();
+        // Escape backslashes so Windows paths don't get misparsed as TOML
+        // unicode escape sequences.
+        let target_str = td.path().to_string_lossy().replace('\\', "\\\\");
         overlay_dir
             .child("over.toml")
             .write_str(&format!("target = \"{}\"", target_str))
@@ -341,7 +354,11 @@ mod tests {
         let td = TempDir::new().unwrap();
         let overlay_dir = td.child("overlay");
         overlay_dir.create_dir_all().unwrap();
-        let target_str = td.path().join("subdir").to_string_lossy().to_string();
+        let target_str = td
+            .path()
+            .join("subdir")
+            .to_string_lossy()
+            .replace('\\', "\\\\");
         overlay_dir
             .child("over.toml")
             .write_str(&format!("target = \"{}\"", target_str))

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -104,10 +104,13 @@ impl fmt::Display for Overlay {
 
 impl Overlay {
     pub fn new(repository: &Repository, root: &Path) -> Result<Self> {
+        // Normalize to `/` so overlay names are portable identifiers that
+        // don't leak the platform's native path separator (`\` on Windows).
         let name = root
             .strip_prefix(repository.root.as_path())?
             .to_str()
-            .ok_or_else(|| anyhow::anyhow!("overlay path is not valid UTF-8"))?;
+            .ok_or_else(|| anyhow::anyhow!("overlay path is not valid UTF-8"))?
+            .replace('\\', "/");
         let mut sources: Vec<File<FileSourceFile, FileFormat>> = Vec::new();
         let mut dir = root;
         loop {
@@ -134,7 +137,7 @@ impl Overlay {
 
         let s = Config::builder()
             .add_source(sources)
-            .set_override("name", name)?
+            .set_override("name", name.clone())?
             .set_override("root", root.to_str())?
             .set_default("target", DEFAULT_TARGET)?
             .build()
@@ -404,9 +407,12 @@ mod tests {
         let overlay_dir = td.child("abs");
         overlay_dir.create_dir_all().unwrap();
         let target_str = abs.to_str().unwrap();
+        // Escape backslashes so Windows paths don't get misparsed as TOML
+        // unicode escape sequences.
+        let target_toml = target_str.replace('\\', "\\\\");
         overlay_dir
             .child("over.toml")
-            .write_str(&format!("target = \"{}\"", target_str))
+            .write_str(&format!("target = \"{}\"", target_toml))
             .unwrap();
         let overlay = repo.get("abs").unwrap();
         let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::{error::Error, fs};
 
 use assert_cmd::Command;
@@ -5,6 +6,21 @@ use predicates::str::contains;
 use tempfile::TempDir;
 
 type TestResult = Result<(), Box<dyn Error>>;
+
+/// Canonicalize a path for comparison against paths reported by libgit2
+/// (e.g. via `git2::Repository::workdir()`), stripping Windows' `\\?\`
+/// verbatim-path prefix that `Path::canonicalize()` adds but that libgit2
+/// never produces. Symlinks are still resolved (needed on macOS, where
+/// `/tmp` is a symlink to `/private/tmp`), only the verbatim prefix differs.
+fn canonical_for_matching(path: &Path) -> std::io::Result<PathBuf> {
+    let canonical = path.canonicalize()?;
+    if cfg!(windows) {
+        let s = canonical.to_string_lossy();
+        Ok(PathBuf::from(s.strip_prefix(r"\\?\").unwrap_or(&s)))
+    } else {
+        Ok(canonical)
+    }
+}
 
 fn setup_overlay_repo() -> TempDir {
     let tmp = TempDir::new().unwrap();
@@ -251,9 +267,13 @@ fn show_overlay_with_target() -> TestResult {
     fs::create_dir_all(&ov)?;
     let target_path = tmp.path().join("target_user");
     let target_str = target_path.to_string_lossy().to_string();
+    // Escape backslashes so Windows paths don't get misparsed as TOML
+    // unicode escape sequences; `target_str` (unescaped) is still what the
+    // CLI should echo back verbatim once round-tripped through TOML.
+    let target_toml = target_str.replace('\\', "\\\\");
     let toml_content = format!(
         "target = \"{}\"\ndescription = \"My test overlay\"",
-        target_str
+        target_toml
     );
     fs::write(ov.join("over.toml"), toml_content.as_bytes())?;
 
@@ -737,10 +757,12 @@ apt = ["curl"]
 #[test]
 fn git_over_add_dry_run() -> TestResult {
     let tmp = TempDir::new()?;
-    let canonical_tmp = tmp.path().canonicalize()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
     let ov = canonical_tmp.join("gitov");
     fs::create_dir_all(&ov)?;
-    let target_str = canonical_tmp.to_string_lossy();
+    // Escape backslashes so Windows paths don't get misparsed as TOML
+    // unicode escape sequences.
+    let target_str = canonical_tmp.to_string_lossy().replace('\\', "\\\\");
     fs::write(ov.join("over.toml"), format!("target = \"{}\"", target_str))?;
     let repo_dir = canonical_tmp.join("repo");
     fs::create_dir_all(&repo_dir)?;
@@ -792,10 +814,12 @@ fn git_over_status_no_overlay_configured() -> TestResult {
 #[test]
 fn git_over_status_with_overlay_configured() -> TestResult {
     let tmp = TempDir::new()?;
-    let canonical_tmp = tmp.path().canonicalize()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
     let ov = canonical_tmp.join("statusov2");
     fs::create_dir_all(&ov)?;
-    let target_str = canonical_tmp.to_string_lossy();
+    // Escape backslashes so Windows paths don't get misparsed as TOML
+    // unicode escape sequences.
+    let target_str = canonical_tmp.to_string_lossy().replace('\\', "\\\\");
     fs::write(ov.join("over.toml"), format!("target = \"{}\"", target_str))?;
     let repo_dir = canonical_tmp.join("repo");
     fs::create_dir_all(&repo_dir)?;
@@ -822,10 +846,12 @@ fn git_over_status_with_overlay_configured() -> TestResult {
 #[test]
 fn git_over_add_multiple_files_dry_run() -> TestResult {
     let tmp = TempDir::new()?;
-    let canonical_tmp = tmp.path().canonicalize()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
     let ov = canonical_tmp.join("gitov_multi");
     fs::create_dir_all(&ov)?;
-    let target_str = canonical_tmp.to_string_lossy();
+    // Escape backslashes so Windows paths don't get misparsed as TOML
+    // unicode escape sequences.
+    let target_str = canonical_tmp.to_string_lossy().replace('\\', "\\\\");
     fs::write(ov.join("over.toml"), format!("target = \"{}\"", target_str))?;
     let repo_dir = canonical_tmp.join("repo");
     fs::create_dir_all(&repo_dir)?;
@@ -856,10 +882,12 @@ fn git_over_add_multiple_files_dry_run() -> TestResult {
 #[test]
 fn git_over_add_directory_dry_run() -> TestResult {
     let tmp = TempDir::new()?;
-    let canonical_tmp = tmp.path().canonicalize()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
     let ov = canonical_tmp.join("gitov_dir");
     fs::create_dir_all(&ov)?;
-    let target_str = canonical_tmp.to_string_lossy();
+    // Escape backslashes so Windows paths don't get misparsed as TOML
+    // unicode escape sequences.
+    let target_str = canonical_tmp.to_string_lossy().replace('\\', "\\\\");
     fs::write(ov.join("over.toml"), format!("target = \"{}\"", target_str))?;
     let repo_dir = canonical_tmp.join("repo");
     fs::create_dir_all(&repo_dir)?;
@@ -888,10 +916,12 @@ fn git_over_add_directory_dry_run() -> TestResult {
 #[test]
 fn git_over_add_nonexistent_file_fails() -> TestResult {
     let tmp = TempDir::new()?;
-    let canonical_tmp = tmp.path().canonicalize()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
     let ov = canonical_tmp.join("gitov_err");
     fs::create_dir_all(&ov)?;
-    let target_str = canonical_tmp.to_string_lossy();
+    // Escape backslashes so Windows paths don't get misparsed as TOML
+    // unicode escape sequences.
+    let target_str = canonical_tmp.to_string_lossy().replace('\\', "\\\\");
     fs::write(ov.join("over.toml"), format!("target = \"{}\"", target_str))?;
     let repo_dir = canonical_tmp.join("repo");
     fs::create_dir_all(&repo_dir)?;


### PR DESCRIPTION
Windows CI has been reporting green for a while despite real test
failures. The `Run tests (with coverage)` step has no `shell:` set, so
on `windows-latest` it defaults to PowerShell — which doesn't fail the
step when a native command like `cargo llvm-cov nextest` exits
non-zero, since the next line in the script still succeeds.

This PR:
- Forces `shell: bash` for that step so Windows behaves like Linux/macOS
  and genuinely fails when tests fail.
- Fixes the 16 Windows-only test failures this was hiding (all
  Windows path-handling issues in test fixtures and, in two cases, in
  how overlay/symlink names were derived from paths).

Confirmed locally that the full suite (625 tests) passes, and clippy/fmt
are clean for the touched files.