### PR TITLE
feat(diff): add over diff command comparing desired and actual state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "serde",
+ "similar",
  "symlink",
  "tempfile",
  "termtree 1.0.0",
@@ -1556,6 +1557,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "similar"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
+dependencies = [
+ "bstr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ futures = "0.3"
 noyalib = { version = "0.0.28", features = ["compat-serde-yaml"] }
 which = "8.0"
 libz-sys = { version = "1.1", optional = true }
+similar = "3.2"
 
 [dependencies.clap]
 features = ["derive", "env", "unicode", "cargo", "color"]

--- a/docs/adr/013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md
+++ b/docs/adr/013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md
@@ -1,0 +1,74 @@
+# ADR-013: `diff` has its own taxonomy and uses `similar` for content diffs, amending ADR-011
+
+**Status:** accepted
+
+## Context
+
+ADR-011 introduced `Plan`/`ActualState` as the shared vocabulary `status`
+and `diff` (#12/#109) would both build on, "without re-deriving their own
+notion of what should be here and what already is". `status` (#12) landed
+first and defined `status::Status` — a closed, 8-variant enum (`Applied`,
+`Missing`, `Modified`, `Broken`, `Conflict`, `Ahead`, `Behind`, `Diverged`)
+answering one question: does this entry need attention?
+
+Issue #109 asks a different question: *what exactly* differs, not just
+whether it does — "missing, modified, conflicting, and unexpected entries",
+with real content diffs for regular files and target-path diffs (not
+content) for symlinks. `status::Status::Conflict` alone can't carry that:
+it's used today for two structurally different situations — a filesystem
+type/content mismatch, and a git merge/rebase/cherry-pick in progress —
+and `status::Status::Modified` is used exclusively for a dirty git
+checkout, never for a filesystem entry.
+
+## Decision
+
+`crate::diff::Change` is its own enum, not a reuse of `status::Status`:
+`Unchanged`, `Missing`, `Modified(ContentDiff)`, `Unexpected { actual:
+ActualState }`, `Broken`, `Checkout(status::Status)`. It is derived
+directly from the same `ActualState` × `MaterializationIntent`
+combinations `SymlinkMaterializer::classify` already produces (no new
+filesystem scanning):
+
+- A file-symlink expected, a real file found: both are regular files, the
+  overlay's source just isn't linked in yet → `Modified`, with a real
+  content diff.
+- Either symlink kind expected, a symlink pointing elsewhere found →
+  `Modified`, with a diff of the target *paths*, never file content.
+- Anything else structurally different (a directory expected, or a
+  directory-symlink expected but a plain file/directory found) →
+  `Unexpected` — #109's "unexpected entries", reinterpreted as a
+  type-mismatch rather than an untracked-file scan (out of scope: no code
+  exists to walk a target tree for files no `DesiredTree` describes, and
+  adding it is a materially bigger feature than this issue asks for).
+- Git checkouts: `status::git::inspect` reused verbatim, wrapped in
+  `Change::Checkout(status::Status)` for the residual
+  dirty/ahead/behind/diverged/conflict cases — commit/merge mechanics stay
+  #110's job, exactly as ADR-011 already scoped for `Plan`.
+
+For the two `Modified` cases, `crate::diff::content::ContentDiff` is a
+plain data type (`Vec<DiffLine>`, each tagged `Equal`/`Delete`/`Insert`),
+built with the `similar` crate (`TextDiff::from_lines` + `grouped_ops(3)`
+for git-like context trimming) rather than shelling out to `git diff
+--no-index` the way `actions::fs::show_diff` already does for interactive
+conflict resolution. `similar` runs in-process (no `git` binary required
+on `PATH`) and produces structured data with no formatting baked in — only
+`ContentDiff`'s `Display` impl (used by the CLI) knows about colors. This
+directly serves #109's explicit ask for "a machine-readable representation
+later without coupling the core model to terminal formatting": today only
+a colored terminal string is printed, but the diff itself is already a
+plain `Vec<DiffLine>` a future `--json` flag could serialize as-is.
+
+## Consequences
+
+`diff` and `status` now derive genuinely independent classifications from
+the same underlying `Plan`/`ActualState`/`status::git::inspect` primitives
+— some duplication of the `(intent, operation)` match compared to
+`status::Report::build`'s equivalent, accepted because the two commands
+answer different questions and forcing one shared enum to serve both would
+either weaken `status`'s existing meaning or bloat `diff`'s with
+irrelevant variants. Binary files (either side not valid UTF-8) fall back
+to a `None`-lines marker rather than erroring, mirroring git's own "binary
+files differ" rather than diffing raw bytes as text. A future `unapply`
+(#64) remains free to define its own third taxonomy the same way, per
+ADR-011's original intent — `Plan`/`DesiredTree` is the shared
+foundation, not a shared result type.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ by editing the old one. The history is the value.
 | [010](010-templating-is-scoped-to-path-strings.md) | Templating is scoped to path-resolution strings, not file content |
 | [011](011-plan-then-execute-reconciliation.md) | Plan-then-execute reconciliation, amending ADR-005 and ADR-006 |
 | [012](012-materializer-backend-registry.md) | Materializer backend registry, amending ADR-011 |
+| [013](013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md) | `diff` has its own taxonomy and uses `similar` for content diffs, amending ADR-011 |

--- a/docs/usage/diff.md
+++ b/docs/usage/diff.md
@@ -1,0 +1,39 @@
+# `over diff`
+
+Show differences between desired overlay state and what actually exists on
+disk (and, for `git` checkouts, in the repository), without touching
+anything.
+
+```
+Usage: over diff [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]  Name of the overlay to check (all overlays if omitted)
+
+Options:
+  -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
+  -r, --root <ROOT>  The target root directory (~)
+  -d, --debug        Toggle debug traces
+      --no-uses      Do not process uses
+  -v, --verbose      Toggle verbose output
+  -h, --help         Print help
+```
+
+`diff` reuses the same `DesiredTree`/`Plan` reconciliation model as
+[`over status`](status.md), but goes one step further: instead of just
+labelling an entry as needing attention, it shows *what* differs —
+
+- a real line-level content diff when an existing plain file hasn't been
+  linked into the overlay yet;
+- a target-path diff (not a content diff) when a symlink already exists but
+  points somewhere other than the overlay's source;
+- an "unexpected" notice when a fundamentally different kind of entity
+  occupies a target (e.g. a real directory where a symlink was expected) —
+  there's nothing meaningful to diff in that case;
+- the same dirty/ahead/behind/diverged/merge-in-progress state
+  `over status` reports for `git` checkouts (commit/merge mechanics
+  themselves are out of scope — see #110).
+
+Without `--verbose`, only entries with something to show are printed; pass
+`--verbose` to also print unchanged entries. See
+[ADR-013](../adr/013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md).

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -17,6 +17,7 @@ integrates the same overlay model with git workflows — Git resolves
 | [`over lint`](lint.md) | Check overlays for configuration issues |
 | [`over completion`](completion.md) | Generate shell completion scripts |
 | [`over status`](status.md) | Get the current repository/directory overlays status |
+| [`over diff`](diff.md) | Show differences between desired and actual overlay state |
 
 ## `git-over`
 

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -1,0 +1,207 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use clap::Args;
+use dirs::home_dir;
+
+use crate::cli::CLI;
+use crate::desired::DesiredTree;
+use crate::diff::Report;
+use crate::exec::Context;
+use crate::overlays::{Overlay, Repository};
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+#[derive(Args, Debug)]
+pub struct Params {
+    #[clap(help = "Name of the overlay to check (all overlays if omitted)")]
+    name: Option<String>,
+
+    #[clap(short, long, help = "The target root directory (~)")]
+    root: Option<PathBuf>,
+
+    #[clap(long, help = "Do not process uses")]
+    no_uses: bool,
+}
+
+pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
+    if cli.debug {
+        tracing::debug!(?cli, ?args, "CLI args");
+    }
+
+    let home = cli.resolve_home()?;
+    let repo = Repository::new(home);
+    let root = args
+        .root
+        .clone()
+        .or_else(home_dir)
+        .ok_or_else(|| anyhow!("could not determine home directory"))?;
+
+    let overlays = match &args.name {
+        Some(name) => vec![repo.get(name)?],
+        None => repo.overlays()?,
+    };
+
+    if overlays.is_empty() {
+        println!("No overlays found.");
+        return Ok(());
+    }
+
+    for overlay in &overlays {
+        print_overlay_diff(cli, &repo, &root, overlay, args.no_uses)?;
+    }
+
+    Ok(())
+}
+
+fn print_overlay_diff(
+    cli: &CLI,
+    repo: &Repository,
+    root: &Path,
+    overlay: &Overlay,
+    no_uses: bool,
+) -> Result<()> {
+    let ctx = Context::builder()
+        .root(root.to_path_buf())
+        .repository(repo.clone())
+        .overlay(overlay.clone())
+        .no_uses(no_uses)
+        .build();
+    let target = overlay.resolve_target(&ctx)?;
+    let ctx = ctx.with_resolved_overlay(overlay.name.clone(), target.to_string_lossy().to_string());
+
+    // Full `uses` graph (not `build_own`): diff reports on everything an
+    // overlay pulls in, exactly like `status` and `Overlay::apply` do.
+    let desired = DesiredTree::build(&ctx, overlay)?;
+    let report = Report::build(&desired)?;
+
+    println!(
+        "{} {} {} {} {}",
+        emojis::PACKAGE,
+        style::white_b("Overlay"),
+        style::cyan(&overlay.name),
+        style::white_b("->"),
+        style::cyan(&short_path(&target.to_string_lossy())),
+    );
+
+    if !report.has_changes() {
+        println!("  {}", style::white("no differences"));
+    }
+
+    for diff_entry in report.entries() {
+        if cli.verbose || diff_entry.has_diff() {
+            println!("  {diff_entry}");
+        }
+    }
+    println!();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use clap::Parser;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn make_cli(home: PathBuf) -> CLI {
+        CLI::parse_from(vec!["over", "--home", home.to_str().unwrap()])
+    }
+
+    fn params(name: Option<&str>, root: PathBuf) -> Params {
+        Params {
+            name: name.map(String::from),
+            root: Some(root),
+            no_uses: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn diff_empty_repository() {
+        let tmp = TempDir::new().unwrap();
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, tmp.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn diff_missing_overlay_target_reports_missing() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~/sub\"").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+        assert!(!root.path().join("sub").exists());
+    }
+
+    #[tokio::test]
+    async fn diff_named_overlay_only() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["first", "second"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(Some("first"), root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn diff_unknown_overlay_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(
+            &cli,
+            &params(Some("does-not-exist"), root.path().to_path_buf()),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn diff_conflicting_file_shows_content_diff() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("conflicted");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        fs::write(ov.join("file.txt"), "overlay content").unwrap();
+        fs::write(root.path().join("file.txt"), "existing content").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn diff_multiple_overlays() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["alpha", "beta", "gamma"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@ mod add;
 mod apply;
 pub(crate) mod common;
 mod completion;
+mod diff;
 pub mod git_over;
 mod lint;
 mod list;
@@ -75,6 +76,12 @@ pub enum Commands {
         about = "Show the reconciliation status of overlays against actual state"
     )]
     Status(status::Params),
+
+    #[clap(
+        name = "diff",
+        about = "Show differences between desired and actual overlay state"
+    )]
+    Diff(diff::Params),
 }
 
 impl CLI {
@@ -115,6 +122,9 @@ pub async fn main() -> Result<()> {
         }
         Some(Commands::Status(ref opt)) => {
             status::execute(&args, opt).await?;
+        }
+        Some(Commands::Diff(ref opt)) => {
+            diff::execute(&args, opt).await?;
         }
         None => {
             use clap::CommandFactory;
@@ -228,6 +238,12 @@ mod tests {
     fn cli_status_subcommand() {
         let args = CLI::parse_from(["over", "status"]);
         assert!(matches!(args.cmd, Some(Commands::Status(_))));
+    }
+
+    #[test]
+    fn cli_diff_subcommand() {
+        let args = CLI::parse_from(["over", "diff"]);
+        assert!(matches!(args.cmd, Some(Commands::Diff(_))));
     }
 
     #[test]

--- a/src/diff/content.rs
+++ b/src/diff/content.rs
@@ -1,0 +1,171 @@
+//! Structured, line-level text diffs (#109).
+//!
+//! [`ContentDiff`] is plain data — a tag plus the line content for every
+//! line `similar` produces, restricted to changed hunks with a little
+//! surrounding context (mirrors `git diff`'s default of 3 context lines)
+//! rather than the whole file. It carries no terminal formatting: only
+//! its [`fmt::Display`] impl (used by the CLI) knows about colors, so a
+//! future machine-readable representation (e.g. JSON output) can reuse
+//! [`ContentDiff`] directly instead of re-deriving the diff.
+
+use std::fmt;
+
+use similar::{ChangeTag, TextDiff};
+
+use crate::ui::style;
+
+/// What kind of line-level change a [`DiffLine`] represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineTag {
+    /// Present, unchanged, on both sides — kept for surrounding context.
+    Equal,
+    /// Present only on the "actual" side.
+    Delete,
+    /// Present only on the "desired" side.
+    Insert,
+}
+
+/// One line of a [`ContentDiff`], tagged with how it differs.
+#[derive(Debug, Clone)]
+pub struct DiffLine {
+    pub tag: LineTag,
+    pub content: String,
+}
+
+/// A structured diff between two texts — `None` when either side isn't
+/// valid UTF-8, mirroring git's own "binary files differ" fallback rather
+/// than diffing raw bytes as if they were text.
+#[derive(Debug, Clone)]
+pub struct ContentDiff {
+    pub lines: Option<Vec<DiffLine>>,
+}
+
+impl ContentDiff {
+    /// Build a line-level diff of `old` (actual) vs `new` (desired),
+    /// grouped into changed hunks with 3 lines of context.
+    pub(crate) fn from_texts(old: &str, new: &str) -> Self {
+        let diff = TextDiff::from_lines(old, new);
+        let mut lines = Vec::new();
+        for group in diff.grouped_ops(3) {
+            for op in &group {
+                for change in diff.iter_changes(op) {
+                    lines.push(DiffLine {
+                        tag: match change.tag() {
+                            ChangeTag::Equal => LineTag::Equal,
+                            ChangeTag::Delete => LineTag::Delete,
+                            ChangeTag::Insert => LineTag::Insert,
+                        },
+                        // `similar` keeps the trailing newline in the
+                        // change's value for line-mode diffs (so it can
+                        // tell whether the last line was newline
+                        // terminated) — trim it, our own `Display` adds
+                        // one line per `DiffLine` itself.
+                        content: change.to_string_lossy().trim_end_matches('\n').to_string(),
+                    });
+                }
+            }
+        }
+        Self { lines: Some(lines) }
+    }
+
+    /// A diff that can't be expressed as text — either side isn't valid
+    /// UTF-8.
+    pub(crate) fn binary() -> Self {
+        Self { lines: None }
+    }
+
+    /// Whether this diff actually has anything to show (a binary
+    /// fallback, or at least one non-`Equal` line).
+    pub fn has_diff(&self) -> bool {
+        match &self.lines {
+            None => true,
+            Some(lines) => lines.iter().any(|l| l.tag != LineTag::Equal),
+        }
+    }
+}
+
+impl fmt::Display for ContentDiff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Some(lines) = &self.lines else {
+            return writeln!(f, "  {}", style::white("binary files differ"));
+        };
+        for line in lines {
+            match line.tag {
+                LineTag::Equal => writeln!(f, "  {}", line.content)?,
+                LineTag::Delete => writeln!(f, "{}", style::red(format!("- {}", line.content)))?,
+                LineTag::Insert => writeln!(f, "{}", style::green(format!("+ {}", line.content)))?,
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_texts_produce_no_changes() {
+        let diff = ContentDiff::from_texts("a\nb\nc\n", "a\nb\nc\n");
+        assert!(!diff.has_diff());
+        let lines = diff.lines.unwrap();
+        assert!(lines.iter().all(|l| l.tag == LineTag::Equal));
+    }
+
+    #[test]
+    fn changed_line_produces_delete_and_insert() {
+        let diff = ContentDiff::from_texts("old content\n", "new content\n");
+        assert!(diff.has_diff());
+        let lines = diff.lines.unwrap();
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.tag == LineTag::Delete && l.content == "old content")
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.tag == LineTag::Insert && l.content == "new content")
+        );
+    }
+
+    #[test]
+    fn single_line_without_trailing_newline_diffs_cleanly() {
+        // Symlink target paths have no trailing newline — make sure a
+        // bare one-line-each diff still works and doesn't leak a stray
+        // newline into `content`.
+        let diff = ContentDiff::from_texts("/old/target", "/new/target");
+        let lines = diff.lines.unwrap();
+        assert!(lines.iter().any(|l| l.content == "/old/target"));
+        assert!(lines.iter().any(|l| l.content == "/new/target"));
+    }
+
+    #[test]
+    fn binary_diff_has_no_lines_but_reports_a_diff() {
+        let diff = ContentDiff::binary();
+        assert!(diff.lines.is_none());
+        assert!(diff.has_diff());
+    }
+
+    #[test]
+    fn display_prints_binary_marker() {
+        let diff = ContentDiff::binary();
+        let s = format!("{diff}");
+        assert!(s.contains("binary files differ"));
+    }
+
+    #[test]
+    fn display_prints_added_and_removed_lines() {
+        let diff = ContentDiff::from_texts("old\n", "new\n");
+        let s = format!("{diff}");
+        assert!(s.contains("- old"));
+        assert!(s.contains("+ new"));
+    }
+
+    #[test]
+    fn display_prints_context_lines_plain() {
+        let diff = ContentDiff::from_texts("same\nold\n", "same\nnew\n");
+        let s = format!("{diff}");
+        assert!(s.contains("same"));
+    }
+}

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1,0 +1,616 @@
+//! Overlay diff (#109): compares desired rendered content/metadata
+//! against actual filesystem (and git) state, so differences are
+//! inspectable before reconciliation.
+//!
+//! Built directly on the same read-only primitives `crate::status` uses —
+//! [`Plan::build`] for filesystem entries, [`status::git::inspect`] for
+//! [`MaterializationIntent::Checkout`] entries — but answers a different
+//! question than `status`: not just *whether* an entry needs attention,
+//! but *what exactly differs*, as a structured [`content::ContentDiff`]
+//! wherever a meaningful line diff can be produced.
+//!
+//! [`Change`] is deliberately its own taxonomy, distinct from
+//! [`status::Status`], derived directly from the `ActualState` ×
+//! `MaterializationIntent` combinations [`crate::materialize::symlink::SymlinkMaterializer::classify`]
+//! already produces:
+//!
+//! - A file-symlink expected, a real file found: both are regular files —
+//!   diff their *content* (the "useful content diff" #109 asks for).
+//! - Either symlink kind expected, a symlink pointing elsewhere found:
+//!   diff the *target path*, never file content (#109: "show target
+//!   differences rather than treating the link as ordinary file
+//!   content").
+//! - Anything else structurally different (a real directory where a
+//!   symlink/directory-symlink was expected, and vice versa): nothing
+//!   meaningful to diff — reported as [`Change::Unexpected`], the
+//!   "unexpected entries" #109 asks for.
+//! - Git checkouts: [`status::git::inspect`] reused unchanged; commit/
+//!   merge mechanics are #110's job, not this one's.
+
+mod content;
+
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
+use crate::plan::{ActualState, Operation, Plan};
+use crate::status::{self, Status};
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+pub use content::{ContentDiff, DiffLine, LineTag};
+
+/// What differs (if anything) between a [`DesiredEntry`] and actual
+/// state — see the module docs for how each variant is derived.
+#[derive(Debug, Clone)]
+pub enum Change {
+    /// Target already matches desired state — nothing to show.
+    Unchanged,
+    /// Target doesn't exist yet.
+    Missing,
+    /// Same kind of entity as desired, but its content or symlink target
+    /// differs — carries the structured diff.
+    Modified(ContentDiff),
+    /// A fundamentally different kind of entity occupies the target than
+    /// what's desired (e.g. a real directory where a symlink was
+    /// expected) — no meaningful line diff to show.
+    Unexpected { actual: ActualState },
+    /// A dangling soft symlink (correctly pointed, but its source
+    /// disappeared), or a checkout path that isn't a valid git repo.
+    Broken,
+    /// Git checkout state — dirty / ahead / behind / diverged / a
+    /// merge-rebase-cherry-pick in progress. Reuses [`status::Status`]
+    /// verbatim: commit/merge mechanics are out of scope here (#110).
+    Checkout(Status),
+}
+
+/// One [`DesiredEntry`] paired with what differs about it.
+#[derive(Debug, Clone)]
+pub struct DiffEntry {
+    pub entry: DesiredEntry,
+    pub change: Change,
+}
+
+impl DiffEntry {
+    /// Whether this entry has anything worth showing — used by the CLI
+    /// to decide what to print without `--verbose`, same convention as
+    /// `status::Status::needs_attention`.
+    pub fn has_diff(&self) -> bool {
+        !matches!(self.change, Change::Unchanged)
+    }
+}
+
+impl fmt::Display for DiffEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let target = short_path(&self.entry.target.to_string_lossy());
+        match &self.change {
+            Change::Unchanged => write!(
+                f,
+                "{} {} {}",
+                emojis::CHECKMARK,
+                style::white("unchanged:"),
+                target
+            ),
+            Change::Missing => write!(
+                f,
+                "{} {} {}",
+                emojis::CROSSMARK,
+                style::white("missing:"),
+                target
+            ),
+            Change::Broken => write!(
+                f,
+                "{} {} {}",
+                emojis::WARNING,
+                style::yellow("broken:"),
+                target
+            ),
+            Change::Unexpected { actual } => write!(
+                f,
+                "{} {} {} (found {})",
+                emojis::WARNING,
+                style::yellow("unexpected:"),
+                target,
+                actual,
+            ),
+            Change::Modified(diff) => {
+                writeln!(
+                    f,
+                    "{} {} {}",
+                    emojis::WARNING,
+                    style::yellow("modified:"),
+                    target
+                )?;
+                write!(f, "{diff}")
+            }
+            // Delegate to `status::EntryStatus`'s own `Display` for the
+            // ahead/behind/diverged/modified/conflict wording, rather
+            // than re-deriving it here.
+            Change::Checkout(current) => {
+                let entry_status = status::EntryStatus {
+                    entry: self.entry.clone(),
+                    status: current.clone(),
+                };
+                write!(f, "{entry_status}")
+            }
+        }
+    }
+}
+
+/// The diff of a whole [`DesiredTree`]: one [`DiffEntry`] per
+/// [`DesiredEntry`].
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    entries: Vec<DiffEntry>,
+}
+
+impl Report {
+    /// Classify every entry in `desired`. Read-only, like [`Plan::build`]
+    /// and `status::Report::build`.
+    pub fn build(desired: &DesiredTree) -> Result<Self> {
+        let plan = Plan::build(desired)?;
+        let mut entries = Vec::with_capacity(plan.len());
+        for step in plan.steps() {
+            let change = if matches!(step.entry.intent, MaterializationIntent::Checkout) {
+                classify_checkout(&step.entry)?
+            } else {
+                classify_fs(&step.entry, &step.operation)?
+            };
+            entries.push(DiffEntry {
+                entry: step.entry.clone(),
+                change,
+            });
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn entries(&self) -> &[DiffEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Whether anything in this report has a diff worth showing.
+    pub fn has_changes(&self) -> bool {
+        self.entries.iter().any(DiffEntry::has_diff)
+    }
+}
+
+/// Classify a filesystem (non-`Checkout`) entry's `Operation` into a
+/// [`Change`].
+fn classify_fs(entry: &DesiredEntry, operation: &Operation) -> Result<Change> {
+    match operation {
+        Operation::Create => Ok(Change::Missing),
+        // Reuse `status`'s own dangling-soft-symlink check rather than
+        // re-deriving it.
+        Operation::Noop => Ok(match status::classify_noop(&entry.intent) {
+            Status::Broken => Change::Broken,
+            _ => Change::Unchanged,
+        }),
+        Operation::Conflict { current } => classify_conflict(entry, current),
+        Operation::Deferred => unreachable!(
+            "only Checkout entries ever classify as Deferred, and those are \
+             routed to classify_checkout before reaching classify_fs"
+        ),
+    }
+}
+
+/// Classify an `Operation::Conflict` into a [`Change`], per the table in
+/// the module docs.
+fn classify_conflict(entry: &DesiredEntry, current: &ActualState) -> Result<Change> {
+    match (&entry.intent, current) {
+        // A file-symlink was expected, a real file occupies the target:
+        // both sides are regular files, just not linked yet — diff their
+        // content.
+        (MaterializationIntent::SymlinkFile { source, .. }, ActualState::File) => {
+            Ok(Change::Modified(content_diff_files(&entry.target, source)?))
+        }
+        // Either symlink kind was expected, a symlink pointing elsewhere
+        // is there: diff the target *paths*, never content.
+        (
+            MaterializationIntent::SymlinkFile { source, .. }
+            | MaterializationIntent::SymlinkDirectory { source, .. },
+            ActualState::Symlink { points_to },
+        ) => Ok(Change::Modified(ContentDiff::from_texts(
+            &points_to.to_string_lossy(),
+            &source.to_string_lossy(),
+        ))),
+        (MaterializationIntent::Checkout, _) => {
+            unreachable!("Checkout entries never reach Plan::build's Conflict classification")
+        }
+        // Everything else structurally mismatched (a directory expected,
+        // or a directory-symlink expected but a real file/directory
+        // found): nothing meaningful to diff.
+        _ => Ok(Change::Unexpected {
+            actual: current.clone(),
+        }),
+    }
+}
+
+/// Read both sides of a file-vs-would-be-symlinked-file conflict and diff
+/// their content, falling back to a binary marker if either side isn't
+/// valid UTF-8 (mirrors git's own "binary files differ").
+fn content_diff_files(actual_path: &Path, desired_path: &Path) -> Result<ContentDiff> {
+    let old = fs::read(actual_path)?;
+    let new = fs::read(desired_path)?;
+    Ok(match (String::from_utf8(old), String::from_utf8(new)) {
+        (Ok(old), Ok(new)) => ContentDiff::from_texts(&old, &new),
+        _ => ContentDiff::binary(),
+    })
+}
+
+/// Classify a `MaterializationIntent::Checkout` entry, reusing
+/// `status::git::inspect` unchanged.
+fn classify_checkout(entry: &DesiredEntry) -> Result<Change> {
+    Ok(match status::git::inspect(entry)? {
+        Status::Applied => Change::Unchanged,
+        Status::Missing => Change::Missing,
+        Status::Broken => Change::Broken,
+        other => Change::Checkout(other),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::symlink::LinkType;
+    use crate::exec::Context;
+    use crate::overlays::Repository;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use rstest::rstest;
+    use std::fs;
+
+    fn repo_and_root() -> (TempDir, Repository) {
+        let td = TempDir::new().unwrap();
+        let repo = Repository::new(td.path().to_path_buf());
+        (td, repo)
+    }
+
+    #[rstest]
+    fn missing_target_reports_missing() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~/sub\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+
+        assert_eq!(report.entries().len(), 1);
+        assert!(matches!(report.entries()[0].change, Change::Missing));
+        assert!(report.has_changes());
+    }
+
+    #[tokio::test]
+    async fn applied_target_reports_unchanged() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(ctx.clone())
+            .await
+            .unwrap();
+
+        let desired2 = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        let file_entry = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+        assert!(matches!(file_entry.change, Change::Unchanged));
+        assert!(!file_entry.has_diff());
+        assert!(!report.has_changes());
+    }
+
+    #[rstest]
+    fn existing_file_conflict_produces_content_diff() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir
+            .child("file.txt")
+            .write_str("desired content\n")
+            .unwrap();
+        fs::write(td.path().join("file.txt"), "actual content\n").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let file_entry = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+
+        match &file_entry.change {
+            Change::Modified(diff) => {
+                let s = format!("{diff}");
+                assert!(s.contains("actual content"));
+                assert!(s.contains("desired content"));
+            }
+            other => panic!("expected Modified, got {other:?}"),
+        }
+        assert!(report.has_changes());
+    }
+
+    #[rstest]
+    fn binary_file_conflict_reports_binary_diff() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        fs::write(overlay_dir.path().join("file.bin"), [0xff_u8, 0xfe, 0x00]).unwrap();
+        fs::write(td.path().join("file.bin"), [0x00_u8, 0xff, 0xfe]).unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let file_entry = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.bin"))
+            .unwrap();
+
+        match &file_entry.change {
+            Change::Modified(diff) => assert!(diff.lines.is_none()),
+            other => panic!("expected Modified(binary), got {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn symlink_pointing_elsewhere_produces_target_diff() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let elsewhere = td.child("elsewhere.txt");
+        elsewhere.write_str("elsewhere").unwrap();
+        symlink::symlink_file(elsewhere.path(), td.path().join("file.txt")).unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let file_entry = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+
+        match &file_entry.change {
+            Change::Modified(diff) => {
+                let s = format!("{diff}");
+                assert!(s.contains("elsewhere.txt"));
+                assert!(s.contains("ov/file.txt") || s.contains("file.txt"));
+            }
+            other => panic!("expected Modified, got {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn directory_expected_but_file_found_is_unexpected() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("subdir").create_dir_all().unwrap();
+        // Occupy the directory's target path with a plain file instead.
+        fs::write(td.path().join("subdir"), "not a directory").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let dir_entry = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("subdir"))
+            .unwrap();
+
+        match &dir_entry.change {
+            Change::Unexpected { actual } => assert_eq!(*actual, ActualState::File),
+            other => panic!("expected Unexpected, got {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn link_dir_expected_but_real_directory_found_is_unexpected() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"\nlink_dirs = [\"mydir\"]")
+            .unwrap();
+        overlay_dir.child("mydir/inner.txt").write_str("x").unwrap();
+        fs::create_dir_all(td.path().join("mydir")).unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let dir_entry = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("mydir"))
+            .unwrap();
+
+        match &dir_entry.change {
+            Change::Unexpected { actual } => assert_eq!(*actual, ActualState::Directory),
+            other => panic!("expected Unexpected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dangling_soft_symlink_noop_is_broken() {
+        let entry = DesiredEntry {
+            target: std::path::PathBuf::from("/tmp/target"),
+            provenance: crate::desired::Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: std::path::PathBuf::from("/repo/ov"),
+            },
+            intent: MaterializationIntent::SymlinkFile {
+                source: std::path::PathBuf::from("/does/not/exist/anymore"),
+                link_type: LinkType::Soft,
+            },
+        };
+        let change = classify_fs(&entry, &Operation::Noop).unwrap();
+        assert!(matches!(change, Change::Broken));
+    }
+
+    #[test]
+    fn empty_desired_tree_produces_empty_report() {
+        let report = Report::build(&DesiredTree::default()).unwrap();
+        assert!(report.is_empty());
+        assert!(!report.has_changes());
+    }
+
+    #[rstest]
+    fn git_checkout_not_cloned_yet_reports_missing() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"\n[git]\n\".config/nvim\" = \"https://example.com/nvim.git\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let checkout_entry = report
+            .entries()
+            .iter()
+            .find(|e| matches!(e.entry.intent, MaterializationIntent::Checkout))
+            .unwrap();
+        assert!(matches!(checkout_entry.change, Change::Missing));
+    }
+
+    #[test]
+    fn dirty_git_checkout_maps_to_checkout_modified() {
+        use crate::actions::git::config::GitRepoConfig;
+        use git2::{Repository as GitRepository, Signature};
+
+        let td = TempDir::new().unwrap();
+        let repo = GitRepository::init(td.path()).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(td.path().join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        fs::write(td.path().join("README.md"), "changed").unwrap();
+
+        let entry = DesiredEntry {
+            target: td.path().to_path_buf(),
+            provenance: crate::desired::Provenance::Git {
+                overlay: "ov".to_string(),
+                repo_key: ".".to_string(),
+                config: Box::new(GitRepoConfig {
+                    url: String::new(),
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    recurse_submodules: false,
+                    worktree: false,
+                    per_worktree_config: false,
+                    worktrees: None,
+                    remotes: None,
+                    config: None,
+                    worktree_config: None,
+                }),
+            },
+            intent: MaterializationIntent::Checkout,
+        };
+
+        let change = classify_checkout(&entry).unwrap();
+        assert!(matches!(change, Change::Checkout(Status::Modified)));
+        let display = format!("{}", DiffEntry { entry, change });
+        assert!(display.contains("modified:"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod actions;
 pub mod cli;
 pub mod desired;
+pub mod diff;
 pub mod exec;
 pub mod lint;
 pub mod materialize;

--- a/src/plan/actual.rs
+++ b/src/plan/actual.rs
@@ -1,8 +1,11 @@
+use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+
+use crate::utils::short_path;
 
 /// What actually exists at a [`super::PlanStep`]'s target path right now,
 /// independent of what [`crate::desired::DesiredEntry`] says should be
@@ -20,6 +23,27 @@ pub enum ActualState {
     /// exist, or may not match what's desired — that's for the caller to
     /// compare).
     Symlink { points_to: PathBuf },
+}
+
+/// Human-readable description of what currently occupies a path — shared
+/// by [`super::step::PlanStep`]'s conflict diagnostics and `crate::diff`'s
+/// `Unexpected` reporting, so both describe the same [`ActualState`] the
+/// same way instead of each re-deriving the wording.
+impl fmt::Display for ActualState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ActualState::Missing => write!(f, "nothing"),
+            ActualState::Directory => write!(f, "a directory"),
+            ActualState::File => write!(f, "a file"),
+            ActualState::Symlink { points_to } => {
+                write!(
+                    f,
+                    "a symlink to {}",
+                    short_path(&points_to.to_string_lossy())
+                )
+            }
+        }
+    }
 }
 
 /// Inspect what currently exists at `path`, without mutating anything.

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -44,19 +44,6 @@ pub struct PlanStep {
     pub operation: Operation,
 }
 
-/// Human-readable description of what currently occupies a path, for
-/// conflict diagnostics.
-fn describe_actual(actual: &ActualState) -> String {
-    match actual {
-        ActualState::Missing => "nothing".to_string(),
-        ActualState::Directory => "a directory".to_string(),
-        ActualState::File => "a file".to_string(),
-        ActualState::Symlink { points_to } => {
-            format!("a symlink to {}", short_path(&points_to.to_string_lossy()))
-        }
-    }
-}
-
 impl fmt::Display for PlanStep {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let target = short_path(&self.entry.target.to_string_lossy());
@@ -83,7 +70,7 @@ impl fmt::Display for PlanStep {
                 emojis::WARNING,
                 style::yellow("conflict:"),
                 target,
-                describe_actual(current),
+                current,
             ),
             (
                 MaterializationIntent::SymlinkFile { source, .. }
@@ -120,7 +107,7 @@ impl fmt::Display for PlanStep {
                 emojis::WARNING,
                 style::yellow("conflict:"),
                 target,
-                describe_actual(current),
+                current,
                 short_path(&source.to_string_lossy()),
             ),
             (MaterializationIntent::Checkout, _) => write!(

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -236,7 +236,10 @@ impl Report {
 /// data independently of the source (the link *is* a second name for the
 /// same inode), and `Directory` has no such concept, so both stay
 /// `Applied`.
-fn classify_noop(intent: &MaterializationIntent) -> Status {
+///
+/// `pub(crate)`: `crate::diff` reuses this exact check for the same
+/// `Noop` case instead of re-deriving it (#109).
+pub(crate) fn classify_noop(intent: &MaterializationIntent) -> Status {
     match intent {
         MaterializationIntent::SymlinkFile { source, link_type }
         | MaterializationIntent::SymlinkDirectory { source, link_type }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -39,6 +39,14 @@ pub fn yellow<D>(value: D) -> StyledObject<D> {
     style(value).yellow()
 }
 
+pub fn green<D>(value: D) -> StyledObject<D> {
+    style(value).green()
+}
+
+pub fn red<D>(value: D) -> StyledObject<D> {
+    style(value).red()
+}
+
 pub struct DialogTheme {
     /// The style for default values
     pub defaults_style: Style,
@@ -361,6 +369,22 @@ mod tests {
     #[test]
     fn test_yellow_styles_text() {
         let styled = yellow("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_green_styles_text() {
+        let styled = green("hello");
+        let mut buf = String::new();
+        write!(&mut buf, "{}", styled).unwrap();
+        assert!(buf.contains("hello"));
+    }
+
+    #[test]
+    fn test_red_styles_text() {
+        let styled = red("hello");
         let mut buf = String::new();
         write!(&mut buf, "{}", styled).unwrap();
         assert!(buf.contains("hello"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -414,6 +414,114 @@ fn status_empty_repository_reports_no_overlays() -> TestResult {
     Ok(())
 }
 
+// ── diff integration tests ───────────────────────────────────────────────
+
+#[test]
+fn diff_reports_missing_before_apply() -> TestResult {
+    let repo = setup_overlay_repo();
+    // A real file not yet linked anywhere — the overlay's own root
+    // directory already exists (it *is* `root`, the default target),
+    // so only this file entry should be reported missing.
+    fs::write(repo.path().join("dev").join("file.txt"), b"content")?;
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["diff", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("missing:"));
+    Ok(())
+}
+
+#[test]
+fn diff_reports_no_differences_after_apply() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"content")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "dev", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["diff", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("no differences"));
+    Ok(())
+}
+
+#[test]
+fn diff_shows_content_diff_for_existing_file() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"overlay content")?;
+    let root = TempDir::new()?;
+    fs::write(root.path().join("file.txt"), b"existing content")?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["diff", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("modified"))
+        .stdout(contains("existing content"))
+        .stdout(contains("overlay content"));
+    Ok(())
+}
+
+#[test]
+fn diff_debug_output() -> TestResult {
+    let repo = setup_overlay_repo();
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .arg("--debug")
+        .args(["diff", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stderr(contains("CLI args"));
+    Ok(())
+}
+
+#[test]
+fn diff_unknown_overlay_fails() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .args(["diff", "does-not-exist"])
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[test]
+fn diff_empty_repository_reports_no_overlays() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .arg("diff")
+        .assert()
+        .success()
+        .stdout(contains("No overlays found"));
+    Ok(())
+}
+
 // ── show integration tests ──────────────────────────────────────────────
 
 #[test]

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,6 +31,7 @@ nav = [
     { "over lint" = "usage/lint.md" },
     { "over completion" = "usage/completion.md" },
     { "over status" = "usage/status.md" },
+    { "over diff" = "usage/diff.md" },
     { "git over mount" = "usage/git-over-mount.md" },
     { "git over add" = "usage/git-over-add.md" },
     { "git over status" = "usage/git-over-status.md" },


### PR DESCRIPTION
Adds `over diff`, a new read-only command that shows what differs between an overlay's desired state and what actually exists on disk (and in git, for checkouts) — inspectable before reconciliation.

It builds on the same `DesiredTree`/`Plan` model `over status` already uses, but goes one step further than a status label:

- An existing plain file not yet linked into the overlay gets a real content diff.
- A symlink pointing somewhere other than the overlay's source gets a target-path diff, not a content diff.
- A fundamentally different kind of entity occupying a target (e.g. a real directory where a symlink was expected) is reported as "unexpected", since there's nothing meaningful to diff there.
- Git checkouts get the same dirty/ahead/behind/diverged/merge-in-progress state `over status` reports — commit/merge mechanics are explicitly out of scope (#110).

Content diffs are computed in-process with the `similar` crate as structured data, decoupled from terminal formatting, so a future machine-readable output doesn't require redoing the diffing itself.

See [ADR-013](docs/adr/013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md) for the design rationale, and [docs/usage/diff.md](docs/usage/diff.md) for usage.

Closes #109
