### PR TITLE
feat(materialize): introduce Materializer backend registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,12 @@ src/
 ├── bin/git-over.rs  the `git-over` binary
 ├── actions/      filesystem, symlink, install and git side effects
 ├── cli/          argument types for both binaries
+├── desired/      the DesiredTree/DesiredEntry desired-state model
 ├── exec/         execution context and templating
 ├── lint/         `over lint` diagnostics
+├── materialize/  Materializer backends (registry, symlink)
 ├── overlays/     the Overlay/Repository domain model
+├── plan/         the Plan/PlanStep reconciliation model
 └── ui/           logging, styling, emojis
 ```
 

--- a/docs/adr/012-materializer-backend-registry.md
+++ b/docs/adr/012-materializer-backend-registry.md
@@ -1,0 +1,73 @@
+# ADR-012: Materializer backend registry, amending ADR-011
+
+**Status:** accepted
+
+## Context
+
+ADR-011 built `Plan`/`PlanStep`/`Operation` between `DesiredTree` and actual
+filesystem state, but left `Plan::execute`'s dispatch hardcoded: a pair of
+free functions, `classify()` and `build_action()`, pattern-matched directly
+on `MaterializationIntent`/`Provenance` and called into the concrete
+`actions::fs`/`actions::symlink` types. ADR-011 named this explicitly as
+acceptable debt: "the seam #108 needs (replacing intent-based dispatch with
+a `Materializer` registry) is documented but not built... given there is
+exactly one materializer today."
+
+Issue #108 asks to make symlink and git-checkout materialization two
+backends of the same `DesiredTree` → `Plan` → materialize pipeline, without
+prematurely building the bidirectional git-checkout workflow itself (#110)
+or rule-migration semantics (#113).
+
+## Decision
+
+`src/materialize/` introduces:
+
+- `Materializer` — a trait owning both read-only actual-state inspection
+  (`classify`) and execution (`materialize`) for the intents it
+  (`handles`). Backends decide for themselves what "inspect actual state"
+  means (plain `symlink_metadata` for symlinks/directories today; a
+  git-aware equivalent for #110's checkout backend later), rather than
+  `Plan` assuming one universal notion of "actual state".
+- `MaterializerRegistry` — a small ordered list of backends. `find(intent)`
+  returns the one that handles it, or `None`. `Plan::build` treats `None`
+  as `Operation::Deferred`, and `Plan::execute` skips `Deferred` steps —
+  both exactly as before this issue.
+- `SymlinkMaterializer` — a straight move of the previous `classify()`/
+  `build_action()` bodies (`Directory`/`SymlinkFile`/`SymlinkDirectory`
+  intents; sidecar-vs-regular `Provenance` dispatch to `EnsureSymlink` vs
+  `EnsureLink`/`EnsureDirLink`/`EnsureDir`). No behavior change: the same
+  conflict semantics (force/no_prompt/interactive skip-overwrite-absorb-diff
+  for regular entries, unconditional overwrite for `.link.*` sidecars) still
+  live in those unchanged `Action` impls.
+
+`MaterializationIntent::Checkout` has no registered backend yet —
+`MaterializerRegistry::find` returns `None` for it, so it still classifies
+as `Operation::Deferred`, identical to the previous hardcoded match arm.
+#110 adds a `CheckoutMaterializer` to the registry's backend list to change
+that, without `Plan` or any other backend changing.
+
+`Materializer::materialize` is declared `#[async_trait(?Send)]`: it
+dispatches to `Box<dyn Action>` internally, and `Action` (`src/exec/
+action.rs`) itself isn't `Send`-bound. Like `Plan::execute` before this
+issue, materialization is only ever awaited inline — never spawned onto
+another task — so this costs nothing today and doesn't preclude a backend
+spawning its own concurrent work internally (as `actions::git::
+clone_repositories` already does with `join_all`).
+
+## Consequences
+
+`Plan` no longer knows about concrete `actions::fs`/`actions::symlink`
+types, or about Git, at all — `plan::reconcile` now only imports
+`MaterializerRegistry`. Adding checkout materialization (#110) or
+materialization-rule migrations (#113) means adding a `Materializer` impl
+and one line in `MaterializerRegistry::default`, not touching `Plan::build`/
+`Plan::execute`. This is a pure refactor: existing `Plan`-level tests
+(idempotency, dry-run, force/no_prompt conflict handling) pass unchanged,
+confirming the registry-mediated path behaves identically to the removed
+hardcoded dispatch.
+
+This does not implement bidirectional Git checkout sync (#110) — `Checkout`
+entries remain `Operation::Deferred` and unmaterializable until that issue
+registers a real backend. It also does not add materialization-rule
+migration detection (#113); `Operation` still has no `Migrate`-style variant.
+</content>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ by editing the old one. The history is the value.
 | [009](009-lint-is-a-separate-tolerant-pass.md) | `over lint` is a separate, tolerant, pre-deserialization static-analysis pass |
 | [010](010-templating-is-scoped-to-path-strings.md) | Templating is scoped to path-resolution strings, not file content |
 | [011](011-plan-then-execute-reconciliation.md) | Plan-then-execute reconciliation, amending ADR-005 and ADR-006 |
+| [012](012-materializer-backend-registry.md) | Materializer backend registry, amending ADR-011 |

--- a/src/desired/entry.rs
+++ b/src/desired/entry.rs
@@ -40,10 +40,11 @@ pub enum MaterializationIntent {
         source: PathBuf,
         link_type: LinkType,
     },
-    /// A Git-managed path (`overlay.git`). Not yet materializable — #108/#110
-    /// own turning this into a real checkout/worktree. Carried here so a
-    /// future `Plan`/diff/status (#13/#109/#12) can at least see and report
-    /// on it.
+    /// A Git-managed path (`overlay.git`). Not yet materializable — no
+    /// [`crate::materialize::Materializer`] claims this intent yet, #110
+    /// owns turning this into a real checkout/worktree backend. Carried
+    /// here so a future `Plan`/diff/status (#13/#109/#12) can at least see
+    /// and report on it.
     Checkout,
 }
 

--- a/src/desired/mod.rs
+++ b/src/desired/mod.rs
@@ -4,9 +4,10 @@
 //! read-only representation of what `over` *wants* the filesystem to look
 //! like, independently from how that state gets materialized. `Overlay::
 //! apply` (#13) builds a [`crate::plan::Plan`] from a `DesiredTree` and
-//! executes it — git repository checkouts remain a separate,
+//! executes it via a registered [`crate::materialize::Materializer`]
+//! (#108) — git repository checkouts remain a separate,
 //! `actions::git::clone_repositories` step, orthogonal to the plan, until
-//! #108/#110 make them a real materializer:
+//! #110 gives them a real materializer backend:
 //!
 //! ```text
 //! root configuration
@@ -38,8 +39,9 @@
 //! - Rendered file content (`DesiredEntry` has no `content` field) — #61.
 //! - Permission metadata (`DesiredEntry` has no `permissions` field) — #65.
 //! - Comparing against actual filesystem state and materializing anything —
-//!   that's [`crate::plan`] (#13) and #108. `DesiredTree` is consumed by
-//!   those, not a replacement for `Overlay::apply` itself.
+//!   that's [`crate::plan`] (#13) and [`crate::materialize`] (#108).
+//!   `DesiredTree` is consumed by those, not a replacement for
+//!   `Overlay::apply` itself.
 //! - `install` config (package managers): not filesystem materialization, so
 //!   it has no representation in `DesiredTree`.
 

--- a/src/desired/tree.rs
+++ b/src/desired/tree.rs
@@ -142,8 +142,9 @@ fn collect_own_entries(
         intent: MaterializationIntent::Directory,
     });
 
-    // Git-managed paths: not yet materializable (#108/#110 own turning these
-    // into a real checkout/worktree), but carried so a future Plan/diff/status
+    // Git-managed paths: not yet materializable (no registered Materializer
+    // claims this intent yet; #110 owns turning these into a real
+    // checkout/worktree backend), but carried so a future Plan/diff/status
     // (#13/#109/#12) can at least see and report on them.
     if let Some(git_repos) = &overlay.git {
         for (repo_key, config) in git_repos {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cli;
 pub mod desired;
 pub mod exec;
 pub mod lint;
+pub mod materialize;
 pub mod overlays;
 pub mod plan;
 pub mod ui;

--- a/src/materialize/mod.rs
+++ b/src/materialize/mod.rs
@@ -1,0 +1,139 @@
+//! Materialization backends (#108).
+//!
+//! [`crate::plan::Plan`] classifies and executes each
+//! [`DesiredEntry`](crate::desired::DesiredEntry) by asking exactly one
+//! registered [`Materializer`] backend: the one that
+//! [`Materializer::handles`] the entry's
+//! [`MaterializationIntent`](crate::desired::MaterializationIntent). `Plan`
+//! itself never knows about concrete `actions::fs`/`actions::symlink` types,
+//! nor (eventually) about Git — that lives entirely in the backends here.
+//!
+//! ```text
+//! DesiredEntry (intent)
+//!       ↓
+//! MaterializerRegistry::find  — routes by intent to one backend
+//!       ↓
+//! Materializer::classify      — read-only actual-state inspection
+//!       ↓
+//! Materializer::materialize   — concrete filesystem/Git changes
+//! ```
+//!
+//! Today [`MaterializerRegistry`] registers exactly one backend,
+//! [`SymlinkMaterializer`], which owns every intent except
+//! [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout).
+//! No backend claims `Checkout` yet: [`MaterializerRegistry::find`] returns
+//! `None` for it, and `Plan::build` falls back to `Operation::Deferred`
+//! exactly like before this issue. #110 adds a `CheckoutMaterializer` here
+//! to turn `Checkout` entries into real Git worktrees/checkouts, without
+//! `Plan` changing at all. #113's rule-migration semantics are a later
+//! extension of the same registry.
+
+mod symlink;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::desired::{DesiredEntry, MaterializationIntent};
+use crate::exec::Ctx;
+use crate::plan::{Operation, PlanStep};
+
+pub use symlink::SymlinkMaterializer;
+
+/// A materialization backend: owns both read-only actual-state inspection
+/// and execution for the [`MaterializationIntent`] variants it
+/// [`handles`](Materializer::handles).
+///
+/// `?Send`: `materialize` dispatches to `Box<dyn Action>` internally
+/// ([`crate::exec::Action`] itself isn't `Send`-bound), and — like
+/// `Plan::execute` before this issue — is only ever awaited inline, never
+/// spawned onto another task.
+#[async_trait(?Send)]
+pub trait Materializer: Send + Sync {
+    /// Does this backend own the given intent? Used by
+    /// [`MaterializerRegistry::find`] to route each entry to exactly one
+    /// materializer. An intent no backend claims is treated as
+    /// `Operation::Deferred` by `Plan::build`.
+    fn handles(&self, intent: &MaterializationIntent) -> bool;
+
+    /// Inspect actual state and classify a single entry. Read-only — never
+    /// mutates the filesystem (or any other backing store).
+    fn classify(&self, entry: &DesiredEntry) -> Result<Operation>;
+
+    /// Turn an actionable (`Create`/`Conflict`) step into concrete changes.
+    /// Never called for `Noop`/`Deferred` steps.
+    async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()>;
+}
+
+/// The set of registered [`Materializer`] backends, consulted by
+/// [`crate::plan::Plan`] to classify and execute every
+/// [`DesiredEntry`].
+pub struct MaterializerRegistry {
+    backends: Vec<Box<dyn Materializer>>,
+}
+
+impl Default for MaterializerRegistry {
+    fn default() -> Self {
+        Self {
+            // #110 adds `Box::new(CheckoutMaterializer)` here to claim
+            // `MaterializationIntent::Checkout`.
+            backends: vec![Box::new(SymlinkMaterializer)],
+        }
+    }
+}
+
+impl MaterializerRegistry {
+    /// The backend that owns `intent`, if any is registered for it.
+    pub fn find(&self, intent: &MaterializationIntent) -> Option<&dyn Materializer> {
+        self.backends
+            .iter()
+            .find(|m| m.handles(intent))
+            .map(|b| b.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::desired::Provenance;
+    use std::path::PathBuf;
+
+    fn entry(intent: MaterializationIntent) -> DesiredEntry {
+        DesiredEntry {
+            target: PathBuf::from("/tmp/does-not-matter"),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: PathBuf::from("/repo/ov"),
+            },
+            intent,
+        }
+    }
+
+    #[test]
+    fn registry_finds_symlink_materializer_for_directory() {
+        let registry = MaterializerRegistry::default();
+        assert!(registry.find(&MaterializationIntent::Directory).is_some());
+    }
+
+    #[test]
+    fn registry_finds_symlink_materializer_for_symlink_file() {
+        let registry = MaterializerRegistry::default();
+        let intent = MaterializationIntent::SymlinkFile {
+            source: PathBuf::from("/repo/ov/file.txt"),
+            link_type: crate::actions::symlink::LinkType::Soft,
+        };
+        assert!(registry.find(&intent).is_some());
+    }
+
+    #[test]
+    fn registry_has_no_backend_for_checkout_yet() {
+        let registry = MaterializerRegistry::default();
+        assert!(registry.find(&MaterializationIntent::Checkout).is_none());
+    }
+
+    #[test]
+    fn registry_find_uses_entry_intent() {
+        let registry = MaterializerRegistry::default();
+        let e = entry(MaterializationIntent::Directory);
+        assert!(registry.find(&e.intent).is_some());
+    }
+}

--- a/src/materialize/symlink.rs
+++ b/src/materialize/symlink.rs
@@ -1,0 +1,221 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::actions::fs::EnsureDirLink;
+use crate::actions::{EnsureDir, EnsureLink, EnsureSymlink};
+use crate::desired::{DesiredEntry, MaterializationIntent, Provenance};
+use crate::exec::{Action, Ctx};
+use crate::plan::actual::{self, ActualState};
+use crate::plan::{Operation, PlanStep};
+
+use super::Materializer;
+
+/// The default materialization backend (ADR-006): plain directories and
+/// symlinks (file- or directory-level), dispatched to the existing
+/// `actions::fs`/`actions::symlink` `Action` impls. Owns every
+/// [`MaterializationIntent`] except
+/// [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout),
+/// which #110 will give its own backend.
+///
+/// This is a pure move of the logic that used to live directly in
+/// `plan::reconcile` (`classify`/`build_action`) — no behavior change.
+pub struct SymlinkMaterializer;
+
+#[async_trait(?Send)]
+impl Materializer for SymlinkMaterializer {
+    fn handles(&self, intent: &MaterializationIntent) -> bool {
+        !matches!(intent, MaterializationIntent::Checkout)
+    }
+
+    /// Classify a single entry against current filesystem state. Read-only.
+    fn classify(&self, entry: &DesiredEntry) -> Result<Operation> {
+        match &entry.intent {
+            MaterializationIntent::Directory => {
+                let actual = actual::inspect(&entry.target)?;
+                Ok(match actual {
+                    ActualState::Missing => Operation::Create,
+                    ActualState::Directory => Operation::Noop,
+                    other => Operation::Conflict { current: other },
+                })
+            }
+            MaterializationIntent::SymlinkFile { source, .. }
+            | MaterializationIntent::SymlinkDirectory { source, .. } => {
+                let actual = actual::inspect(&entry.target)?;
+                Ok(match actual {
+                    ActualState::Missing => Operation::Create,
+                    ActualState::Symlink { ref points_to } if points_to == source => {
+                        Operation::Noop
+                    }
+                    other => Operation::Conflict { current: other },
+                })
+            }
+            MaterializationIntent::Checkout => {
+                unreachable!("MaterializerRegistry only calls classify() after handles() passed")
+            }
+        }
+    }
+
+    async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()> {
+        let action = build_action(ctx.clone(), &step.entry);
+        action.execute(ctx).await
+    }
+}
+
+/// Translate an entry into the existing, tested `Action` that materializes
+/// it — the single place that knows about concrete `actions::fs`/
+/// `actions::symlink` types.
+///
+/// Dispatches on `provenance`, not just `intent`, because two different
+/// existing actions handle symlinks with different conflict semantics:
+/// regular per-file overlay entries go through `EnsureLink`/`EnsureDirLink`
+/// (interactive skip/overwrite/absorb/diff resolution, ADR-006), while
+/// `.link.*` sidecar entries go through `EnsureSymlink` (unconditional
+/// overwrite, and the only one of the two that supports hard links).
+fn build_action(ctx: Ctx, entry: &DesiredEntry) -> Box<dyn Action> {
+    let is_sidecar = matches!(entry.provenance, Provenance::SymlinkSidecar { .. });
+
+    match &entry.intent {
+        MaterializationIntent::Directory => Box::new(EnsureDir::new(entry.target.clone())),
+        MaterializationIntent::SymlinkFile { source, link_type } => {
+            if is_sidecar {
+                Box::new(EnsureSymlink::new(
+                    source.clone(),
+                    entry.target.clone(),
+                    link_type.clone(),
+                    false,
+                ))
+            } else {
+                Box::new(EnsureLink::new(ctx, source.clone(), entry.target.clone()))
+            }
+        }
+        MaterializationIntent::SymlinkDirectory { source, link_type } => {
+            if is_sidecar {
+                Box::new(EnsureSymlink::new(
+                    source.clone(),
+                    entry.target.clone(),
+                    link_type.clone(),
+                    true,
+                ))
+            } else {
+                Box::new(EnsureDirLink::new(
+                    ctx,
+                    source.clone(),
+                    entry.target.clone(),
+                ))
+            }
+        }
+        MaterializationIntent::Checkout => {
+            unreachable!("SymlinkMaterializer::handles filters out Checkout entries")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::symlink::LinkType;
+    use crate::exec::Context;
+    use std::path::PathBuf;
+
+    fn entry(intent: MaterializationIntent) -> DesiredEntry {
+        DesiredEntry {
+            target: PathBuf::from("/tmp/does-not-matter-for-this-test"),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: PathBuf::from("/repo/ov"),
+            },
+            intent,
+        }
+    }
+
+    #[test]
+    fn handles_returns_false_for_checkout() {
+        let m = SymlinkMaterializer;
+        assert!(!m.handles(&MaterializationIntent::Checkout));
+    }
+
+    #[test]
+    fn handles_returns_true_for_directory_and_symlinks() {
+        let m = SymlinkMaterializer;
+        assert!(m.handles(&MaterializationIntent::Directory));
+        assert!(m.handles(&MaterializationIntent::SymlinkFile {
+            source: PathBuf::from("/src"),
+            link_type: LinkType::Soft,
+        }));
+        assert!(m.handles(&MaterializationIntent::SymlinkDirectory {
+            source: PathBuf::from("/src"),
+            link_type: LinkType::Soft,
+        }));
+    }
+
+    #[test]
+    fn missing_directory_classifies_as_create() {
+        let m = SymlinkMaterializer;
+        let e = entry(MaterializationIntent::Directory);
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Create));
+    }
+
+    #[test]
+    fn existing_directory_classifies_as_noop() {
+        use assert_fs::TempDir;
+        let td = TempDir::new().unwrap();
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: td.path().to_path_buf(),
+            ..entry(MaterializationIntent::Directory)
+        };
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    fn file_where_directory_expected_is_a_conflict() {
+        use assert_fs::TempDir;
+        let td = TempDir::new().unwrap();
+        let blocked = td.path().join("blocked");
+        std::fs::write(&blocked, "in the way").unwrap();
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: blocked,
+            ..entry(MaterializationIntent::Directory)
+        };
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict { .. }
+        ));
+    }
+
+    #[test]
+    fn build_action_directory() {
+        let entry = DesiredEntry {
+            target: PathBuf::from("/tmp/does-not-matter"),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: PathBuf::from("/repo/ov"),
+            },
+            intent: MaterializationIntent::Directory,
+        };
+        let ctx = Context::builder().build();
+        let action = build_action(ctx, &entry);
+        assert!(format!("{action}").contains("create directory:"));
+    }
+
+    #[test]
+    fn build_action_symlink_sidecar_uses_ensure_symlink() {
+        let entry = DesiredEntry {
+            target: PathBuf::from("/tmp/link"),
+            provenance: Provenance::SymlinkSidecar {
+                overlay: "ov".to_string(),
+                config: PathBuf::from("/repo/ov/x.link.toml"),
+                template: "/opt/x".to_string(),
+                resolved: PathBuf::from("/opt/x"),
+            },
+            intent: MaterializationIntent::SymlinkFile {
+                source: PathBuf::from("/opt/x"),
+                link_type: LinkType::Soft,
+            },
+        };
+        let ctx = Context::builder().build();
+        let action = build_action(ctx, &entry);
+        assert!(format!("{action}").contains("symlink"));
+    }
+}

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -272,12 +272,14 @@ impl Overlay {
                 }
             }
 
-            // Git checkouts stay outside the plan (#108/#110 own real
-            // checkout materialization); everything else — the overlay's
-            // own directory, files, and `.link.*` sidecars — goes through a
-            // Plan built from this overlay's own DesiredTree (no `uses`
-            // recursion here: that's handled above, one overlay at a time,
-            // so each dependency keeps its own banner/cycle-check).
+            // Git checkouts stay outside the plan (no registered
+            // Materializer claims MaterializationIntent::Checkout yet;
+            // #110 owns adding a real checkout/worktree backend);
+            // everything else — the overlay's own directory, files, and
+            // `.link.*` sidecars — goes through a Plan built from this
+            // overlay's own DesiredTree (no `uses` recursion here: that's
+            // handled above, one overlay at a time, so each dependency
+            // keeps its own banner/cycle-check).
             actions::git::clone_repositories(ctx.clone(), self, &target).await?;
 
             let ctx_with_target =

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -20,8 +20,9 @@
 //!       ↓
 //! Plan                       (this module — one PlanStep per DesiredEntry)
 //!       ↓
-//! Plan::execute               (translates steps into the existing, tested
-//!                              actions::fs / actions::symlink Action impls)
+//! Plan::execute               (delegates each step to the registered
+//!                              crate::materialize::Materializer that owns
+//!                              its intent, #108)
 //! ```
 //!
 //! [`Plan::build`] is read-only, like `DesiredTree::build`; only
@@ -31,12 +32,18 @@
 //! uses today) or a full `uses`-graph — so the same type is reusable by
 //! `status`/`diff` (#12/#109) later.
 //!
+//! Neither `Plan::build` nor `Plan::execute` know about concrete
+//! `actions::fs`/`actions::symlink` types, or about Git: both ask a
+//! [`crate::materialize::MaterializerRegistry`] for the backend that owns
+//! each entry's `MaterializationIntent` (#108).
+//!
 //! ## What's deliberately *not* here
 //!
-//! - Git checkout materialization: [`MaterializationIntent::Checkout`]
-//!   entries are classified as [`Operation::Deferred`] and never executed
-//!   by [`Plan::execute`] — #108/#110 own turning them into real
-//!   checkouts/worktrees. `Overlay::apply` still clones git repositories
+//! - A real Git-checkout backend: [`MaterializationIntent::Checkout`]
+//!   entries have no registered [`crate::materialize::Materializer`] yet,
+//!   so they're classified as [`Operation::Deferred`] and never executed —
+//!   #110 registers a `CheckoutMaterializer` to change that, without this
+//!   module changing. `Overlay::apply` still clones git repositories
 //!   through the existing, separate `actions::git::clone_repositories`,
 //!   entirely orthogonal to this module.
 //! - Materialization-rule migrations (symlink ↔ checkout, file-level ↔
@@ -46,7 +53,7 @@
 //! - `status`/`diff`/`unapply` commands themselves — #12/#109/#64. This
 //!   module only makes `Plan` reusable for them.
 
-mod actual;
+pub(crate) mod actual;
 mod reconcile;
 mod step;
 

--- a/src/plan/reconcile.rs
+++ b/src/plan/reconcile.rs
@@ -4,13 +4,11 @@ use std::sync::LazyLock;
 use anyhow::{Context as AnyhowContext, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 
-use crate::actions::fs::EnsureDirLink;
-use crate::actions::{EnsureDir, EnsureLink, EnsureSymlink};
-use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent, Provenance};
-use crate::exec::{Action, Ctx};
+use crate::desired::DesiredTree;
+use crate::exec::Ctx;
+use crate::materialize::MaterializerRegistry;
 use crate::ui::style;
 
-use super::actual::{self, ActualState};
 use super::step::{Operation, PlanStep};
 
 static SPINNER_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
@@ -20,22 +18,32 @@ static SPINNER_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
 });
 
 /// The reconciliation plan for a [`DesiredTree`]: one [`PlanStep`] per
-/// [`DesiredEntry`], classified against actual filesystem state.
+/// [`DesiredEntry`], classified against actual state by whichever
+/// [`crate::materialize::Materializer`] owns its intent.
 ///
 /// Building a plan never touches the filesystem beyond read-only inspection
-/// (see [`actual::inspect`]); only [`Plan::execute`] mutates anything, and it
-/// still honors `ctx.dry_run` exactly like every `Action` already does.
+/// (see [`Materializer::classify`](crate::materialize::Materializer::classify));
+/// only [`Plan::execute`] mutates anything, and it still honors `ctx.dry_run`
+/// exactly like every `Action` already does.
 #[derive(Debug, Clone, Default)]
 pub struct Plan {
     steps: Vec<PlanStep>,
 }
 
 impl Plan {
-    /// Classify every entry in `desired` against current filesystem state.
+    /// Classify every entry in `desired` against current state, asking the
+    /// registered [`Materializer`](crate::materialize::Materializer) that
+    /// owns each entry's intent. An intent no backend claims yet (today,
+    /// only [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout))
+    /// classifies as [`Operation::Deferred`].
     pub fn build(desired: &DesiredTree) -> Result<Self> {
+        let registry = MaterializerRegistry::default();
         let mut steps = Vec::with_capacity(desired.len());
         for entry in desired.entries() {
-            let operation = classify(entry)?;
+            let operation = match registry.find(&entry.intent) {
+                Some(materializer) => materializer.classify(entry)?,
+                None => Operation::Deferred,
+            };
             steps.push(PlanStep {
                 entry: entry.clone(),
                 operation,
@@ -66,8 +74,8 @@ impl Plan {
     /// deterministic order (`DesiredTree` sorts entries by target path, so
     /// a directory's entry always precedes anything nested under it).
     /// `Noop`/`Deferred` steps are skipped — the former because there's
-    /// nothing to do, the latter because [`MaterializationIntent::Checkout`]
-    /// isn't materializable yet (#108/#110).
+    /// nothing to do, the latter because no backend claims that intent yet
+    /// (today, only [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout) — #110).
     pub async fn execute(&self, ctx: Ctx) -> Result<()> {
         let has_actionable = self
             .steps
@@ -77,6 +85,7 @@ impl Plan {
             return Ok(());
         }
 
+        let registry = MaterializerRegistry::default();
         let progress = ProgressBar::new_spinner()
             .with_style(SPINNER_STYLE.clone())
             .with_message("");
@@ -91,10 +100,18 @@ impl Plan {
             }
             progress.set_message(format!("{step}"));
 
-            let action = build_action(ctx.clone(), &step.entry);
-            action.execute(ctx.clone()).await.with_context(|| {
-                format!("failed to reconcile '{}'", step.entry.target.display())
+            let materializer = registry.find(&step.entry.intent).with_context(|| {
+                format!(
+                    "no materializer registered for '{}'",
+                    step.entry.target.display()
+                )
             })?;
+            materializer
+                .materialize(ctx.clone(), step)
+                .await
+                .with_context(|| {
+                    format!("failed to reconcile '{}'", step.entry.target.display())
+                })?;
         }
 
         progress.finish_and_clear();
@@ -145,84 +162,9 @@ impl fmt::Display for Plan {
     }
 }
 
-/// Classify a single entry against current filesystem state. Read-only.
-fn classify(entry: &DesiredEntry) -> Result<Operation> {
-    match &entry.intent {
-        MaterializationIntent::Directory => {
-            let actual = actual::inspect(&entry.target)?;
-            Ok(match actual {
-                ActualState::Missing => Operation::Create,
-                ActualState::Directory => Operation::Noop,
-                other => Operation::Conflict { current: other },
-            })
-        }
-        MaterializationIntent::SymlinkFile { source, .. }
-        | MaterializationIntent::SymlinkDirectory { source, .. } => {
-            let actual = actual::inspect(&entry.target)?;
-            Ok(match actual {
-                ActualState::Missing => Operation::Create,
-                ActualState::Symlink { ref points_to } if points_to == source => Operation::Noop,
-                other => Operation::Conflict { current: other },
-            })
-        }
-        MaterializationIntent::Checkout => Ok(Operation::Deferred),
-    }
-}
-
-/// Translate an entry into the existing, tested `Action` that materializes
-/// it — the single place that knows about concrete `actions::fs`/
-/// `actions::symlink` types (see [`super::step::Operation`]'s doc comment:
-/// #108 replaces this with a registered `Materializer` lookup).
-///
-/// Dispatches on `provenance`, not just `intent`, because two different
-/// existing actions handle symlinks with different conflict semantics:
-/// regular per-file overlay entries go through `EnsureLink`/`EnsureDirLink`
-/// (interactive skip/overwrite/absorb/diff resolution, ADR-006), while
-/// `.link.*` sidecar entries go through `EnsureSymlink` (unconditional
-/// overwrite, and the only one of the two that supports hard links).
-fn build_action(ctx: Ctx, entry: &DesiredEntry) -> Box<dyn Action> {
-    let is_sidecar = matches!(entry.provenance, Provenance::SymlinkSidecar { .. });
-
-    match &entry.intent {
-        MaterializationIntent::Directory => Box::new(EnsureDir::new(entry.target.clone())),
-        MaterializationIntent::SymlinkFile { source, link_type } => {
-            if is_sidecar {
-                Box::new(EnsureSymlink::new(
-                    source.clone(),
-                    entry.target.clone(),
-                    link_type.clone(),
-                    false,
-                ))
-            } else {
-                Box::new(EnsureLink::new(ctx, source.clone(), entry.target.clone()))
-            }
-        }
-        MaterializationIntent::SymlinkDirectory { source, link_type } => {
-            if is_sidecar {
-                Box::new(EnsureSymlink::new(
-                    source.clone(),
-                    entry.target.clone(),
-                    link_type.clone(),
-                    true,
-                ))
-            } else {
-                Box::new(EnsureDirLink::new(
-                    ctx,
-                    source.clone(),
-                    entry.target.clone(),
-                ))
-            }
-        }
-        MaterializationIntent::Checkout => {
-            unreachable!("Checkout entries are always Operation::Deferred and never executed")
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::actions::symlink::LinkType;
     use crate::exec::Context;
     use crate::overlays::{Overlay, Repository};
     use assert_fs::TempDir;
@@ -489,40 +431,5 @@ mod tests {
         // Hard links are real files, not symlinks.
         assert!(!target.is_symlink());
         assert_eq!(fs::read_to_string(&target).unwrap(), "hard");
-    }
-
-    #[test]
-    fn build_action_directory() {
-        let entry = DesiredEntry {
-            target: PathBuf::from("/tmp/does-not-matter"),
-            provenance: Provenance::Overlay {
-                overlay: "ov".to_string(),
-                source: PathBuf::from("/repo/ov"),
-            },
-            intent: MaterializationIntent::Directory,
-        };
-        let ctx = Context::builder().build();
-        let action = build_action(ctx, &entry);
-        assert!(format!("{action}").contains("create directory:"));
-    }
-
-    #[test]
-    fn build_action_symlink_sidecar_uses_ensure_symlink() {
-        let entry = DesiredEntry {
-            target: PathBuf::from("/tmp/link"),
-            provenance: Provenance::SymlinkSidecar {
-                overlay: "ov".to_string(),
-                config: PathBuf::from("/repo/ov/x.link.toml"),
-                template: "/opt/x".to_string(),
-                resolved: PathBuf::from("/opt/x"),
-            },
-            intent: MaterializationIntent::SymlinkFile {
-                source: PathBuf::from("/opt/x"),
-                link_type: LinkType::Soft,
-            },
-        };
-        let ctx = Context::builder().build();
-        let action = build_action(ctx, &entry);
-        assert!(format!("{action}").contains("symlink"));
     }
 }

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -9,17 +9,17 @@ use super::actual::ActualState;
 /// What a single [`PlanStep`] needs to do to reconcile actual state with
 /// [`DesiredEntry`] intent.
 ///
-/// Deliberately a small, closed set today. Two extension points this issue
-/// is asked to leave open, without implementing either yet:
+/// Deliberately a small, closed set today. One extension point this issue
+/// is asked to leave open, without implementing it yet:
 ///
 /// - #113 will add rule-change transitions (symlink ↔ checkout, file-level
 ///   ↔ directory-level symlink) as new variants here (e.g. a future
 ///   `Migrate`) rather than requiring a different `Plan`/[`PlanStep`] shape.
-/// - #108 will replace [`super::Plan::execute`]'s direct dispatch on
-///   [`MaterializationIntent`] (the only place that knows about concrete
-///   `actions::fs`/`actions::symlink` types) with a lookup into a
-///   registered `Materializer` per intent. `Operation` itself doesn't need
-///   to change for that.
+///
+/// #108 already replaced [`super::Plan::execute`]'s direct dispatch on
+/// [`MaterializationIntent`] with a lookup into a registered
+/// [`crate::materialize::Materializer`] per intent — `Operation` itself
+/// didn't need to change for that.
 #[derive(Debug, Clone)]
 pub enum Operation {
     /// Target is missing; safe to materialize.
@@ -28,10 +28,11 @@ pub enum Operation {
     Noop,
     /// Target exists and does not match the desired intent.
     Conflict { current: ActualState },
-    /// Not yet materializable ([`MaterializationIntent::Checkout`] —
-    /// #108/#110 own turning this into a real checkout/worktree). Carried
-    /// so a plan preview can still report on it; [`super::Plan::execute`]
-    /// never acts on it.
+    /// No registered [`crate::materialize::Materializer`] claims this
+    /// entry's intent yet (today, only
+    /// [`MaterializationIntent::Checkout`] — #110 owns turning this into a
+    /// real checkout/worktree). Carried so a plan preview can still report
+    /// on it; [`super::Plan::execute`] never acts on it.
     Deferred,
 }
 
@@ -128,7 +129,7 @@ impl fmt::Display for PlanStep {
                 emojis::THREAD,
                 style::white("checkout:"),
                 target,
-                style::white("git materialization not yet supported, see #108/#110"),
+                style::white("git materialization not yet supported, see #110"),
             ),
             // `Directory`/`SymlinkFile`/`SymlinkDirectory` never produce
             // `Deferred` (only `Checkout` does, handled above) — unreachable
@@ -243,6 +244,6 @@ mod tests {
         };
         let s = format!("{step}");
         assert!(s.contains("checkout:"));
-        assert!(s.contains("#108/#110"));
+        assert!(s.contains("#110"));
     }
 }


### PR DESCRIPTION
Introduces the `Materializer` abstraction between `Plan` and the filesystem, so symlink and (eventually) Git-checkout materialization are two backends of the same `DesiredTree` → `Plan` → materialize pipeline.

`Plan::execute` used to hardcode a pair of free functions (`classify`/`build_action`) that pattern-matched directly on `MaterializationIntent`/`Provenance` and called into `actions::fs`/`actions::symlink`. This moves that logic behind a `Materializer` trait (owning both read-only actual-state inspection and execution) and a small `MaterializerRegistry`, so `Plan` no longer knows about concrete action types, or about Git, at all.

`SymlinkMaterializer` is a pure move of the previous logic — no observable behavior change. `MaterializationIntent::Checkout` still has no registered backend (falls back to `Operation::Deferred`, same as before); #110 will register a `CheckoutMaterializer` to turn it into a real Git worktree/checkout backend without `Plan` changing.

ADR-012 documents the decision, amending ADR-011.

Closes #108
