### PR TITLE
feat(templates): expose machine info as {{ machine.* }} template variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "dirs",
  "etcetera",
  "futures",
+ "gethostname",
  "git2",
  "git2_credentials",
  "glob",
@@ -603,6 +604,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ strip = true
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 dirs = "6.0"
 etcetera = "0.11"
+gethostname = "1.1"
 glob = "0.3"
 globset = "0.4"
 symlink = "0.1"

--- a/src/actions/install.rs
+++ b/src/actions/install.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeSet, HashSet};
-use std::{env::consts::OS, fs, sync::OnceLock};
+use std::env::consts::OS;
 
-use crate::{exec::Ctx, overlays::Overlay};
+use crate::{exec::Ctx, overlays::Overlay, utils::detect_linux_distro_id};
 use anyhow::{Context as AnyhowContext, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use which::which;
@@ -42,28 +42,12 @@ const PRECEDENCE_GENERIC_LINUX: &[SystemManager] = &[
     SystemManager::Brew,
 ]; // attempt all known managers
 
-fn detect_linux_distro() -> Option<String> {
-    static DISTRO: OnceLock<Option<String>> = OnceLock::new();
-    DISTRO
-        .get_or_init(|| {
-            let content = fs::read_to_string("/etc/os-release").ok()?;
-            for line in content.lines() {
-                if let Some(rest) = line.strip_prefix("ID=") {
-                    let id = rest.trim_matches('"').to_string();
-                    return Some(id);
-                }
-            }
-            None
-        })
-        .clone()
-}
-
 /// Resolve the platform-specific config override for the current OS.
 fn resolve_platform_override(install: &InstallConfig) -> Option<&PlatformInstallConfig> {
     if OS == "macos" {
         install.platforms.get("macos")
     } else if OS == "linux" {
-        detect_linux_distro().and_then(|distro| install.platforms.get(&distro))
+        detect_linux_distro_id().and_then(|distro| install.platforms.get(&distro))
     } else if OS == "windows" {
         install.platforms.get("windows")
     } else {
@@ -546,7 +530,7 @@ fn decide_linux_managers(distro: &str, install_cfg: &InstallConfig) -> Vec<Syste
 }
 
 async fn install_linux(ctx: &Ctx, overlay: &Overlay) -> Result<()> {
-    let distro = detect_linux_distro().unwrap_or_else(|| "linux".to_string());
+    let distro = detect_linux_distro_id().unwrap_or_else(|| "linux".to_string());
     let Some(install_cfg) = overlay.install.as_ref() else {
         return Ok(());
     };
@@ -693,7 +677,7 @@ async fn get_archlinux_packages(
     collect_packages(ctx, overlay, visited, |install, _platform| {
         // Archlinux has special platform resolution: "arch" / "archlinux" aliases
         let platform_override = if OS == "linux" {
-            detect_linux_distro().and_then(|distro| {
+            detect_linux_distro_id().and_then(|distro| {
                 let key = if install.platforms.contains_key("arch") {
                     Some("arch")
                 } else if install.platforms.contains_key("archlinux") {
@@ -3614,7 +3598,7 @@ post = ["echo win-post"]
 
     #[tokio::test]
     async fn test_install_linux_with_platform_pre_post_dry_run() {
-        let distro = detect_linux_distro().unwrap_or_else(|| "linux".to_string());
+        let distro = detect_linux_distro_id().unwrap_or_else(|| "linux".to_string());
         let (td, repo) = repo_and_root();
         let a = td.child("a");
         a.create_dir_all().unwrap();

--- a/src/actions/symlink.rs
+++ b/src/actions/symlink.rs
@@ -10,7 +10,7 @@ use noyalib::compat::serde_yaml as serde_yml;
 use serde::{Deserialize, Serialize};
 use symlink::{remove_symlink_dir, remove_symlink_file, symlink_dir, symlink_file};
 
-use crate::exec::{Action, Ctx};
+use crate::exec::{Action, Context, Ctx, MachineInfo};
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -231,11 +231,22 @@ pub fn discover_symlinks(overlay_root: &Path) -> Result<Vec<(String, SymlinkConf
     Ok(results)
 }
 
-pub fn render_symlink_target(template: &str, overlays: &HashMap<String, String>) -> Result<String> {
-    let env_vars: HashMap<String, String> = std::env::vars().collect();
-    let mut state = HashMap::new();
-    state.insert("env", env_vars);
-    state.insert("overlays", overlays.clone());
+/// Ephemeral render context for `.link.toml` symlink targets: environment
+/// variables, resolved overlay paths, and machine facts — mirroring what's
+/// available when rendering an overlay's own `target =` template.
+#[derive(Serialize)]
+struct SymlinkTemplateContext<'a> {
+    env: HashMap<String, String>,
+    overlays: &'a HashMap<String, String>,
+    machine: &'a MachineInfo,
+}
+
+pub fn render_symlink_target(template: &str, ctx: &Context) -> Result<String> {
+    let state = SymlinkTemplateContext {
+        env: std::env::vars().collect(),
+        overlays: ctx.resolved_overlays.as_ref(),
+        machine: &ctx.machine,
+    };
 
     crate::exec::templates::render_string(template, &state)
         .with_context(|| format!("failed to render symlink target template '{}'", template))
@@ -247,6 +258,7 @@ mod tests {
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
     use rstest::rstest;
+    use std::sync::Arc;
 
     /// Install a tracing subscriber so `tracing::warn!` etc. bodies are executed during tests.
     fn init_test_tracing() {
@@ -301,8 +313,8 @@ mod tests {
         unsafe {
             std::env::set_var("OVER_TEST_HOME", "/test/home");
         }
-        let overlays = HashMap::new();
-        let result = render_symlink_target("{{ env.OVER_TEST_HOME }}/config", &overlays).unwrap();
+        let ctx = crate::exec::Context::builder().build();
+        let result = render_symlink_target("{{ env.OVER_TEST_HOME }}/config", &ctx).unwrap();
         assert_eq!(result, "/test/home/config");
     }
 
@@ -310,9 +322,18 @@ mod tests {
     fn render_symlink_target_with_overlays() {
         let mut overlays = HashMap::new();
         overlays.insert("apps/nvim".to_string(), "/opt/nvim".to_string());
-        let result =
-            render_symlink_target("{{ overlays['apps/nvim'] }}/init.lua", &overlays).unwrap();
+        let ctx = crate::exec::Context::builder()
+            .resolved_overlays(Arc::new(overlays))
+            .build();
+        let result = render_symlink_target("{{ overlays['apps/nvim'] }}/init.lua", &ctx).unwrap();
         assert_eq!(result, "/opt/nvim/init.lua");
+    }
+
+    #[test]
+    fn render_symlink_target_with_machine_os() {
+        let ctx = crate::exec::Context::builder().build();
+        let result = render_symlink_target("{{ machine.os }}/config", &ctx).unwrap();
+        assert_eq!(result, format!("{}/config", std::env::consts::OS));
     }
 
     #[rstest]
@@ -639,15 +660,15 @@ mod tests {
 
     #[test]
     fn render_symlink_target_invalid_template() {
-        let overlays = HashMap::new();
-        let result = render_symlink_target("{{ invalid.template", &overlays);
+        let ctx = crate::exec::Context::builder().build();
+        let result = render_symlink_target("{{ invalid.template", &ctx);
         assert!(result.is_err());
     }
 
     #[test]
     fn render_symlink_target_plain() {
-        let overlays = HashMap::new();
-        let result = render_symlink_target("/plain/path", &overlays).unwrap();
+        let ctx = crate::exec::Context::builder().build();
+        let result = render_symlink_target("/plain/path", &ctx).unwrap();
         assert_eq!(result, "/plain/path");
     }
 
@@ -659,11 +680,12 @@ mod tests {
         }
         let mut overlays = HashMap::new();
         overlays.insert("apps/tool".to_string(), "/opt/tool".to_string());
-        let result = render_symlink_target(
-            "{{ env.OVER_TEST_USER }}/{{ overlays['apps/tool'] }}",
-            &overlays,
-        )
-        .unwrap();
+        let ctx = crate::exec::Context::builder()
+            .resolved_overlays(Arc::new(overlays))
+            .build();
+        let result =
+            render_symlink_target("{{ env.OVER_TEST_USER }}/{{ overlays['apps/tool'] }}", &ctx)
+                .unwrap();
         assert_eq!(result, "testuser//opt/tool");
     }
 }

--- a/src/exec/context.rs
+++ b/src/exec/context.rs
@@ -1,10 +1,57 @@
 use std::collections::HashMap;
+use std::env::consts::{ARCH, OS};
 use std::{path::PathBuf, sync::Arc};
 
+use gethostname::gethostname;
 use indicatif::{MultiProgress, ProgressBar};
 use serde::Serialize;
 
 use crate::overlays::{Overlay, Repository};
+use crate::utils;
+
+/// Machine facts exposed to templates as `{{ machine.* }}` (OS, arch,
+/// hostname, username, Linux distro), enabling conditional overlay behavior
+/// per machine.
+#[derive(Debug, Clone, Serialize)]
+pub struct MachineInfo {
+    pub os: String,
+    pub arch: String,
+    pub hostname: String,
+    pub username: String,
+    pub distro: Option<String>,
+    pub distro_id: Option<String>,
+}
+
+impl MachineInfo {
+    /// Detect facts about the machine `over` is currently running on.
+    pub fn detect() -> Self {
+        Self {
+            os: OS.to_string(),
+            arch: ARCH.to_string(),
+            hostname: gethostname().to_string_lossy().to_string(),
+            username: detect_username(),
+            distro: utils::detect_linux_distro_name(),
+            distro_id: utils::detect_linux_distro_id(),
+        }
+    }
+}
+
+impl Default for MachineInfo {
+    // `Context`/`ContextBuilder` derive `Default`, which requires every field
+    // to implement it; there's no meaningful "empty" machine, so default
+    // means "the real, detected machine".
+    fn default() -> Self {
+        Self::detect()
+    }
+}
+
+/// Resolve current username from `USER` (Unix) / `USERNAME` (Windows),
+/// falling back to "unknown" in sandboxes/containers where neither is set.
+fn detect_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
 
 #[derive(Debug, Default, Serialize)]
 pub struct Context {
@@ -32,6 +79,9 @@ pub struct Context {
     pub repository: Repository,
 
     pub overlay: Option<Overlay>,
+
+    /// Facts about the current machine, available to all templates.
+    pub machine: MachineInfo,
 
     #[serde(skip)]
     pub progress: Option<Progress>,
@@ -79,6 +129,7 @@ pub struct ContextBuilder {
     root: PathBuf,
     repository: Repository,
     overlay: Option<Overlay>,
+    machine: MachineInfo,
     progress: Option<Progress>,
     resolved_overlays: Arc<HashMap<String, String>>,
 }
@@ -129,6 +180,11 @@ impl ContextBuilder {
         self
     }
 
+    pub fn machine(mut self, machine: MachineInfo) -> Self {
+        self.machine = machine;
+        self
+    }
+
     pub fn progress(mut self, progress: Progress) -> Self {
         self.progress = Some(progress);
         self
@@ -150,6 +206,7 @@ impl ContextBuilder {
             root: self.root,
             repository: self.repository,
             overlay: self.overlay,
+            machine: self.machine,
             progress: self.progress,
             resolved_overlays: self.resolved_overlays,
         })
@@ -173,6 +230,7 @@ impl Context {
             root: self.root.clone(),
             repository: self.repository.clone(),
             overlay: Some(overlay),
+            machine: self.machine.clone(),
             progress: self.progress.clone(),
             resolved_overlays: self.resolved_overlays.clone(),
         })
@@ -189,6 +247,7 @@ impl Context {
             root: self.root.clone(),
             repository: self.repository.clone(),
             overlay: self.overlay.clone(),
+            machine: self.machine.clone(),
             progress: Some(Progress::Progress(progress)),
             resolved_overlays: self.resolved_overlays.clone(),
         })
@@ -205,6 +264,7 @@ impl Context {
             root: self.root.clone(),
             repository: self.repository.clone(),
             overlay: self.overlay.clone(),
+            machine: self.machine.clone(),
             progress: Some(Progress::MultiProgress(progress)),
             resolved_overlays: self.resolved_overlays.clone(),
         })
@@ -238,6 +298,7 @@ impl Context {
             root: self.root.clone(),
             repository: self.repository.clone(),
             overlay: self.overlay.clone(),
+            machine: self.machine.clone(),
             progress: self.progress.clone(),
             resolved_overlays: self.resolved_overlays.clone(),
         }
@@ -286,6 +347,9 @@ mod tests {
         assert_eq!(ctx.root, PathBuf::default());
         assert!(ctx.overlay.is_none());
         assert!(ctx.progress.is_none());
+        // Default `machine` is the real detected machine, not an empty value.
+        assert_eq!(ctx.machine.os, std::env::consts::OS);
+        assert_eq!(ctx.machine.arch, std::env::consts::ARCH);
     }
 
     #[test]
@@ -355,6 +419,7 @@ mod tests {
         assert!(new_ctx.verbose);
         assert_eq!(new_ctx.root, root_path);
         assert!(new_ctx.overlay.is_some());
+        assert_eq!(new_ctx.machine.os, ctx.machine.os);
         // Original should be unchanged
         assert!(ctx.overlay.is_none());
     }
@@ -517,5 +582,30 @@ mod tests {
         let cloned = ctx.clone_for_overlay_update();
         assert!(cloned.dry_run);
         assert_eq!(cloned.root, root_path);
+    }
+
+    #[test]
+    fn machine_info_detect_populates_os_and_arch() {
+        let machine = MachineInfo::detect();
+        assert_eq!(machine.os, std::env::consts::OS);
+        assert_eq!(machine.arch, std::env::consts::ARCH);
+    }
+
+    #[test]
+    fn builder_with_machine_override() {
+        let machine = MachineInfo {
+            os: "macos".to_string(),
+            arch: "aarch64".to_string(),
+            hostname: "test-host".to_string(),
+            username: "tester".to_string(),
+            distro: None,
+            distro_id: None,
+        };
+        let ctx = Context::builder()
+            .repository(dummy_repo())
+            .machine(machine)
+            .build();
+        assert_eq!(ctx.machine.os, "macos");
+        assert_eq!(ctx.machine.hostname, "test-host");
     }
 }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -3,4 +3,4 @@ mod context;
 pub mod templates;
 
 pub use action::Action;
-pub use context::{Context, Ctx};
+pub use context::{Context, Ctx, MachineInfo};

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -326,8 +326,7 @@ impl Overlay {
             .with_message("");
 
         for (name, config) in &symlinks {
-            let resolved_target =
-                actions::symlink::render_symlink_target(&config.target, &ctx.resolved_overlays)?;
+            let resolved_target = actions::symlink::render_symlink_target(&config.target, &ctx)?;
             let target_path = PathBuf::from(&resolved_target);
             let is_dir = target_path.is_dir()
                 || resolved_target.ends_with(std::path::MAIN_SEPARATOR_STR)
@@ -422,6 +421,22 @@ mod tests {
         let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
         let resolved = overlay.resolve_target(&c).unwrap();
         assert_eq!(resolved, PathBuf::from(target_str));
+    }
+
+    #[test]
+    fn test_resolve_target_with_machine_os() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~/{{ machine.os }}\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let root = td.path().to_path_buf();
+        let c = ctx(root.clone(), repo.clone(), Some(overlay.clone()));
+        let resolved = overlay.resolve_target(&c).unwrap();
+        assert_eq!(resolved, root.join(std::env::consts::OS));
     }
 
     #[tokio::test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
+use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use anyhow::Result;
 use dirs::home_dir;
@@ -33,6 +35,41 @@ pub fn short_path(path: &str) -> String {
     } else {
         path.to_string()
     }
+}
+
+/// Parse a single `KEY=value` line from `/etc/os-release`-formatted content,
+/// stripping surrounding quotes (values are often quoted, e.g. `NAME="Ubuntu"`).
+fn parse_os_release_field(content: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
+    content
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix.as_str()))
+        .map(|value| value.trim_matches('"').to_string())
+}
+
+/// Distro ID (e.g. `"ubuntu"`, `"arch"`) from `/etc/os-release`. Used both for
+/// package-manager resolution (`actions::install`) and the `machine.distro_id`
+/// template variable. Memoized: the file never changes mid-process.
+pub fn detect_linux_distro_id() -> Option<String> {
+    static DISTRO_ID: OnceLock<Option<String>> = OnceLock::new();
+    DISTRO_ID
+        .get_or_init(|| {
+            let content = fs::read_to_string("/etc/os-release").ok()?;
+            parse_os_release_field(&content, "ID")
+        })
+        .clone()
+}
+
+/// Human-readable distro name (e.g. `"Ubuntu"`, `"Arch Linux"`) from
+/// `/etc/os-release`, exposed to templates as `machine.distro`.
+pub fn detect_linux_distro_name() -> Option<String> {
+    static DISTRO_NAME: OnceLock<Option<String>> = OnceLock::new();
+    DISTRO_NAME
+        .get_or_init(|| {
+            let content = fs::read_to_string("/etc/os-release").ok()?;
+            parse_os_release_field(&content, "NAME")
+        })
+        .clone()
 }
 
 // Find the longest common suffix between two strings
@@ -110,5 +147,24 @@ mod tests {
         let result = resolve_home(None).unwrap();
         let expected = home_dir().unwrap().join(".over");
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_os_release_field_extracts_quoted_and_unquoted_values() {
+        let content = "ID=ubuntu\nNAME=\"Ubuntu\"\nVERSION_ID=\"22.04\"\n";
+        assert_eq!(
+            parse_os_release_field(content, "ID"),
+            Some("ubuntu".to_string())
+        );
+        assert_eq!(
+            parse_os_release_field(content, "NAME"),
+            Some("Ubuntu".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_os_release_field_missing_key_returns_none() {
+        let content = "ID=arch\n";
+        assert_eq!(parse_os_release_field(content, "NAME"), None);
     }
 }


### PR DESCRIPTION
## Summary

Adds OS, architecture, hostname, username, and Linux distro as a `machine` struct exposed to all templating contexts, enabling conditional overlay behavior per machine.

```toml
# over.toml
target = "{% if machine.os == 'macos' %}~/Library/Application Support{% else %}~/.config{% endif %}"
```

```toml
# .link.toml
target = "{{ env.HOME }}/.config/{{ machine.hostname }}/settings.json"
```

## Implementation notes

- `MachineInfo` lives in `exec::context` and is populated once per `Context` (via `MachineInfo::detect()`), then flows into MiniJinja like every other `Context` field.
- Distro detection (previously private to `actions::install`) was extracted into a shared, memoized helper in `utils`, split into `distro_id` (used for package-manager resolution) and `distro` (human-readable name, new).
- `.link.toml` symlink targets previously only saw `env`/`overlays`; `render_symlink_target` now also receives `machine`, so both templating surfaces are consistent.

Closes #15
