### PR TITLE
feat(xdg): add XDG state/cache layout and persistence boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "console",
  "dialoguer",
  "dirs",
+ "etcetera",
  "futures",
  "git2",
  "git2_credentials",
@@ -436,6 +437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ strip = true
 [dependencies]
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 dirs = "6.0"
+etcetera = "0.11"
 glob = "0.3"
 globset = "0.4"
 symlink = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ pub mod exec;
 pub mod lint;
 pub mod overlays;
 pub mod ui;
+pub mod xdg;
 
 pub mod utils;

--- a/src/xdg/mod.rs
+++ b/src/xdg/mod.rs
@@ -1,0 +1,160 @@
+//! XDG Base Directory layout for `over`.
+//!
+//! Resolves the three directories `over` is allowed to touch outside of the
+//! overlay repository itself (`~/.over`, resolved separately by
+//! [`crate::utils::resolve_home`]):
+//!
+//! - `config_dir` (`$XDG_CONFIG_HOME/over`) — reserved for future user
+//!   configuration; nothing reads or writes it yet.
+//! - `state_dir` (`$XDG_STATE_HOME/over`) — persistent operational metadata
+//!   (see [`state`]). Deleting it should only lose recoverable checkpoints,
+//!   never authoritative data.
+//! - `cache_dir` (`$XDG_CACHE_HOME/over`) — disposable derived data. Nothing
+//!   may depend on its presence: deleting it must always be harmless.
+//!
+//! `over` deliberately follows the XDG Base Directory Specification on every
+//! platform (unlike the `dirs`/`directories` crates, which map to
+//! platform-native locations on macOS/Windows) so behavior stays predictable
+//! across environments.
+
+pub mod state;
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use etcetera::app_strategy::{self, AppStrategy, AppStrategyArgs};
+
+/// Resolved XDG directories for `over`.
+pub struct XdgDirs {
+    inner: app_strategy::Xdg,
+}
+
+impl XdgDirs {
+    /// Resolves `over`'s XDG directories from the environment.
+    pub fn new() -> Result<Self> {
+        let inner = app_strategy::Xdg::new(AppStrategyArgs {
+            // Xdg ignores qualifier/author (they only affect the Apple/Windows
+            // strategies), but `AppStrategyArgs` still requires them.
+            top_level_domain: String::new(),
+            author: String::new(),
+            app_name: "over".to_string(),
+        })
+        .context("could not determine home directory")?;
+        Ok(Self { inner })
+    }
+
+    /// `$XDG_CONFIG_HOME/over`, defaulting to `~/.config/over`.
+    ///
+    /// Reserved for future user configuration; not read or written yet.
+    pub fn config_dir(&self) -> PathBuf {
+        self.inner.config_dir()
+    }
+
+    /// `$XDG_STATE_HOME/over`, defaulting to `~/.local/state/over`.
+    pub fn state_dir(&self) -> PathBuf {
+        self.inner
+            .state_dir()
+            // The Xdg strategy always resolves a state dir (only the Apple/
+            // Windows strategies return `None` here), so this never fires.
+            .expect("Xdg strategy always provides a state_dir")
+    }
+
+    /// `$XDG_CACHE_HOME/over`, defaulting to `~/.cache/over`.
+    ///
+    /// Nothing depends on this directory existing or its contents surviving:
+    /// deleting it must always be harmless.
+    pub fn cache_dir(&self) -> PathBuf {
+        self.inner.cache_dir()
+    }
+
+    /// Creates `path` (and its parents) if it doesn't exist yet.
+    ///
+    /// XDG directories are never guaranteed to pre-exist (the spec requires
+    /// applications to create them on demand), so every writer must call
+    /// this before touching a file inside one.
+    pub fn ensure_dir(path: &Path) -> Result<()> {
+        std::fs::create_dir_all(path)
+            .with_context(|| format!("failed to create directory {}", path.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Clears every XDG env var so tests observe the documented defaults.
+    ///
+    /// # Safety
+    /// `env::remove_var` is only unsound when other threads read/write the
+    /// process environment concurrently; `cargo nextest` runs each test in
+    /// its own process, so this is safe in practice for this test suite.
+    fn clear_xdg_env() {
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("XDG_STATE_HOME");
+            std::env::remove_var("XDG_CACHE_HOME");
+        }
+    }
+
+    /// # Safety
+    /// See [`clear_xdg_env`].
+    unsafe fn set_env(key: &str, value: &Path) {
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    #[test]
+    fn defaults_follow_the_xdg_spec_under_home() {
+        clear_xdg_env();
+        let home = etcetera::home_dir().unwrap();
+        let dirs = XdgDirs::new().unwrap();
+
+        assert_eq!(dirs.config_dir(), home.join(".config/over"));
+        assert_eq!(dirs.state_dir(), home.join(".local/state/over"));
+        assert_eq!(dirs.cache_dir(), home.join(".cache/over"));
+    }
+
+    #[test]
+    fn config_dir_honors_xdg_config_home() {
+        clear_xdg_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { set_env("XDG_CONFIG_HOME", tmp.path()) };
+
+        let dirs = XdgDirs::new().unwrap();
+
+        assert_eq!(dirs.config_dir(), tmp.path().join("over"));
+    }
+
+    #[test]
+    fn state_dir_honors_xdg_state_home() {
+        clear_xdg_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { set_env("XDG_STATE_HOME", tmp.path()) };
+
+        let dirs = XdgDirs::new().unwrap();
+
+        assert_eq!(dirs.state_dir(), tmp.path().join("over"));
+    }
+
+    #[test]
+    fn cache_dir_honors_xdg_cache_home() {
+        clear_xdg_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { set_env("XDG_CACHE_HOME", tmp.path()) };
+
+        let dirs = XdgDirs::new().unwrap();
+
+        assert_eq!(dirs.cache_dir(), tmp.path().join("over"));
+    }
+
+    #[test]
+    fn ensure_dir_creates_missing_parents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("a/b/c");
+
+        XdgDirs::ensure_dir(&nested).unwrap();
+
+        assert!(nested.is_dir());
+    }
+}

--- a/src/xdg/state.rs
+++ b/src/xdg/state.rs
@@ -1,0 +1,357 @@
+//! Versioned, atomic, locked persistence boundary for files under
+//! `$XDG_STATE_HOME/over`.
+//!
+//! This module only provides the generic mechanics — schema-less consumers
+//! (repository/worktree associations, sync checkpoints, status caches, …)
+//! are added by later features on top of [`StateFile`]. Rules enforced here,
+//! per the XDG state contract:
+//!
+//! - every document is versioned, so a mismatched on-disk schema is either
+//!   migrated or rejected loudly, never silently misread;
+//! - writes are atomic (temp file + rename), so a crash mid-write can never
+//!   leave a half-written document behind;
+//! - reads and writes are serialized through an advisory file lock, so two
+//!   concurrent `over`/`git-over` invocations can't corrupt the same file.
+
+use std::fs::OpenOptions;
+use std::path::PathBuf;
+// `std::fs::File::lock`/`lock_shared`/`unlock` (stable since Rust 1.89) give
+// us advisory `flock`/`LockFileEx` locking natively, so no extra dependency
+// (e.g. `fs4`) is needed here.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::task::spawn_blocking;
+
+/// A document that can be persisted under `$XDG_STATE_HOME/over`.
+///
+/// `Default` is required because a missing state file is a normal, expected
+/// condition (first run, or the user deleted it): [`StateFile::load`]
+/// returns `T::default()` rather than an error.
+pub trait VersionedState: Serialize + DeserializeOwned + Default {
+    /// Current on-disk schema version for this document.
+    const VERSION: u32;
+
+    /// Upgrades an older, raw on-disk document to the current shape.
+    ///
+    /// The default implementation refuses every version, so implementors
+    /// only need to add a match arm the day they actually introduce a new
+    /// schema; until then, an unreadable file fails loudly instead of the
+    /// migration boundary silently doing nothing.
+    fn migrate(version: u32, _raw: toml::Value) -> Result<Self> {
+        anyhow::bail!("cannot migrate state from unknown schema version {version}")
+    }
+}
+
+/// On-disk envelope: `{ version = N, [state] ... }`.
+///
+/// Kept separate from `T` so a version mismatch can be detected (and
+/// migrated) *before* attempting to deserialize the body as the current
+/// shape.
+#[derive(serde::Deserialize)]
+struct RawEnvelope {
+    version: u32,
+    state: toml::Value,
+}
+
+#[derive(Serialize)]
+struct Envelope<'a, T> {
+    version: u32,
+    state: &'a T,
+}
+
+/// A single versioned, atomically-written, lock-protected state document.
+pub struct StateFile<T> {
+    path: PathBuf,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> StateFile<T>
+where
+    T: VersionedState + Send + 'static,
+{
+    /// Points at `path` (not required to exist yet).
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Advisory lock sentinel next to `path`.
+    ///
+    /// A dedicated file (rather than locking `path` itself) so the state
+    /// file can always be replaced with `rename` without disturbing an
+    /// in-progress lock on the old inode.
+    fn lock_path(&self) -> PathBuf {
+        let mut lock_path = self.path.clone().into_os_string();
+        lock_path.push(".lock");
+        lock_path.into()
+    }
+
+    /// Returns `T::default()` if the file doesn't exist yet.
+    pub async fn load(&self) -> Result<T> {
+        let path = self.path.clone();
+        let lock_path = self.lock_path();
+        spawn_blocking(move || {
+            // A shared lock is defense-in-depth beyond the atomic-rename
+            // guarantee (helps on filesystems without atomic rename, e.g.
+            // some network filesystems) and serializes with concurrent
+            // `update()`/`save()` calls.
+            let lock_file = Self::open_lock_file(&lock_path)?;
+            lock_file
+                .lock_shared()
+                .with_context(|| format!("failed to lock {}", lock_path.display()))?;
+            let state = Self::read(&path)?;
+            lock_file.unlock().ok();
+            Ok(state)
+        })
+        .await?
+    }
+
+    /// Whole-document overwrite, written atomically.
+    pub async fn save(&self, value: T) -> Result<()> {
+        let path = self.path.clone();
+        let lock_path = self.lock_path();
+        spawn_blocking(move || {
+            let lock_file = Self::open_lock_file(&lock_path)?;
+            lock_file
+                .lock()
+                .with_context(|| format!("failed to lock {}", lock_path.display()))?;
+            Self::write_atomic(&path, &value)?;
+            lock_file.unlock().ok();
+            Ok(())
+        })
+        .await?
+    }
+
+    /// Locked read-modify-write: loads the current document (or its
+    /// default), lets `mutate` update it in place, then saves it — all
+    /// inside a single critical section, so concurrent callers can't
+    /// interleave and lose an update.
+    pub async fn update(
+        &self,
+        mutate: impl FnOnce(&mut T) -> Result<()> + Send + 'static,
+    ) -> Result<()> {
+        let path = self.path.clone();
+        let lock_path = self.lock_path();
+        spawn_blocking(move || {
+            // `lock`/`lock_shared` are blocking syscalls; running the whole
+            // read-modify-write sequence inside this one `spawn_blocking`
+            // closure keeps the lock held across the mutation without ever
+            // holding it across an `.await` point.
+            let lock_file = Self::open_lock_file(&lock_path)?;
+            lock_file
+                .lock()
+                .with_context(|| format!("failed to lock {}", lock_path.display()))?;
+
+            let mut state = Self::read(&path)?;
+            mutate(&mut state)?;
+            Self::write_atomic(&path, &state)?;
+
+            // Locks are released on drop too; unlocking explicitly makes
+            // the end of the critical section visible in the code.
+            lock_file.unlock().ok();
+            Ok(())
+        })
+        .await?
+    }
+
+    /// Opens (creating if needed) the lock sentinel file, creating its
+    /// parent directory first since XDG state dirs aren't guaranteed to
+    /// pre-exist.
+    fn open_lock_file(lock_path: &std::path::Path) -> Result<std::fs::File> {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(lock_path)
+            .with_context(|| format!("failed to open lock file {}", lock_path.display()))
+    }
+
+    /// Reads and parses the document, applying [`VersionedState::migrate`]
+    /// if it was written by an older schema version. Missing file → default.
+    fn read(path: &std::path::Path) -> Result<T> {
+        let contents = match std::fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(T::default()),
+            Err(err) => {
+                return Err(err).with_context(|| format!("failed to read {}", path.display()));
+            }
+        };
+        let raw: RawEnvelope = toml::from_str(&contents)
+            .with_context(|| format!("failed to parse state file {}", path.display()))?;
+
+        match raw.version.cmp(&T::VERSION) {
+            std::cmp::Ordering::Equal => raw
+                .state
+                .try_into()
+                .with_context(|| format!("failed to decode state file {}", path.display())),
+            std::cmp::Ordering::Less => T::migrate(raw.version, raw.state).with_context(|| {
+                format!(
+                    "failed to migrate state file {} from schema v{} to v{}",
+                    path.display(),
+                    raw.version,
+                    T::VERSION
+                )
+            }),
+            std::cmp::Ordering::Greater => anyhow::bail!(
+                "state file {} was written by a newer version of over (schema v{}, expected v{}); refusing to read it",
+                path.display(),
+                raw.version,
+                T::VERSION
+            ),
+        }
+    }
+
+    /// Serializes `value` and atomically replaces `path`: write to a sibling
+    /// temp file in the same directory (so `rename` stays on one
+    /// filesystem), then rename over the target.
+    fn write_atomic(path: &std::path::Path, value: &T) -> Result<()> {
+        let parent = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+
+        let envelope = Envelope {
+            version: T::VERSION,
+            state: value,
+        };
+        let contents = toml::to_string_pretty(&envelope)
+            .context("failed to serialize state document to TOML")?;
+
+        let tmp_path = parent.join(format!(
+            ".{}.tmp-{}",
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("state"),
+            std::process::id()
+        ));
+        std::fs::write(&tmp_path, contents)
+            .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, path).with_context(|| {
+            format!(
+                "failed to atomically replace {} with {}",
+                path.display(),
+                tmp_path.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
+    struct Counter {
+        count: u32,
+    }
+
+    impl VersionedState for Counter {
+        const VERSION: u32 = 1;
+    }
+
+    #[tokio::test]
+    async fn load_returns_default_when_file_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file: StateFile<Counter> = StateFile::new(tmp.path().join("state.toml"));
+
+        let value = state_file.load().await.unwrap();
+
+        assert_eq!(value, Counter::default());
+    }
+
+    #[tokio::test]
+    async fn save_then_load_round_trips_the_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file: StateFile<Counter> = StateFile::new(tmp.path().join("state.toml"));
+
+        state_file.save(Counter { count: 42 }).await.unwrap();
+        let value = state_file.load().await.unwrap();
+
+        assert_eq!(value, Counter { count: 42 });
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
+    struct Migrated {
+        count: u32,
+        // Introduced in v2; migrated-from-v1 documents get the default.
+        label: String,
+    }
+
+    impl VersionedState for Migrated {
+        const VERSION: u32 = 2;
+
+        fn migrate(version: u32, raw: toml::Value) -> Result<Self> {
+            if version != 1 {
+                anyhow::bail!("cannot migrate state from unknown schema version {version}");
+            }
+            let old: Counter = raw.try_into()?;
+            Ok(Migrated {
+                count: old.count,
+                label: String::new(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn load_migrates_an_older_schema_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.toml");
+        std::fs::write(&path, "version = 1\n\n[state]\ncount = 7\n").unwrap();
+        let state_file: StateFile<Migrated> = StateFile::new(path);
+
+        let value = state_file.load().await.unwrap();
+
+        assert_eq!(
+            value,
+            Migrated {
+                count: 7,
+                label: String::new()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn load_rejects_a_newer_schema_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.toml");
+        std::fs::write(&path, "version = 99\n\n[state]\ncount = 1\n").unwrap();
+        let state_file: StateFile<Counter> = StateFile::new(path);
+
+        let err = state_file.load().await.unwrap_err();
+
+        assert!(err.to_string().contains("newer version"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_updates_are_serialized_and_none_are_lost() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.toml");
+        let a: StateFile<Counter> = StateFile::new(path.clone());
+        let b: StateFile<Counter> = StateFile::new(path);
+
+        let (r1, r2) = tokio::join!(
+            a.update(|s| {
+                s.count += 1;
+                Ok(())
+            }),
+            b.update(|s| {
+                s.count += 1;
+                Ok(())
+            })
+        );
+        r1.unwrap();
+        r2.unwrap();
+
+        let value = a.load().await.unwrap();
+        assert_eq!(value.count, 2);
+    }
+}


### PR DESCRIPTION
Adds `over`'s XDG Base Directory layout and a reusable persistence
boundary for state documents, as defined in #111.

`XdgDirs` resolves the three directories `over` is allowed to touch
outside of the overlay repository itself:

- `$XDG_CONFIG_HOME/over` — reserved for future user configuration
- `$XDG_STATE_HOME/over` — persistent operational metadata
- `$XDG_CACHE_HOME/over` — disposable derived data

Unlike the `dirs`/`directories` crates, this follows the XDG spec on
every platform rather than mapping to macOS/Windows-native locations,
so `over`'s behavior stays predictable everywhere.

`StateFile<T>` provides the generic mechanics future features (state
checkpoints, repo/worktree associations, status caching) will build
on: every document is versioned via the `VersionedState` trait
(migrated or rejected loudly, never silently misread), writes are
atomic (temp file + rename), and reads/writes are serialized through
an advisory lock so concurrent `over`/`git-over` invocations can't
corrupt the same file.

This is infrastructure only — no product schema, no CLI wiring. That's
left to the features that consume it.

Closes #111
