### PR TITLE
ci(docs): fix broken docs build and gate deployment to PRs vs main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,14 @@ env:
   # Owned by the template: bump it there and `git tpl update` propagates it.
   # The docs and prepare-release workflows repeat the literal — keep them in
   # sync, as `env:` does not cross workflow files.
-  PINNED_MISE_VERSION: 2026.7.18
+  #
+  # Bumped off 2026.7.18 as a local exception: that release resolves the
+  # `uv` aqua package by downloading the glibc asset while checking for its
+  # binaries under the musl asset's directory name, so it silently installs
+  # with zero shims (no `uv`, no `uvx`) whenever both linux-x64 variants are
+  # in mise.lock — exactly our case. Fixed by 2026.8.14. This should also be
+  # bumped upstream in rust.tpl so other projects don't hit it.
+  PINNED_MISE_VERSION: 2026.8.14
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,14 @@ on:
       - docs/**
       - zensical.toml
       - .github/workflows/docs.yaml
+  # Same paths as the push trigger: this is a check that the docs still
+  # build, not a deploy, so it only needs to run when doc-affecting files
+  # change — not on every unrelated PR.
+  pull_request:
+    paths:
+      - docs/**
+      - zensical.toml
+      - .github/workflows/docs.yaml
   workflow_dispatch:
 
 permissions:
@@ -14,15 +22,16 @@ permissions:
   pages: write
   id-token: write
 
-# Only one deployment at a time; never cancel one midway.
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   build:
     name: 🏗️ Build
     runs-on: ubuntu-latest
+    # Redundant pushes to the same PR/branch should cancel their predecessor's
+    # build — this is a fast check, not a deploy, so nothing needs the strict
+    # serialization the `pages` group below requires.
+    concurrency:
+      group: docs-build-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v7
 
@@ -44,7 +53,15 @@ jobs:
   deploy:
     name: 🚀 Deploy
     needs: build
+    # Never deploy from a pull_request event — including from forks, which
+    # get no `pages`/`id-token` write access from GitHub regardless of what's
+    # declared above. `workflow_dispatch` keeps deploying, as today.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # Only one deployment at a time; never cancel one midway.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: jdx/mise-action@v4
         with:
           # Keep in sync with PINNED_MISE_VERSION in ci.yaml.
-          version: 2026.7.18
+          version: 2026.8.14
           cache: true
 
       - name: Build the site

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -71,7 +71,7 @@ jobs:
       - uses: jdx/mise-action@v4
         with:
           # Keep in sync with PINNED_MISE_VERSION in ci.yaml.
-          version: 2026.7.18
+          version: 2026.8.14
           cache: true
 
       # --- versioning: ours, not gh-ship's ---------------------------------

--- a/.github/workflows/template.yaml
+++ b/.github/workflows/template.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: jdx/mise-action@v4
         with:
           # Keep in sync with PINNED_MISE_VERSION in ci.yaml.
-          version: 2026.7.18
+          version: 2026.8.14
           cache: true
 
       # `actions/checkout` fetches `refs/heads/*` and `refs/tags/*` and nothing

--- a/mise.toml
+++ b/mise.toml
@@ -55,7 +55,11 @@ cargo-binstall = "latest"
 # An explicit version, never `latest`: mise applies a `minimum_release_age`, so
 # `latest` resolves to whatever is old enough rather than to the newest release.
 "cargo:git-tpl" = "0.5.0"
-# Zensical runs through `uvx`, so uv is the only thing the docs build needs.
+# Zensical runs through `uv tool run`, so uv is the only thing the docs build
+# needs. Not the `uvx` shorthand: whether the aqua-installed `uv` package also
+# gets a `uvx` shim depends on registry metadata mise doesn't control, and a
+# stale `mise-action` cache can carry that gap forward silently. `uv tool run`
+# only ever needs the `uv` binary mise itself resolves and always shims.
 uv = "latest"
 # cargo-insta is declared on the task that uses it instead of here — see the
 # note in the header.
@@ -142,11 +146,11 @@ run = "cargo install --path . --force"
 
 [tasks.docs]
 description = "Serve the documentation locally"
-run = "uvx zensical serve"
+run = "uv tool run zensical serve"
 
 [tasks."docs:build"]
 description = "Build the documentation"
-run = "uvx zensical build"
+run = "uv tool run zensical build"
 
 # --- Release ----------------------------------------------------------------
 


### PR DESCRIPTION
The docs job was failing on every run (`sh: 1: uvx: not found`, then `sh: 1: uv: not found`). The real cause: mise 2026.7.18 resolves the `uv` aqua package by downloading the glibc asset for linux-x64 but looking for its binaries under the musl asset's directory name, so it silently installs with zero shims whenever both linux-x64 variants are in `mise.lock` — exactly this repo's case. Bumped the pinned mise version to 2026.8.14, which resolves it correctly, and switched the docs tasks to `uv tool run` instead of the `uvx` alias, which only ever needs the `uv` binary mise itself resolves.

This should also be bumped upstream in `rust.tpl` so other projects rendered from it don't hit the same issue.

While in there, restructured the docs workflow so it's actually useful as a PR check: it now builds (and validates) the site on every pull request that touches docs, while deployment to GitHub Pages remains gated to pushes on `main` (and manual dispatch).
