### PR TITLE
feat(status): derive overlay status from the DesiredTree/Plan model

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,9 +72,9 @@ pub enum Commands {
 
     #[clap(
         name = "status",
-        about = "Get the current repository/directory overlays status"
+        about = "Show the reconciliation status of overlays against actual state"
     )]
-    Status,
+    Status(status::Params),
 }
 
 impl CLI {
@@ -113,8 +113,8 @@ pub async fn main() -> Result<()> {
         Some(Commands::Show(ref opt)) => {
             show::execute(&args, opt).await?;
         }
-        Some(Commands::Status) => {
-            status::execute(&args).await?;
+        Some(Commands::Status(ref opt)) => {
+            status::execute(&args, opt).await?;
         }
         None => {
             use clap::CommandFactory;
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn cli_status_subcommand() {
         let args = CLI::parse_from(["over", "status"]);
-        assert!(matches!(args.cmd, Some(Commands::Status)));
+        assert!(matches!(args.cmd, Some(Commands::Status(_))));
     }
 
     #[test]

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,38 +1,97 @@
-use crate::cli::CLI;
-use crate::overlays::Repository;
-use crate::ui::style;
-use crate::utils::short_path;
-use anyhow::Result;
+use std::path::{Path, PathBuf};
 
-pub async fn execute(cli: &CLI) -> Result<()> {
+use anyhow::{Result, anyhow};
+use clap::Args;
+use dirs::home_dir;
+
+use crate::cli::CLI;
+use crate::desired::DesiredTree;
+use crate::exec::Context;
+use crate::overlays::{Overlay, Repository};
+use crate::status::Report;
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+#[derive(Args, Debug)]
+pub struct Params {
+    #[clap(help = "Name of the overlay to check (all overlays if omitted)")]
+    name: Option<String>,
+
+    #[clap(short, long, help = "The target root directory (~)")]
+    root: Option<PathBuf>,
+
+    #[clap(long, help = "Do not process uses")]
+    no_uses: bool,
+}
+
+pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
+    if cli.debug {
+        tracing::debug!(?cli, ?args, "CLI args");
+    }
+
     let home = cli.resolve_home()?;
     let repo = Repository::new(home);
+    let root = args
+        .root
+        .clone()
+        .or_else(home_dir)
+        .ok_or_else(|| anyhow!("could not determine home directory"))?;
+
+    let overlays = match &args.name {
+        Some(name) => vec![repo.get(name)?],
+        None => repo.overlays()?,
+    };
+
+    if overlays.is_empty() {
+        println!("No overlays found.");
+        return Ok(());
+    }
+
+    for overlay in &overlays {
+        print_overlay_status(cli, &repo, &root, overlay, args.no_uses)?;
+    }
+
+    Ok(())
+}
+
+fn print_overlay_status(
+    cli: &CLI,
+    repo: &Repository,
+    root: &Path,
+    overlay: &Overlay,
+    no_uses: bool,
+) -> Result<()> {
+    let ctx = Context::builder()
+        .root(root.to_path_buf())
+        .repository(repo.clone())
+        .overlay(overlay.clone())
+        .no_uses(no_uses)
+        .build();
+    let target = overlay.resolve_target(&ctx)?;
+    let ctx = ctx.with_resolved_overlay(overlay.name.clone(), target.to_string_lossy().to_string());
+
+    // Full `uses` graph (not `build_own`): status reports on everything an
+    // overlay pulls in, exactly like `Overlay::apply` reconciles it.
+    let desired = DesiredTree::build(&ctx, overlay)?;
+    let report = Report::build(&desired)?;
 
     println!(
-        "{} {}",
-        style::white_b("Repository:"),
-        short_path(&repo.root.to_string_lossy()),
+        "{} {} {} {} {}",
+        emojis::PACKAGE,
+        style::white_b("Overlay"),
+        style::cyan(&overlay.name),
+        style::white_b("->"),
+        style::cyan(&short_path(&target.to_string_lossy())),
     );
+    println!("  {}", report.counts());
 
-    let overlays = repo.overlays()?;
-    if overlays.is_empty() {
-        println!("  No overlays found.");
-    } else {
-        println!("  {} overlay(s):", overlays.len(),);
-        for overlay in &overlays {
-            let desc = overlay.description.as_deref().unwrap_or("");
-            if desc.is_empty() {
-                println!("    {} -> {}", style::cyan(&overlay.name), overlay.target);
-            } else {
-                println!(
-                    "    {} -> {} ({})",
-                    style::cyan(&overlay.name),
-                    overlay.target,
-                    desc,
-                );
-            }
+    for entry_status in report.entries() {
+        if cli.verbose || entry_status.status.needs_attention() {
+            println!("  {entry_status}");
         }
     }
+    println!();
+
     Ok(())
 }
 
@@ -40,6 +99,7 @@ pub async fn execute(cli: &CLI) -> Result<()> {
 mod tests {
     use super::*;
     use assert_fs::TempDir;
+    use assert_fs::prelude::*;
     use clap::Parser;
     use std::fs;
     use std::path::PathBuf;
@@ -48,58 +108,97 @@ mod tests {
         CLI::parse_from(vec!["over", "--home", home.to_str().unwrap()])
     }
 
+    fn params(name: Option<&str>, root: PathBuf) -> Params {
+        Params {
+            name: name.map(String::from),
+            root: Some(root),
+            no_uses: false,
+        }
+    }
+
     #[tokio::test]
     async fn status_empty_repository() {
         let tmp = TempDir::new().unwrap();
         let cli = make_cli(tmp.path().to_path_buf());
-        let result = execute(&cli).await;
+        let result = execute(&cli, &params(None, tmp.path().to_path_buf())).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn status_single_overlay_no_description() {
+    async fn status_missing_overlay_target_reports_missing() {
         let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
         let ov = tmp.path().join("myoverlay");
         fs::create_dir_all(&ov).unwrap();
-        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~/sub\"").unwrap();
 
         let cli = make_cli(tmp.path().to_path_buf());
-        let result = execute(&cli).await;
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+        assert!(!root.path().join("sub").exists());
+    }
+
+    #[tokio::test]
+    async fn status_named_overlay_only() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["first", "second"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(Some("first"), root.path().to_path_buf())).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn status_overlay_with_description() {
+    async fn status_unknown_overlay_errors() {
         let tmp = TempDir::new().unwrap();
-        let ov = tmp.path().join("described");
-        fs::create_dir_all(&ov).unwrap();
-        fs::write(
-            ov.join("over.toml"),
-            "target = \"~\"\ndescription = \"My described overlay\"",
-        )
-        .unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
 
         let cli = make_cli(tmp.path().to_path_buf());
-        let result = execute(&cli).await;
+        let result = execute(
+            &cli,
+            &params(Some("does-not-exist"), root.path().to_path_buf()),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn status_conflicting_file_is_reported() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("conflicted");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        fs::write(ov.join("file.txt"), "overlay").unwrap();
+        fs::write(root.path().join("file.txt"), "existing").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn status_multiple_overlays() {
         let tmp = TempDir::new().unwrap();
-        for (name, has_desc) in [("first", true), ("second", false), ("third", true)] {
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["alpha", "beta", "gamma"] {
             let ov = tmp.path().join(name);
             fs::create_dir_all(&ov).unwrap();
-            let content = if has_desc {
-                format!("target = \"~\"\ndescription = \"{}\"", name)
-            } else {
-                "target = \"~\"".to_string()
-            };
-            fs::write(ov.join("over.toml"), content).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
         }
 
         let cli = make_cli(tmp.path().to_path_buf());
-        let result = execute(&cli).await;
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
         assert!(result.is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod lint;
 pub mod materialize;
 pub mod overlays;
 pub mod plan;
+pub mod status;
 pub mod ui;
 pub mod xdg;
 

--- a/src/status/git.rs
+++ b/src/status/git.rs
@@ -1,0 +1,445 @@
+//! Git checkout status (#12): inspects the actual git repository/worktree
+//! on disk for [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout)
+//! entries, reusing git's own semantics (`repo.state()`, `repo.statuses()`,
+//! `repo.graph_ahead_behind()`) rather than reimplementing clean/dirty/
+//! ahead/behind/diverged detection.
+//!
+//! No [`crate::materialize::Materializer`] claims `Checkout` yet (#110 owns
+//! that), so this only ever *reads* whatever `actions::git::clone_repositories`
+//! (called directly by `Overlay::apply`, outside the `Plan`/`Materializer`
+//! model) already put on disk.
+
+use std::path::Path;
+
+use anyhow::Result;
+use git2::{Branch, Repository, RepositoryState};
+
+use crate::desired::{DesiredEntry, Provenance};
+
+use super::Status;
+
+/// Inspect the git state behind a `Provenance::Git` entry.
+///
+/// Only ever called for entries carrying
+/// [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout),
+/// which `DesiredTree::build`/`build_own` only ever pair with
+/// `Provenance::Git`.
+pub fn inspect(entry: &DesiredEntry) -> Result<Status> {
+    let Provenance::Git { config, .. } = &entry.provenance else {
+        unreachable!(
+            "only Provenance::Git entries carry MaterializationIntent::Checkout \
+             (see desired::tree::collect_own_entries)"
+        );
+    };
+
+    let is_bare = config.worktree || config.worktrees.is_some();
+    if !is_bare {
+        return inspect_checkout(&entry.target);
+    }
+
+    // Bare + worktree(s) (mirrors `actions::git::ensure_worktrees`): the
+    // bare repo itself has no working tree to report on, so aggregate
+    // every configured worktree's status instead. `DesiredTree` only
+    // carries one entry per git map path today, so we reduce to a single
+    // `Status` by severity — finer per-worktree reporting is a natural
+    // follow-up once #110 gives `Checkout` its own entry per worktree.
+    let bare_path = entry.target.join(".git");
+    if !bare_path.exists() {
+        return Ok(Status::Missing);
+    }
+    let repo = match Repository::open_bare(&bare_path) {
+        Ok(r) => r,
+        Err(_) => return Ok(Status::Broken),
+    };
+
+    let mut worst: Option<Status> = None;
+    // `StringArray::iter()` yields `Result<Option<&str>, Error>` (non-UTF8
+    // names surface as `Ok(None)`, invalid arrays as `Err`); the double
+    // `flatten()` discards both — worktree names are always plain UTF-8
+    // in practice, and a corrupt entry here shouldn't fail the whole
+    // aggregation.
+    for name in repo.worktrees()?.iter().flatten().flatten() {
+        let wt_path = entry.target.join(name);
+        if !wt_path.exists() {
+            continue;
+        }
+        let status = inspect_checkout(&wt_path)?;
+        worst = Some(match worst {
+            Some(current) => merge(current, status),
+            None => status,
+        });
+    }
+    // No configured worktree materialized on disk yet: the bare repo
+    // exists, but there's nothing to report status *of* — treat the same
+    // as a non-worktree checkout that hasn't been cloned.
+    Ok(worst.unwrap_or(Status::Missing))
+}
+
+/// Inspect a single plain (or worktree) checkout directory. Worktree `.git`
+/// *files* (not directories) redirecting to the shared bare repo are
+/// followed transparently by `Repository::open`, so this same logic covers
+/// both plain and worktree checkouts.
+fn inspect_checkout(path: &Path) -> Result<Status> {
+    if !path.exists() {
+        return Ok(Status::Missing);
+    }
+
+    let repo = match Repository::open(path) {
+        Ok(r) => r,
+        // Something occupies the path but it isn't a valid git repo —
+        // e.g. a leftover plain directory, or a corrupted checkout.
+        Err(_) => return Ok(Status::Broken),
+    };
+
+    // A merge/rebase/cherry-pick in progress takes priority over
+    // dirty/ahead/behind — git's own semantics, not reimplemented here.
+    if repo.state() != RepositoryState::Clean {
+        return Ok(Status::Conflict);
+    }
+
+    if is_dirty(&repo)? {
+        return Ok(Status::Modified);
+    }
+
+    Ok(match ahead_behind(&repo)? {
+        None | Some((0, 0)) => Status::Applied,
+        Some((ahead, 0)) => Status::Ahead(ahead),
+        Some((0, behind)) => Status::Behind(behind),
+        Some((ahead, behind)) => Status::Diverged { ahead, behind },
+    })
+}
+
+/// Whether the working tree has uncommitted changes (tracked or
+/// untracked, ignored files excluded).
+fn is_dirty(repo: &Repository) -> Result<bool> {
+    let mut opts = git2::StatusOptions::new();
+    opts.include_ignored(false).include_untracked(true);
+    Ok(!repo.statuses(Some(&mut opts))?.is_empty())
+}
+
+/// Ahead/behind counts of `HEAD` against its upstream tracking branch.
+/// `None` when `HEAD` is detached or has no configured upstream — neither
+/// is an error, just nothing to compare against.
+fn ahead_behind(repo: &Repository) -> Result<Option<(usize, usize)>> {
+    let head = repo.head()?;
+    if !head.is_branch() {
+        return Ok(None);
+    }
+    let Some(local_oid) = head.target() else {
+        return Ok(None);
+    };
+
+    let branch = Branch::wrap(head);
+    let Ok(upstream) = branch.upstream() else {
+        return Ok(None);
+    };
+    let Some(upstream_oid) = upstream.get().target() else {
+        return Ok(None);
+    };
+
+    let (ahead, behind) = repo.graph_ahead_behind(local_oid, upstream_oid)?;
+    Ok(Some((ahead, behind)))
+}
+
+/// Reduce two statuses to the one that most urgently needs attention,
+/// used when aggregating multiple worktrees behind a single `DesiredEntry`.
+fn merge(a: Status, b: Status) -> Status {
+    if severity(&b) > severity(&a) { b } else { a }
+}
+
+/// Higher means more urgent to surface when aggregating statuses.
+fn severity(status: &Status) -> u8 {
+    match status {
+        Status::Applied => 0,
+        Status::Ahead(_) => 1,
+        Status::Behind(_) => 2,
+        Status::Diverged { .. } => 3,
+        Status::Modified => 4,
+        Status::Missing => 5,
+        Status::Broken => 6,
+        Status::Conflict => 7,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::git::config::GitRepoConfig;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use git2::Signature;
+    use std::collections::HashMap;
+    use std::fs;
+
+    fn git_config(
+        worktree: bool,
+        worktrees: Option<HashMap<String, crate::actions::git::config::WorktreeEntry>>,
+    ) -> GitRepoConfig {
+        GitRepoConfig {
+            url: String::new(),
+            branch: None,
+            tag: None,
+            rev: None,
+            recurse_submodules: false,
+            worktree,
+            per_worktree_config: false,
+            worktrees,
+            remotes: None,
+            config: None,
+            worktree_config: None,
+        }
+    }
+
+    fn entry(target: std::path::PathBuf, config: GitRepoConfig) -> DesiredEntry {
+        DesiredEntry {
+            target,
+            provenance: Provenance::Git {
+                overlay: "ov".to_string(),
+                repo_key: ".".to_string(),
+                config: Box::new(config),
+            },
+            intent: crate::desired::MaterializationIntent::Checkout,
+        }
+    }
+
+    /// Init a repo with a committer identity and one commit, so `head()`
+    /// resolves and `graph_ahead_behind` has something to compare.
+    fn init_committed_repo(path: &std::path::Path) -> Repository {
+        let repo = Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        {
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn missing_path_is_missing() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("does-not-exist");
+        let e = entry(target, git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Missing);
+    }
+
+    #[test]
+    fn non_git_directory_is_broken() {
+        let td = TempDir::new().unwrap();
+        let target = td.child("plain");
+        target.create_dir_all().unwrap();
+        let e = entry(target.path().to_path_buf(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Broken);
+    }
+
+    #[test]
+    fn clean_checkout_with_no_upstream_is_applied() {
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        let e = entry(td.path().to_path_buf(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Applied);
+    }
+
+    #[test]
+    fn dirty_checkout_is_modified() {
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        fs::write(td.path().join("README.md"), "changed").unwrap();
+        let e = entry(td.path().to_path_buf(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Modified);
+    }
+
+    #[test]
+    fn untracked_file_is_modified() {
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        fs::write(td.path().join("new.txt"), "new").unwrap();
+        let e = entry(td.path().to_path_buf(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Modified);
+    }
+
+    #[test]
+    fn merge_in_progress_is_conflict() {
+        let td = TempDir::new().unwrap();
+        let repo = init_committed_repo(td.path());
+        // `repo.state()` reports non-Clean purely from the presence of
+        // `MERGE_HEAD` — no need to actually drive a conflicting merge.
+        let head_oid = repo.head().unwrap().target().unwrap();
+        fs::write(repo.path().join("MERGE_HEAD"), head_oid.to_string()).unwrap();
+        let e = entry(td.path().to_path_buf(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Conflict);
+    }
+
+    #[test]
+    fn ahead_behind_and_diverged_are_detected() {
+        let remote_td = TempDir::new().unwrap();
+        init_committed_repo(remote_td.path());
+
+        let local_td = TempDir::new().unwrap();
+        let local_path = local_td.path().join("local");
+        let local_repo = git2::build::RepoBuilder::new()
+            .clone(remote_td.path().to_str().unwrap(), &local_path)
+            .unwrap();
+        // Set up `main`'s upstream to the origin tracking branch cloning
+        // already created.
+        {
+            let mut branch = local_repo
+                .find_branch("main", git2::BranchType::Local)
+                .unwrap();
+            branch.set_upstream(Some("origin/main")).unwrap();
+        }
+
+        let e = entry(local_path.clone(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Applied);
+
+        // Ahead: commit locally without pushing.
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(local_path.join("local.txt"), "local").unwrap();
+        {
+            let mut index = local_repo.index().unwrap();
+            index
+                .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+                .unwrap();
+            index.write().unwrap();
+            let tree_id = index.write_tree().unwrap();
+            let tree = local_repo.find_tree(tree_id).unwrap();
+            let head = local_repo.head().unwrap().peel_to_commit().unwrap();
+            local_repo
+                .commit(Some("HEAD"), &sig, &sig, "local commit", &tree, &[&head])
+                .unwrap();
+        }
+        assert_eq!(inspect(&e).unwrap(), Status::Ahead(1));
+
+        // Behind: advance the remote, fetch it into `origin/main`, but
+        // reset the local `main` back to the shared ancestor (undoing the
+        // "ahead" commit above) so only "behind" is in play.
+        let remote_repo = Repository::open(remote_td.path()).unwrap();
+        let shared_ancestor = remote_repo.head().unwrap().peel_to_commit().unwrap();
+        fs::write(remote_td.path().join("remote.txt"), "remote").unwrap();
+        {
+            let mut index = remote_repo.index().unwrap();
+            index
+                .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+                .unwrap();
+            index.write().unwrap();
+            let tree_id = index.write_tree().unwrap();
+            let tree = remote_repo.find_tree(tree_id).unwrap();
+            remote_repo
+                .commit(
+                    Some("HEAD"),
+                    &sig,
+                    &sig,
+                    "remote commit",
+                    &tree,
+                    &[&shared_ancestor],
+                )
+                .unwrap();
+        }
+        local_repo
+            .find_remote("origin")
+            .unwrap()
+            .fetch(&["main"], None, None)
+            .unwrap();
+        // `shared_ancestor` belongs to `remote_repo`'s object database —
+        // look it up by id in `local_repo` (fetch above made it reachable
+        // there too) before using it as a reset/commit target.
+        let local_shared_ancestor = local_repo.find_commit(shared_ancestor.id()).unwrap();
+        // Hard reset (not just moving the ref) so the working tree and
+        // index drop `local.txt` too — otherwise it'd linger as an
+        // uncommitted addition and this would report `Modified` instead.
+        local_repo
+            .reset(
+                local_shared_ancestor.as_object(),
+                git2::ResetType::Hard,
+                None,
+            )
+            .unwrap();
+        assert_eq!(inspect(&e).unwrap(), Status::Behind(1));
+
+        // Diverged: local gets its own commit again on top of the shared
+        // ancestor, while remote is already one commit ahead.
+        fs::write(local_path.join("diverge.txt"), "diverge").unwrap();
+        {
+            let mut index = local_repo.index().unwrap();
+            index
+                .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+                .unwrap();
+            index.write().unwrap();
+            let tree_id = index.write_tree().unwrap();
+            let tree = local_repo.find_tree(tree_id).unwrap();
+            local_repo
+                .commit(
+                    Some("HEAD"),
+                    &sig,
+                    &sig,
+                    "diverging commit",
+                    &tree,
+                    &[&local_shared_ancestor],
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            inspect(&e).unwrap(),
+            Status::Diverged {
+                ahead: 1,
+                behind: 1
+            }
+        );
+    }
+
+    #[test]
+    fn bare_worktree_missing_is_missing() {
+        let td = TempDir::new().unwrap();
+        let e = entry(td.path().to_path_buf(), git_config(true, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Missing);
+    }
+
+    #[test]
+    fn bare_worktree_with_one_clean_worktree_is_applied() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+
+        let dest_td = TempDir::new().unwrap();
+        let bare_path = dest_td.path().join(".git");
+        let bare_repo = git2::build::RepoBuilder::new()
+            .bare(true)
+            .clone(source_td.path().to_str().unwrap(), &bare_path)
+            .unwrap();
+
+        let main_wt = dest_td.path().join("main");
+        // A bare clone already mirrors `refs/heads/*` from the source, so
+        // `main` typically exists as a local branch already — only
+        // create it from the remote-tracking ref as a fallback (mirrors
+        // `actions::git::create_worktree`'s own local-then-remote lookup).
+        let branch_ref = match bare_repo.find_branch("main", git2::BranchType::Local) {
+            Ok(branch) => branch.into_reference(),
+            Err(_) => {
+                let reference = bare_repo
+                    .find_reference("refs/remotes/origin/main")
+                    .unwrap();
+                let commit = reference.peel_to_commit().unwrap();
+                bare_repo
+                    .branch("main", &commit, false)
+                    .unwrap()
+                    .into_reference()
+            }
+        };
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(&branch_ref));
+        bare_repo.worktree("main", &main_wt, Some(&opts)).unwrap();
+
+        let e = entry(dest_td.path().to_path_buf(), git_config(true, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Applied);
+    }
+}

--- a/src/status/git.rs
+++ b/src/status/git.rs
@@ -405,41 +405,172 @@ mod tests {
         assert_eq!(inspect(&e).unwrap(), Status::Missing);
     }
 
+    /// Bare-clone `source` into `<dest>/.git` and add a `main` worktree at
+    /// `<dest>/main`, returning the bare `Repository` handle for further
+    /// setup. Shared by every bare+worktree test below.
+    fn clone_bare_with_main_worktree(
+        source: &std::path::Path,
+        dest: &std::path::Path,
+    ) -> Repository {
+        let bare_path = dest.join(".git");
+        let bare_repo = git2::build::RepoBuilder::new()
+            .bare(true)
+            .clone(source.to_str().unwrap(), &bare_path)
+            .unwrap();
+
+        let main_wt = dest.join("main");
+        {
+            // A bare clone already mirrors `refs/heads/*` from the source,
+            // so `main` typically exists as a local branch already — only
+            // create it from the remote-tracking ref as a fallback (mirrors
+            // `actions::git::create_worktree`'s own local-then-remote
+            // lookup). Scoped so `branch_ref`/`opts` (both borrow
+            // `bare_repo`) are dropped before it's returned below.
+            let branch_ref = match bare_repo.find_branch("main", git2::BranchType::Local) {
+                Ok(branch) => branch.into_reference(),
+                Err(_) => {
+                    let reference = bare_repo
+                        .find_reference("refs/remotes/origin/main")
+                        .unwrap();
+                    let commit = reference.peel_to_commit().unwrap();
+                    bare_repo
+                        .branch("main", &commit, false)
+                        .unwrap()
+                        .into_reference()
+                }
+            };
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(&branch_ref));
+            bare_repo.worktree("main", &main_wt, Some(&opts)).unwrap();
+        }
+        bare_repo
+    }
+
     #[test]
     fn bare_worktree_with_one_clean_worktree_is_applied() {
         let source_td = TempDir::new().unwrap();
         init_committed_repo(source_td.path());
-
         let dest_td = TempDir::new().unwrap();
-        let bare_path = dest_td.path().join(".git");
-        let bare_repo = git2::build::RepoBuilder::new()
-            .bare(true)
-            .clone(source_td.path().to_str().unwrap(), &bare_path)
-            .unwrap();
-
-        let main_wt = dest_td.path().join("main");
-        // A bare clone already mirrors `refs/heads/*` from the source, so
-        // `main` typically exists as a local branch already — only
-        // create it from the remote-tracking ref as a fallback (mirrors
-        // `actions::git::create_worktree`'s own local-then-remote lookup).
-        let branch_ref = match bare_repo.find_branch("main", git2::BranchType::Local) {
-            Ok(branch) => branch.into_reference(),
-            Err(_) => {
-                let reference = bare_repo
-                    .find_reference("refs/remotes/origin/main")
-                    .unwrap();
-                let commit = reference.peel_to_commit().unwrap();
-                bare_repo
-                    .branch("main", &commit, false)
-                    .unwrap()
-                    .into_reference()
-            }
-        };
-        let mut opts = git2::WorktreeAddOptions::new();
-        opts.reference(Some(&branch_ref));
-        bare_repo.worktree("main", &main_wt, Some(&opts)).unwrap();
+        clone_bare_with_main_worktree(source_td.path(), dest_td.path());
 
         let e = entry(dest_td.path().to_path_buf(), git_config(true, None));
         assert_eq!(inspect(&e).unwrap(), Status::Applied);
+    }
+
+    #[test]
+    fn bare_worktree_aggregates_across_multiple_worktrees() {
+        // Two worktrees, one clean and one dirty: the aggregation loop's
+        // second iteration must hit the `Some(current) => merge(...)`
+        // branch (the first only ever hits `None => status`), and the
+        // dirty one's higher severity should win regardless of iteration
+        // order.
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let bare_repo = clone_bare_with_main_worktree(source_td.path(), dest_td.path());
+
+        let second_wt = dest_td.path().join("second");
+        {
+            let head_commit = bare_repo
+                .find_reference("refs/heads/main")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap();
+            bare_repo.branch("second", &head_commit, false).unwrap();
+            let branch_ref = bare_repo
+                .find_branch("second", git2::BranchType::Local)
+                .unwrap()
+                .into_reference();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(&branch_ref));
+            bare_repo
+                .worktree("second", &second_wt, Some(&opts))
+                .unwrap();
+        }
+        fs::write(second_wt.join("README.md"), "uncommitted change").unwrap();
+
+        let e = entry(dest_td.path().to_path_buf(), git_config(true, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Modified);
+    }
+
+    #[test]
+    fn bare_worktree_metadata_without_directory_is_missing() {
+        // The bare repo still lists "main" as a worktree (its
+        // `.git/worktrees/main` metadata is untouched), but the actual
+        // checkout directory is gone — e.g. deleted by hand outside
+        // `over`. Every configured worktree is then skipped via
+        // `continue`, so nothing contributes to `worst` and the entry
+        // falls back to `Missing`, same as a never-cloned checkout.
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        clone_bare_with_main_worktree(source_td.path(), dest_td.path());
+        fs::remove_dir_all(dest_td.path().join("main")).unwrap();
+
+        let e = entry(dest_td.path().to_path_buf(), git_config(true, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Missing);
+    }
+
+    #[test]
+    fn bare_path_that_is_not_a_valid_repo_is_broken() {
+        // `<target>/.git` exists but is a plain file, not a bare
+        // repository — `Repository::open_bare` fails, which must not
+        // bubble up as an error but report `Broken` instead.
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join(".git"), "not a git repo").unwrap();
+
+        let e = entry(td.path().to_path_buf(), git_config(true, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Broken);
+    }
+
+    #[test]
+    fn detached_head_checkout_is_applied() {
+        // No branch to compare against an upstream — `ahead_behind`
+        // returns `None`, which is not an error, just "nothing to
+        // report", same as a clean checkout in sync with its upstream.
+        let td = TempDir::new().unwrap();
+        let repo = init_committed_repo(td.path());
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.set_head_detached(head_commit.id()).unwrap();
+
+        let e = entry(td.path().to_path_buf(), git_config(false, None));
+        assert_eq!(inspect(&e).unwrap(), Status::Applied);
+    }
+
+    #[test]
+    fn severity_orders_by_urgency() {
+        // Matches `severity`'s own ranking: Applied < Ahead < Behind <
+        // Diverged < Modified < Missing < Broken < Conflict.
+        let ordered = [
+            Status::Applied,
+            Status::Ahead(1),
+            Status::Behind(1),
+            Status::Diverged {
+                ahead: 1,
+                behind: 1,
+            },
+            Status::Modified,
+            Status::Missing,
+            Status::Broken,
+            Status::Conflict,
+        ];
+        for window in ordered.windows(2) {
+            assert!(
+                severity(&window[1]) > severity(&window[0]),
+                "{:?} should be more severe than {:?}",
+                window[1],
+                window[0],
+            );
+        }
+    }
+
+    #[test]
+    fn merge_keeps_the_more_severe_status() {
+        assert_eq!(merge(Status::Applied, Status::Modified), Status::Modified);
+        assert_eq!(merge(Status::Conflict, Status::Applied), Status::Conflict);
+        assert_eq!(
+            merge(Status::Ahead(1), Status::Behind(1)),
+            Status::Behind(1)
+        );
     }
 }

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -398,6 +398,148 @@ mod tests {
         );
     }
 
+    /// Exercise every `EntryStatus` `Display` arm directly — most of them
+    /// (`Applied`, `Modified`, `Broken`, `Ahead`, `Behind`, `Diverged`)
+    /// never print by default (`cli::status` only prints entries that
+    /// `needs_attention()`, and `Applied` never does), so a report built
+    /// through `Report::build` alone wouldn't reach them.
+    #[test]
+    fn entry_status_display_covers_every_status_variant() {
+        fn entry_status(status: Status) -> EntryStatus {
+            EntryStatus {
+                entry: DesiredEntry {
+                    target: std::path::PathBuf::from("/tmp/target"),
+                    provenance: crate::desired::Provenance::Overlay {
+                        overlay: "ov".to_string(),
+                        source: std::path::PathBuf::from("/repo/ov"),
+                    },
+                    intent: MaterializationIntent::Directory,
+                },
+                status,
+            }
+        }
+
+        assert!(format!("{}", entry_status(Status::Applied)).contains("applied:"));
+        assert!(format!("{}", entry_status(Status::Missing)).contains("missing:"));
+        assert!(format!("{}", entry_status(Status::Modified)).contains("modified:"));
+        assert!(format!("{}", entry_status(Status::Broken)).contains("broken:"));
+        assert!(format!("{}", entry_status(Status::Conflict)).contains("conflict:"));
+        let ahead = format!("{}", entry_status(Status::Ahead(1)));
+        assert!(ahead.contains("ahead:") && ahead.contains("1 commit ahead"));
+        let ahead_plural = format!("{}", entry_status(Status::Ahead(2)));
+        assert!(ahead_plural.contains("2 commits ahead"));
+        let behind = format!("{}", entry_status(Status::Behind(1)));
+        assert!(behind.contains("behind:") && behind.contains("1 commit behind"));
+        let behind_plural = format!("{}", entry_status(Status::Behind(3)));
+        assert!(behind_plural.contains("3 commits behind"));
+        let diverged = format!(
+            "{}",
+            entry_status(Status::Diverged {
+                ahead: 2,
+                behind: 3
+            })
+        );
+        assert!(diverged.contains("diverged:"));
+        assert!(diverged.contains("2 ahead, 3 behind"));
+    }
+
+    /// `Report::counts()` only increments a bucket when a matching status
+    /// is present — build a synthetic `Report` (private field, but tests
+    /// are a child module) covering every variant, since `Report::build`
+    /// alone never produces `Modified`/`Broken`/`Ahead`/`Behind`/`Diverged`
+    /// without a real git checkout on disk.
+    #[test]
+    fn counts_tallies_every_status_variant() {
+        fn entry_status(status: Status) -> EntryStatus {
+            EntryStatus {
+                entry: DesiredEntry {
+                    target: std::path::PathBuf::from("/tmp/target"),
+                    provenance: crate::desired::Provenance::Overlay {
+                        overlay: "ov".to_string(),
+                        source: std::path::PathBuf::from("/repo/ov"),
+                    },
+                    intent: MaterializationIntent::Directory,
+                },
+                status,
+            }
+        }
+
+        let report = Report {
+            entries: vec![
+                entry_status(Status::Applied),
+                entry_status(Status::Missing),
+                entry_status(Status::Modified),
+                entry_status(Status::Broken),
+                entry_status(Status::Conflict),
+                entry_status(Status::Ahead(1)),
+                entry_status(Status::Behind(1)),
+                entry_status(Status::Diverged {
+                    ahead: 1,
+                    behind: 1,
+                }),
+            ],
+        };
+        let counts = report.counts();
+        assert_eq!(
+            counts,
+            Counts {
+                applied: 1,
+                missing: 1,
+                modified: 1,
+                broken: 1,
+                conflict: 1,
+                ahead: 1,
+                behind: 1,
+                diverged: 1,
+            }
+        );
+        assert!(report.has_issues());
+    }
+
+    #[test]
+    fn dangling_soft_symlink_directory_noop_is_broken() {
+        // Same as `dangling_soft_symlink_noop_is_broken` but for the
+        // `SymlinkDirectory` alternative of `classify_noop`'s pattern.
+        let intent = MaterializationIntent::SymlinkDirectory {
+            source: std::path::PathBuf::from("/does/not/exist/anymore"),
+            link_type: LinkType::Soft,
+        };
+        assert_eq!(classify_noop(&intent), Status::Broken);
+    }
+
+    #[rstest]
+    fn git_checkout_entry_dispatches_to_git_inspect() {
+        // Not yet cloned: `DesiredTree` only ever describes the checkout
+        // (`Overlay::apply` clones it separately, outside `Plan`), so
+        // `Report::build` should route it through `git::inspect` and get
+        // `Missing` back, exercising the `Checkout` arm of its match.
+        // Uses a subpath (not the overlay's own target root, which the
+        // fresh `TempDir` already exists as — that would report `Broken`
+        // instead, a real directory occupying a git-managed path).
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"\n[git]\n\".config/nvim\" = \"https://example.com/nvim.git\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let checkout_status = report
+            .entries()
+            .iter()
+            .find(|e| matches!(e.entry.intent, MaterializationIntent::Checkout))
+            .unwrap();
+        assert_eq!(checkout_status.status, Status::Missing);
+    }
+
     #[test]
     fn counts_display_lists_every_status() {
         let counts = Counts {

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -1,0 +1,423 @@
+//! Overlay status (#12): derives per-entry reconciliation status from the
+//! same [`DesiredTree`]/[`Plan`] model [`crate::overlays::Overlay::apply`]
+//! uses (#107/#13), plus git working-tree state for
+//! [`MaterializationIntent::Checkout`] entries (see [`git`]).
+//!
+//! Deliberately read-only: building a [`Report`] never mutates the
+//! filesystem or any git repository, exactly like [`Plan::build`].
+//! Persistent metadata (`$XDG_STATE_HOME/over`) is not involved — status
+//! must stay fully reconstructible from disk/git/config alone, per the
+//! issue's own requirement.
+
+pub mod git;
+
+use std::fmt;
+
+use anyhow::Result;
+
+use crate::actions::symlink::LinkType;
+use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
+use crate::plan::{Operation, Plan};
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+/// The status of a single [`DesiredEntry`] — a closed set covering every
+/// entry kind uniformly (directories, symlinks, and git checkouts alike),
+/// matching the minimum set called for by #12.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    /// Target matches desired intent — nothing to do.
+    Applied,
+    /// Target doesn't exist yet.
+    Missing,
+    /// A git checkout has uncommitted changes.
+    Modified,
+    /// A dangling soft symlink (correctly pointed, but its source
+    /// disappeared), or a checkout path that isn't a valid git repo.
+    Broken,
+    /// Target exists and doesn't match desired intent, or a git checkout
+    /// has a merge/rebase/cherry-pick in progress.
+    Conflict,
+    /// A git checkout is ahead of its upstream by this many commits.
+    Ahead(usize),
+    /// A git checkout is behind its upstream by this many commits.
+    Behind(usize),
+    /// A git checkout has diverged from its upstream.
+    Diverged { ahead: usize, behind: usize },
+}
+
+impl Status {
+    /// Whether this status needs attention — used by [`Report::has_issues`]
+    /// and by the CLI to decide what to show without `--verbose`.
+    pub fn needs_attention(&self) -> bool {
+        !matches!(self, Status::Applied)
+    }
+}
+
+/// One [`DesiredEntry`] paired with its reconciliation [`Status`].
+#[derive(Debug, Clone)]
+pub struct EntryStatus {
+    pub entry: DesiredEntry,
+    pub status: Status,
+}
+
+impl fmt::Display for EntryStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let target = short_path(&self.entry.target.to_string_lossy());
+        match &self.status {
+            Status::Applied => write!(
+                f,
+                "{} {} {}",
+                emojis::CHECKMARK,
+                style::white("applied:"),
+                target
+            ),
+            Status::Missing => write!(
+                f,
+                "{} {} {}",
+                emojis::CROSSMARK,
+                style::white("missing:"),
+                target
+            ),
+            Status::Modified => write!(
+                f,
+                "{} {} {}",
+                emojis::WARNING,
+                style::yellow("modified:"),
+                target
+            ),
+            Status::Broken => write!(
+                f,
+                "{} {} {}",
+                emojis::WARNING,
+                style::yellow("broken:"),
+                target
+            ),
+            Status::Conflict => write!(
+                f,
+                "{} {} {}",
+                emojis::WARNING,
+                style::yellow("conflict:"),
+                target
+            ),
+            Status::Ahead(n) => write!(
+                f,
+                "{} {} {} ({} commit{} ahead)",
+                emojis::THREAD,
+                style::white("ahead:"),
+                target,
+                n,
+                if *n == 1 { "" } else { "s" },
+            ),
+            Status::Behind(n) => write!(
+                f,
+                "{} {} {} ({} commit{} behind)",
+                emojis::THREAD,
+                style::white("behind:"),
+                target,
+                n,
+                if *n == 1 { "" } else { "s" },
+            ),
+            Status::Diverged { ahead, behind } => write!(
+                f,
+                "{} {} {} ({ahead} ahead, {behind} behind)",
+                emojis::WARNING,
+                style::yellow("diverged:"),
+                target,
+            ),
+        }
+    }
+}
+
+/// Per-`Status` counts of a [`Report`], in the same order `Status` is
+/// declared.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Counts {
+    pub applied: usize,
+    pub missing: usize,
+    pub modified: usize,
+    pub broken: usize,
+    pub conflict: usize,
+    pub ahead: usize,
+    pub behind: usize,
+    pub diverged: usize,
+}
+
+impl fmt::Display for Counts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} applied, {} missing, {} modified, {} broken, {} conflict(s), \
+             {} ahead, {} behind, {} diverged",
+            self.applied,
+            self.missing,
+            self.modified,
+            self.broken,
+            self.conflict,
+            self.ahead,
+            self.behind,
+            self.diverged,
+        )
+    }
+}
+
+/// The reconciliation status of a whole [`DesiredTree`]: one
+/// [`EntryStatus`] per [`DesiredEntry`].
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    entries: Vec<EntryStatus>,
+}
+
+impl Report {
+    /// Classify every entry in `desired` — [`Plan::build`] handles
+    /// directories/symlinks (never touching the filesystem beyond
+    /// read-only inspection), and [`git::inspect`] handles
+    /// [`MaterializationIntent::Checkout`] entries (the only ones `Plan`
+    /// leaves as [`Operation::Deferred`], since no
+    /// [`crate::materialize::Materializer`] claims that intent yet).
+    pub fn build(desired: &DesiredTree) -> Result<Self> {
+        let plan = Plan::build(desired)?;
+        let mut entries = Vec::with_capacity(plan.len());
+        for step in plan.steps() {
+            let status = match (&step.entry.intent, &step.operation) {
+                (MaterializationIntent::Checkout, _) => git::inspect(&step.entry)?,
+                (_, Operation::Create) => Status::Missing,
+                (_, Operation::Conflict { .. }) => Status::Conflict,
+                (intent, Operation::Noop) => classify_noop(intent),
+                (_, Operation::Deferred) => {
+                    unreachable!("only Checkout entries ever classify as Deferred")
+                }
+            };
+            entries.push(EntryStatus {
+                entry: step.entry.clone(),
+                status,
+            });
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn entries(&self) -> &[EntryStatus] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn counts(&self) -> Counts {
+        let mut counts = Counts::default();
+        for e in &self.entries {
+            match e.status {
+                Status::Applied => counts.applied += 1,
+                Status::Missing => counts.missing += 1,
+                Status::Modified => counts.modified += 1,
+                Status::Broken => counts.broken += 1,
+                Status::Conflict => counts.conflict += 1,
+                Status::Ahead(_) => counts.ahead += 1,
+                Status::Behind(_) => counts.behind += 1,
+                Status::Diverged { .. } => counts.diverged += 1,
+            }
+        }
+        counts
+    }
+
+    /// Whether anything in this report needs attention (everything except
+    /// `Applied`). Informational only — `over status` never fails the
+    /// process just because entries need attention, mirroring `git
+    /// status`.
+    pub fn has_issues(&self) -> bool {
+        self.entries.iter().any(|e| e.status.needs_attention())
+    }
+}
+
+/// Classify an [`Operation::Noop`] entry more precisely than "applied":
+/// a soft symlink that already points where desired but whose source has
+/// since disappeared is `Broken`, not `Applied`. Hard links keep their
+/// data independently of the source (the link *is* a second name for the
+/// same inode), and `Directory` has no such concept, so both stay
+/// `Applied`.
+fn classify_noop(intent: &MaterializationIntent) -> Status {
+    match intent {
+        MaterializationIntent::SymlinkFile { source, link_type }
+        | MaterializationIntent::SymlinkDirectory { source, link_type }
+            if *link_type == LinkType::Soft =>
+        {
+            if source.exists() {
+                Status::Applied
+            } else {
+                Status::Broken
+            }
+        }
+        _ => Status::Applied,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exec::Context;
+    use crate::overlays::Repository;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use rstest::rstest;
+    use std::fs;
+
+    fn repo_and_root() -> (TempDir, Repository) {
+        let td = TempDir::new().unwrap();
+        let repo = Repository::new(td.path().to_path_buf());
+        (td, repo)
+    }
+
+    #[rstest]
+    fn missing_target_reports_missing() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~/sub\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+
+        assert_eq!(report.entries().len(), 1);
+        assert_eq!(report.entries()[0].status, Status::Missing);
+        assert_eq!(report.counts().missing, 1);
+        assert!(report.has_issues());
+    }
+
+    #[tokio::test]
+    async fn applied_target_reports_applied() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        crate::plan::Plan::build(&desired)
+            .unwrap()
+            .execute(ctx.clone())
+            .await
+            .unwrap();
+
+        let desired2 = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        let file_status = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+        assert_eq!(file_status.status, Status::Applied);
+        assert_eq!(report.counts().missing, 0);
+        assert!(!report.has_issues());
+    }
+
+    #[rstest]
+    fn conflicting_file_reports_conflict() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("overlay").unwrap();
+        fs::write(td.path().join("file.txt"), "existing").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let file_status = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+        assert_eq!(file_status.status, Status::Conflict);
+        assert!(report.has_issues());
+    }
+
+    #[test]
+    fn dangling_soft_symlink_noop_is_broken() {
+        // The overlay source no longer exists on disk (deleted after the
+        // link was created) — `DesiredTree` itself won't ever produce this
+        // entry (its source vanished from `walk_overlay_tree`), so exercise
+        // `classify_noop` directly against the intent a stale `Plan::build`
+        // classification would still see as `Noop` (the on-disk symlink
+        // still points to the recorded `source` path).
+        let intent = MaterializationIntent::SymlinkFile {
+            source: std::path::PathBuf::from("/does/not/exist/anymore"),
+            link_type: LinkType::Soft,
+        };
+        assert_eq!(classify_noop(&intent), Status::Broken);
+    }
+
+    #[test]
+    fn empty_desired_tree_produces_empty_report() {
+        let report = Report::build(&DesiredTree::default()).unwrap();
+        assert!(report.is_empty());
+        assert!(!report.has_issues());
+    }
+
+    #[test]
+    fn hard_link_noop_is_always_applied_even_if_source_missing() {
+        let intent = MaterializationIntent::SymlinkFile {
+            source: std::path::PathBuf::from("/does/not/exist"),
+            link_type: LinkType::Hard,
+        };
+        assert_eq!(classify_noop(&intent), Status::Applied);
+    }
+
+    #[test]
+    fn directory_noop_is_always_applied() {
+        assert_eq!(
+            classify_noop(&MaterializationIntent::Directory),
+            Status::Applied
+        );
+    }
+
+    #[test]
+    fn counts_display_lists_every_status() {
+        let counts = Counts {
+            applied: 1,
+            missing: 2,
+            modified: 3,
+            broken: 4,
+            conflict: 5,
+            ahead: 6,
+            behind: 7,
+            diverged: 8,
+        };
+        let s = format!("{counts}");
+        assert!(s.contains("1 applied"));
+        assert!(s.contains("2 missing"));
+        assert!(s.contains("3 modified"));
+        assert!(s.contains("4 broken"));
+        assert!(s.contains("5 conflict(s)"));
+        assert!(s.contains("6 ahead"));
+        assert!(s.contains("7 behind"));
+        assert!(s.contains("8 diverged"));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -374,6 +374,22 @@ fn status_reports_conflict_for_existing_file() -> TestResult {
 }
 
 #[test]
+fn status_debug_output() -> TestResult {
+    let repo = setup_overlay_repo();
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .arg("--debug")
+        .args(["status", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stderr(contains("CLI args"));
+    Ok(())
+}
+
+#[test]
 fn status_unknown_overlay_fails() -> TestResult {
     let tmp = TempDir::new()?;
     Command::cargo_bin("over")?

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -312,6 +312,92 @@ fn lint_cycle_detection() -> TestResult {
     Ok(())
 }
 
+// ── status integration tests ─────────────────────────────────────────────
+
+#[test]
+fn status_reports_missing_before_apply() -> TestResult {
+    let repo = setup_overlay_repo();
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["status", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("missing"));
+    Ok(())
+}
+
+#[test]
+fn status_reports_applied_after_apply() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"content")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "dev", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["status", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("applied"));
+    Ok(())
+}
+
+#[test]
+fn status_reports_conflict_for_existing_file() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"overlay")?;
+    let root = TempDir::new()?;
+    fs::write(root.path().join("file.txt"), b"existing")?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["status", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("conflict"));
+    Ok(())
+}
+
+#[test]
+fn status_unknown_overlay_fails() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .args(["status", "does-not-exist"])
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[test]
+fn status_empty_repository_reports_no_overlays() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(contains("No overlays found"));
+    Ok(())
+}
+
 // ── show integration tests ──────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Rewrites `over status` around the same `DesiredTree`/`Plan` reconciliation model `apply` uses, instead of the previous "just list overlay names" behavior.

A new `status` module classifies every desired entry into one of `Applied`/`Missing`/`Modified`/`Broken`/`Conflict`/`Ahead`/`Behind`/`Diverged`:

- Directories and symlinks reuse `Plan`'s existing `Create`/`Noop`/`Conflict` classification, with a `Broken` refinement for dangling soft symlinks.
- Git-managed checkouts (`overlay.git`) get their status read directly from git (via `git2`): clean/dirty, merge/rebase-in-progress, and ahead/behind/diverged against the upstream branch — reusing git's own semantics rather than reimplementing them.

`over status [NAME]` now resolves the full `uses` graph (matching how `apply` reconciles it) and prints a per-overlay counts summary plus any entry needing attention (`--verbose` shows everything, including `applied` entries).

Closes #12
