### PR TITLE
feat(sync): add bidirectional synchronization for checkout-materialized overlays

### DIFF
--- a/docs/adr/014-bidirectional-checkout-synchronization.md
+++ b/docs/adr/014-bidirectional-checkout-synchronization.md
@@ -1,0 +1,118 @@
+# ADR-014: Bidirectional checkout synchronization is `over sync`, scoped to an overlay's root git entry
+
+**Status:** accepted
+
+## Context
+
+ADR-011/012 both explicitly deferred "turning `Checkout` entries into real
+Git worktrees/checkouts" to #110, leaving `MaterializerRegistry::find`
+return `None` for `MaterializationIntent::Checkout` and `Plan::build`
+classify every such entry as `Operation::Deferred`. Issue #110 asks for
+more than materialization, though: a checkout, once it exists, must be
+editable with normal git tooling at its target and reconciled back to its
+source — "the overlay itself materialized as a checkout is a bidirectional
+synchronization surface" — while explicitly treating "git repositories
+declared inside an overlay" (the same `overlay.git` map, used for e.g.
+plugin-manager checkouts at a subpath) as an opaque resource whose content
+is never synchronized.
+
+Today, `overlay.git` is a single, undifferentiated `HashMap<String,
+GitRepoConfig>`: every entry — whether it's the overlay's own root content
+or a nested plugin repo — is cloned/configured identically by
+`actions::git::clone_repositories`/`EnsureGitRepository`, called directly
+and unconditionally by `Overlay::apply_inner`, entirely outside
+`Plan`/`Materializer`.
+
+## Decision
+
+**Scope: only the root entry (`ROOT_PATH`, `"."`) is a bidirectional sync
+surface.** `ROOT_PATH` already exists as the sentinel for "this overlay's
+own content, cloned to its target root" (the shorthand single-URL/single-
+object `git` form resolves to it). No new config field is introduced to
+distinguish "sync surface" from "opaque resource": the existing key
+already carries that meaning, and it maps exactly onto the issue's own
+two-concern split. Any non-root `git` entry keeps today's behavior
+unchanged — ensured present/configured, never content-synced.
+
+**`CheckoutMaterializer` fills the registry seam, but only for presence,
+not sync.** `src/materialize/checkout.rs` registers a real `Materializer`
+for `MaterializationIntent::Checkout`: `classify` reuses
+`status::git::inspect` (no duplicated git-state logic) and maps
+`Status::Missing → Operation::Create`, every other status (`Applied`,
+`Modified`, `Ahead`, `Behind`, `Diverged`, `Broken`, `Conflict`) →
+`Operation::Noop`. Mapping non-`Missing` states to `Operation::Conflict`
+was rejected: that would route a git checkout through the filesystem
+conflict-resolution UI (`--force`/`--no-prompt`/interactive
+skip-overwrite-absorb-diff) built for symlinks and files, which could
+overwrite or prompt to overwrite a checkout's real content — precisely
+what the issue asks never to do implicitly. `materialize` delegates to the
+existing, unchanged `EnsureGitRepository` action.
+
+`Overlay::apply_inner`'s direct, parallel `actions::git::clone_repositories`
+call is deliberately **left in place**. By the time `Plan::build`
+classifies a `Checkout` entry during a normal `apply`, the repository
+already exists (clone happened first, synchronously), so
+`CheckoutMaterializer::materialize` is naturally a no-op fallback there —
+it only does real work for any other caller of `Plan::execute` (e.g.
+tests, or a future direct caller). This keeps `apply`'s existing
+parallel-clone performance for overlays with multiple `git` entries,
+rather than serializing them through `Plan::execute`'s sequential step
+loop for no behavioral benefit today.
+
+**Bidirectional sync is a new, separate `over sync` command — never part
+of `apply`.** `apply`'s job stays "ensure presence/configuration"; it never
+pulls or pushes checkout content. `src/actions/git/sync.rs` adds the
+mutating primitives (`fetch_origin`, `pull`, `push_branch`,
+`abort_merge`), all built on git2's own merge machinery
+(`merge_analysis`/`merge`/`cleanup_state`) rather than a custom merge
+algorithm — real conflicts are left as real conflict markers in the
+working tree and index, exactly as `git merge` would leave them, for the
+user to resolve with ordinary git tooling. `src/sync/mod.rs` orchestrates:
+it finds every root `Checkout` entry in a `DesiredTree`, expands a
+`worktree`/`worktrees` bare-repo config into one independently-synced unit
+per worktree directory that exists on disk (satisfying "define behavior
+for multiple materialized checkouts from the same overlay source" without
+needing per-worktree `DesiredEntry`s — a documented future refinement,
+same as the existing aggregation-by-severity in `status::git::inspect`),
+and refuses to touch a dirty working tree at the pull step.
+
+**Merge only, no rebase, no auto-stash, for this iteration.** The pull
+direction always produces a fast-forward or a real merge commit
+(`git pull --no-rebase` semantics) — rebase-based sync is a documented
+future option, not built now. A dirty checkout blocks the pull step with a
+clear error rather than being auto-stashed: "never discard uncommitted
+changes implicitly" is read literally.
+
+**`over sync --abort` never needs a persisted "pre-merge HEAD".** A
+conflicted `git2::Repository::merge` never moves `HEAD` (confirmed against
+git2's own docs) — only the index/working directory and `MERGE_HEAD`
+change. Aborting is therefore just `reset(HEAD, Hard)` +
+`cleanup_state()`, using whatever `HEAD` already is.
+
+**XDG state (`src/sync/state.rs`) is informational only, never
+authoritative.** It persists a `SyncState { checkouts: HashMap<path,
+CheckoutRecord> }` — overlay/repo-key/worktree association, last synced
+commit, last outcome — read back only to enrich `over sync`'s own output.
+Nothing in the pull/push/abort decision tree reads it: conflict/resume
+correctness comes entirely from git's own `repo.state()`/`MERGE_HEAD`/
+index, per the issue's own constraint ("state is operational metadata...
+not a second Git database"). Deleting the file is always harmless.
+
+## Consequences
+
+`over apply`, `over status`, and `over diff` are unchanged in behavior:
+`status::git`/`diff` already classified git checkouts independently of the
+`Materializer` registry and continue to do so. `Plan`/`PlanStep`/
+`Operation`/`ActualState` are unchanged — no new variants were needed,
+confirming ADR-012's registry design absorbs #110 without touching the
+shared `Plan` vocabulary. The cost of leaving `apply_inner`'s parallel
+clone path untouched is that `CheckoutMaterializer::materialize`'s
+"ensure repository presence" logic is exercised twice in slightly
+different code paths (the direct call, and the registry-mediated
+fallback) — accepted as low risk since both ultimately call the same,
+unchanged `EnsureGitRepository` action.
+
+This does not implement rebase-based sync, auto-stash, per-worktree
+`DesiredEntry`s, or content synchronization for non-root `git` entries —
+all documented, deliberate non-goals left for later issues. `unapply`
+(#64) and materialization-rule migrations (#113) are untouched.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -18,6 +18,7 @@ integrates the same overlay model with git workflows — Git resolves
 | [`over completion`](completion.md) | Generate shell completion scripts |
 | [`over status`](status.md) | Get the current repository/directory overlays status |
 | [`over diff`](diff.md) | Show differences between desired and actual overlay state |
+| [`over sync`](sync.md) | Reconcile a checkout-materialized overlay with its git source |
 
 ## `git-over`
 

--- a/docs/usage/sync.md
+++ b/docs/usage/sync.md
@@ -1,0 +1,79 @@
+# `over sync`
+
+Reconcile a checkout-materialized overlay with its git source: pull
+upstream changes into the checkout, and push local commits made directly in
+the checkout back upstream.
+
+```
+Usage: over sync [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]  Name of the overlay to sync (all overlays if omitted)
+
+Options:
+  -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
+  -r, --root <ROOT>  The target root directory (~)
+  -d, --debug        Toggle debug traces
+      --no-uses      Do not process uses
+      --pull-only    Only pull upstream changes into the checkout
+  -v, --verbose      Toggle verbose output
+      --push-only    Only push local commits to the overlay source
+      --continue     Re-attempt a sync after resolving conflicts manually
+      --abort        Abort an in-progress merge left by a conflicted sync
+  -n, --dry-run      Report what would happen without syncing
+  -h, --help         Print help
+```
+
+## Scope: the overlay's root git entry only
+
+An overlay's `git` map can declare two conceptually different things:
+
+- the overlay's **own** content, cloned to its target root (the `"."`
+  entry, or the shorthand single-URL/single-object form) — this is "the
+  overlay itself materialized as a checkout", and the only thing `over
+  sync` ever touches.
+- **nested repositories declared inside the overlay** (any other path key,
+  e.g. a plugin-manager checkout at `.config/nvim/pack/plugins/foo`) — a
+  separate concern. `over apply` ensures these exist and are configured as
+  declared, but their content/history is never synchronized by `over
+  sync`. Manage them with plain git yourself.
+
+## What it does
+
+For each overlay's root checkout (and, for a `worktree`/`worktrees`
+bare-repo config, for every worktree directory that exists on disk —
+synced independently):
+
+1. Refuses to touch a checkout with uncommitted changes. Commit or stash
+   first.
+2. Fetches `origin` and fast-forwards or three-way-merges the current
+   branch with its upstream — real git merge machinery, not a custom
+   algorithm. A conflicting merge leaves real conflict markers in the
+   working tree and stops there (no push): resolve with ordinary `git add`
+   / `git commit`, then re-run `over sync`, or run `over sync --abort` to
+   discard the in-progress merge (`git merge --abort` equivalent — your
+   own commits are never touched, only the failed merge attempt).
+3. Pushes the branch to `origin` if it ended up ahead.
+
+`--pull-only`/`--push-only` restrict this to one direction. `--dry-run`
+never performs any network I/O or mutation; it reports what's already
+known locally.
+
+## What it never does
+
+- Touch a dirty working tree, even partially.
+- Auto-resolve conflicts, rebase, or invent its own merge algorithm — git's
+  own merge/rebase/conflict tooling is authoritative.
+- Synchronize nested (non-root) `git` entries (see above).
+- Discard local commits: `--abort` only resets an *in-progress, uncommitted*
+  merge back to the pre-merge `HEAD`.
+
+`over sync` persists a small, informational-only checkpoint under
+`$XDG_STATE_HOME/over` (overlay/checkout association, last synced commit
+and outcome). It is never read back to decide correctness — git's own
+repository state remains authoritative — so deleting it is always
+harmless.
+
+See [ADR-014](../adr/014-bidirectional-checkout-synchronization.md) and
+[the roadmap](https://github.com/noirbizarre/over/issues/112) for the full
+design rationale.

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub(crate) mod sync;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -550,6 +551,18 @@ static DONE_PROGRESS_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
         .expect("static progress template must be valid")
 });
 
+/// Credential-enabled `RemoteCallbacks` shared by every git2 network
+/// operation (clone, and — via `sync.rs` — fetch/push): a fresh
+/// `git2::Config::open_default()` per call so the system/global credential
+/// helpers are always read from their current on-disk state.
+pub(crate) fn remote_callbacks<'cb>() -> Result<git2::RemoteCallbacks<'cb>> {
+    let mut cb = git2::RemoteCallbacks::new();
+    let git_config = git2::Config::open_default()?;
+    let mut ch = CredentialHandler::new(git_config);
+    cb.credentials(move |url, username, allowed| ch.try_next_credential(url, username, allowed));
+    Ok(cb)
+}
+
 fn clone(
     url: &str,
     dst: &Path,
@@ -558,12 +571,7 @@ fn clone(
     recurse_submodules: bool,
     progress: &Sender<CloneMessage>,
 ) -> Result<Repository> {
-    let mut cb = git2::RemoteCallbacks::new();
-    let git_config = git2::Config::open_default()?;
-
-    // Credentials management
-    let mut ch = CredentialHandler::new(git_config);
-    cb.credentials(move |url, username, allowed| ch.try_next_credential(url, username, allowed));
+    let mut cb = remote_callbacks()?;
     cb.transfer_progress(|stats| {
         let stats = CloneStats::from(stats);
         // Ignore send errors (receiver may have dropped)

--- a/src/actions/git/sync.rs
+++ b/src/actions/git/sync.rs
@@ -1,0 +1,401 @@
+//! Low-level git2 mutating primitives for bidirectional checkout
+//! synchronization (#110). Parallel to the clone/worktree/remote helpers in
+//! [`super`]: those ensure a repository's *presence and configuration*;
+//! this module is the only place that ever fetches, merges, or pushes
+//! *content*.
+//!
+//! Conflict resolution is never reimplemented here: [`pull`] leaves real
+//! git conflict markers in the index/working directory exactly as `git
+//! merge` would, and the caller (`crate::sync`) never auto-resolves them —
+//! the user resolves with ordinary git tooling (`git add`, `git commit`, or
+//! `git merge --abort` — mirrored here by [`abort_merge`]).
+
+use anyhow::{Context as _, Result};
+use git2::{FetchOptions, PushOptions, Repository, ResetType, Signature};
+
+use super::remote_callbacks;
+
+/// Outcome of attempting to pull upstream changes into `repo`'s current
+/// branch. Never invoked against a dirty working tree or a repository
+/// already mid-merge — `crate::sync` checks both before calling [`pull`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PullOutcome {
+    /// Detached `HEAD`, or the current branch has no upstream (or its
+    /// upstream ref doesn't exist, e.g. never pushed) — nothing to compare
+    /// against.
+    NoUpstream,
+    /// Already level with (or ahead of) the upstream; nothing to merge.
+    UpToDate,
+    /// Local branch had no divergent commits; its ref was simply moved
+    /// forward (no merge commit created).
+    FastForwarded,
+    /// A real three-way merge was performed and committed cleanly.
+    Merged,
+    /// The merge produced conflicts: real conflict markers are now in the
+    /// working directory and the index, and `repo.state()` reports
+    /// `Merging`. Caller must stop (no push) until the user resolves and
+    /// commits, or runs [`abort_merge`].
+    Conflict,
+}
+
+/// Fetch every configured refspec from `origin` (same as plain `git
+/// fetch`, no refspec override).
+pub(crate) fn fetch_origin(repo: &Repository) -> Result<()> {
+    let mut remote = repo
+        .find_remote("origin")
+        .context("no 'origin' remote configured")?;
+    let mut fetch_options = FetchOptions::new();
+    fetch_options.remote_callbacks(remote_callbacks()?);
+    remote
+        .fetch(&[] as &[&str], Some(&mut fetch_options), None)
+        .context("failed to fetch 'origin'")?;
+    Ok(())
+}
+
+/// Fetch `origin`, then fast-forward or three-way-merge `repo`'s current
+/// branch with its upstream tracking ref. Reuses git's own merge
+/// machinery (`merge_analysis`/`merge`) rather than reimplementing
+/// three-way merge.
+pub(crate) fn pull(repo: &Repository) -> Result<PullOutcome> {
+    let head = repo.head().context("failed to resolve HEAD")?;
+    if !head.is_branch() {
+        return Ok(PullOutcome::NoUpstream);
+    }
+    let branch_name = head
+        .shorthand()
+        .context("current branch name is not valid UTF-8")?
+        .to_string();
+
+    let branch = git2::Branch::wrap(head);
+    let Ok(upstream) = branch.upstream() else {
+        return Ok(PullOutcome::NoUpstream);
+    };
+    let upstream_refname = upstream
+        .get()
+        .name()
+        .context("upstream ref name is not valid UTF-8")?
+        .to_string();
+    drop(upstream);
+    drop(branch);
+
+    fetch_origin(repo)?;
+
+    // Re-resolve the upstream ref *after* fetching: any handle obtained
+    // beforehand points at its pre-fetch target.
+    let upstream_ref = repo
+        .find_reference(&upstream_refname)
+        .with_context(|| format!("upstream ref '{upstream_refname}' not found after fetch"))?;
+    let fetch_commit = repo.reference_to_annotated_commit(&upstream_ref)?;
+
+    let (analysis, _preference) = repo.merge_analysis(&[&fetch_commit])?;
+
+    if analysis.is_up_to_date() {
+        return Ok(PullOutcome::UpToDate);
+    }
+
+    if analysis.is_fast_forward() {
+        let branch_refname = format!("refs/heads/{branch_name}");
+        let mut branch_ref = repo
+            .find_reference(&branch_refname)
+            .with_context(|| format!("local branch ref '{branch_refname}' not found"))?;
+        branch_ref.set_target(fetch_commit.id(), "over sync: fast-forward")?;
+        repo.set_head(&branch_refname)?;
+        // Force: the working directory must move from the pre-fetch tree
+        // to the fast-forwarded one; safe because the caller only ever
+        // reaches this branch on a *clean* working tree (checked before
+        // `pull` is invoked).
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))?;
+        return Ok(PullOutcome::FastForwarded);
+    }
+
+    if analysis.is_normal() {
+        // Writes conflict markers (if any) straight into the index/working
+        // directory and puts the repo in a merging state; does not move
+        // HEAD. Caller inspects the index below before deciding whether to
+        // commit or leave it for the user.
+        repo.merge(&[&fetch_commit], None, None)?;
+
+        let mut index = repo.index()?;
+        if index.has_conflicts() {
+            return Ok(PullOutcome::Conflict);
+        }
+
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+        let head_commit = repo.head()?.peel_to_commit()?;
+        let their_commit = repo.find_commit(fetch_commit.id())?;
+        let sig = signature(repo)?;
+        let message = format!("Merge '{upstream_refname}' via `over sync`");
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            &message,
+            &tree,
+            &[&head_commit, &their_commit],
+        )?;
+        // Clears MERGE_HEAD/MERGE_MSG now that the merge commit exists —
+        // mirrors what `git commit` does automatically after a conflict-free
+        // `git merge`.
+        repo.cleanup_state()?;
+        return Ok(PullOutcome::Merged);
+    }
+
+    // ANALYSIS_UNBORN (no commits yet) or any other combination we don't
+    // special-case: nothing safe to do automatically.
+    Ok(PullOutcome::UpToDate)
+}
+
+/// Abort an in-progress merge left by a conflicted [`pull`]: resets the
+/// index and working directory back to `HEAD` (which a plain `git2::merge`
+/// never moves, conflicted or not — confirmed against git2's own docs) and
+/// clears `MERGE_HEAD`/`MERGE_MSG`. Mirrors `git merge --abort` without
+/// needing to persist a "pre-merge HEAD" anywhere: `HEAD` already *is* the
+/// pre-merge commit.
+pub(crate) fn abort_merge(repo: &Repository) -> Result<()> {
+    let head_commit = repo
+        .head()
+        .context("failed to resolve HEAD")?
+        .peel_to_commit()
+        .context("HEAD does not point at a commit")?;
+    repo.reset(head_commit.as_object(), ResetType::Hard, None)
+        .context("failed to reset the working tree while aborting the merge")?;
+    repo.cleanup_state()
+        .context("failed to clear merge state (MERGE_HEAD/MERGE_MSG)")?;
+    Ok(())
+}
+
+/// Push `branch` to `origin` under the same name. Callers only invoke this
+/// once they've established the branch is actually ahead of its upstream
+/// (`status::git`'s ahead/behind helper) — pushing an up-to-date branch is
+/// harmless but wasteful.
+pub(crate) fn push_branch(repo: &Repository, branch: &str) -> Result<()> {
+    let mut remote = repo
+        .find_remote("origin")
+        .context("no 'origin' remote configured")?;
+    let mut push_options = PushOptions::new();
+    push_options.remote_callbacks(remote_callbacks()?);
+    let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+    remote
+        .push(&[refspec], Some(&mut push_options))
+        .with_context(|| format!("failed to push '{branch}' to 'origin'"))?;
+    Ok(())
+}
+
+/// The signature used for merge commits `over sync` creates. Prefers the
+/// checkout's own configured `user.name`/`user.email` (`repo.signature()`,
+/// which fails if neither is set) so authorship matches what the user
+/// would get from a manual `git merge`; falls back to an `over`-authored
+/// identity rather than erroring, since refusing to sync over a missing
+/// git identity would be a surprising, easily-hit failure mode for a tool
+/// managing the checkout on the user's behalf.
+fn signature(repo: &Repository) -> Result<Signature<'static>> {
+    match repo.signature() {
+        Ok(sig) => Ok(sig),
+        Err(_) => Signature::now("over", "over@localhost")
+            .context("failed to construct a fallback git signature"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use git2::{RepositoryState, Signature as GitSignature};
+    use std::fs;
+
+    /// Init a repo with a committer identity and one commit at `README.md`.
+    fn init_committed_repo(path: &std::path::Path) -> Repository {
+        let repo = Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        commit_all(&repo, "initial");
+        repo
+    }
+
+    fn commit_all(repo: &Repository, message: &str) {
+        let sig = GitSignature::now("Test", "test@test.com").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parents: Vec<_> = repo
+            .head()
+            .ok()
+            .and_then(|h| h.peel_to_commit().ok())
+            .into_iter()
+            .collect();
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+            .unwrap();
+    }
+
+    /// Clone `source` into a fresh local checkout with `main` tracking
+    /// `origin/main`, the fixture every test below builds on.
+    fn clone_with_tracking(source: &std::path::Path, dest: &std::path::Path) -> Repository {
+        let repo = git2::build::RepoBuilder::new()
+            .clone(source.to_str().unwrap(), dest)
+            .unwrap();
+        {
+            let mut branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+            branch.set_upstream(Some("origin/main")).unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn pull_with_no_upstream_reports_no_upstream() {
+        let td = TempDir::new().unwrap();
+        let repo = init_committed_repo(td.path());
+        assert_eq!(pull(&repo).unwrap(), PullOutcome::NoUpstream);
+    }
+
+    #[test]
+    fn pull_up_to_date_reports_up_to_date() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let repo = clone_with_tracking(source_td.path(), &dest_td.path().join("clone"));
+        assert_eq!(pull(&repo).unwrap(), PullOutcome::UpToDate);
+    }
+
+    #[test]
+    fn pull_fast_forwards_when_only_upstream_moved() {
+        let source_td = TempDir::new().unwrap();
+        let source_repo = init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let repo = clone_with_tracking(source_td.path(), &dest_td.path().join("clone"));
+
+        fs::write(source_td.path().join("new.txt"), "new").unwrap();
+        commit_all(&source_repo, "advance");
+
+        assert_eq!(pull(&repo).unwrap(), PullOutcome::FastForwarded);
+        assert!(dest_td.path().join("clone").join("new.txt").exists());
+        assert_eq!(repo.state(), RepositoryState::Clean);
+    }
+
+    #[test]
+    fn pull_merges_when_both_sides_advanced_without_conflict() {
+        let source_td = TempDir::new().unwrap();
+        let source_repo = init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let clone_path = dest_td.path().join("clone");
+        let repo = clone_with_tracking(source_td.path(), &clone_path);
+
+        // Diverge: one new file upstream, a different new file locally.
+        fs::write(source_td.path().join("upstream.txt"), "upstream").unwrap();
+        commit_all(&source_repo, "upstream change");
+        fs::write(clone_path.join("local.txt"), "local").unwrap();
+        commit_all(&repo, "local change");
+
+        assert_eq!(pull(&repo).unwrap(), PullOutcome::Merged);
+        assert!(clone_path.join("upstream.txt").exists());
+        assert!(clone_path.join("local.txt").exists());
+        assert_eq!(repo.state(), RepositoryState::Clean);
+        // A real merge commit with two parents was created.
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.parent_count(), 2);
+    }
+
+    #[test]
+    fn pull_leaves_real_conflict_markers_on_conflicting_changes() {
+        let source_td = TempDir::new().unwrap();
+        let source_repo = init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let clone_path = dest_td.path().join("clone");
+        let repo = clone_with_tracking(source_td.path(), &clone_path);
+
+        // Same file, conflicting content on both sides.
+        fs::write(source_td.path().join("README.md"), "upstream version").unwrap();
+        commit_all(&source_repo, "upstream edit");
+        fs::write(clone_path.join("README.md"), "local version").unwrap();
+        commit_all(&repo, "local edit");
+
+        assert_eq!(pull(&repo).unwrap(), PullOutcome::Conflict);
+        assert_eq!(repo.state(), RepositoryState::Merge);
+        let content = fs::read_to_string(clone_path.join("README.md")).unwrap();
+        assert!(content.contains("<<<<<<<"));
+    }
+
+    #[test]
+    fn abort_merge_restores_clean_pre_merge_state() {
+        let source_td = TempDir::new().unwrap();
+        let source_repo = init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let clone_path = dest_td.path().join("clone");
+        let repo = clone_with_tracking(source_td.path(), &clone_path);
+
+        fs::write(source_td.path().join("README.md"), "upstream version").unwrap();
+        commit_all(&source_repo, "upstream edit");
+        fs::write(clone_path.join("README.md"), "local version").unwrap();
+        commit_all(&repo, "local edit");
+        // Capture HEAD right before the conflicted merge attempt — this is
+        // what `abort_merge` must restore back to (it never moves HEAD
+        // itself, by construction).
+        let pre_merge_head = repo.head().unwrap().peel_to_commit().unwrap().id();
+        assert_eq!(pull(&repo).unwrap(), PullOutcome::Conflict);
+
+        abort_merge(&repo).unwrap();
+
+        assert_eq!(repo.state(), RepositoryState::Clean);
+        assert_eq!(
+            repo.head().unwrap().peel_to_commit().unwrap().id(),
+            pre_merge_head
+        );
+        assert!(!repo.index().unwrap().has_conflicts());
+        let content = fs::read_to_string(clone_path.join("README.md")).unwrap();
+        assert_eq!(content, "local version");
+    }
+
+    /// Bare "origin" remote seeded with one commit — libgit2's local
+    /// transport refuses to push into a non-bare repository ("local push
+    /// doesn't (yet) support pushing to non-bare repos"), so every push
+    /// test needs a bare destination, unlike the fetch/pull tests above
+    /// (fetching *from* a checked-out working directory over the local
+    /// transport is fine).
+    fn bare_origin_with_initial_commit(bare_path: &std::path::Path) {
+        let seed_td = TempDir::new().unwrap();
+        init_committed_repo(seed_td.path());
+        git2::Repository::init_bare(bare_path).unwrap();
+        let seed_repo = Repository::open(seed_td.path()).unwrap();
+        let mut remote = seed_repo
+            .remote_anonymous(bare_path.to_str().unwrap())
+            .unwrap();
+        remote
+            .push(&["refs/heads/main:refs/heads/main"], None)
+            .unwrap();
+        // A freshly pushed-to bare repo has no HEAD until one is set.
+        let bare_repo = Repository::open_bare(bare_path).unwrap();
+        bare_repo.set_head("refs/heads/main").unwrap();
+    }
+
+    #[test]
+    fn push_branch_sends_local_commits_to_origin() {
+        let origin_td = TempDir::new().unwrap();
+        let origin_path = origin_td.path().join("origin.git");
+        bare_origin_with_initial_commit(&origin_path);
+
+        let dest_td = TempDir::new().unwrap();
+        let clone_path = dest_td.path().join("clone");
+        let repo = clone_with_tracking(&origin_path, &clone_path);
+
+        fs::write(clone_path.join("local.txt"), "local").unwrap();
+        commit_all(&repo, "local change");
+
+        push_branch(&repo, "main").unwrap();
+
+        let origin_repo = Repository::open_bare(&origin_path).unwrap();
+        let origin_head = origin_repo
+            .find_reference("refs/heads/main")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap();
+        let local_head = repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(origin_head.id(), local_head.id());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ mod list;
 mod new;
 mod show;
 mod status;
+mod sync;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -82,6 +83,12 @@ pub enum Commands {
         about = "Show differences between desired and actual overlay state"
     )]
     Diff(diff::Params),
+
+    #[clap(
+        name = "sync",
+        about = "Reconcile a checkout-materialized overlay with its git source"
+    )]
+    Sync(sync::Params),
 }
 
 impl CLI {
@@ -125,6 +132,9 @@ pub async fn main() -> Result<()> {
         }
         Some(Commands::Diff(ref opt)) => {
             diff::execute(&args, opt).await?;
+        }
+        Some(Commands::Sync(ref opt)) => {
+            sync::execute(&args, opt).await?;
         }
         None => {
             use clap::CommandFactory;

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,0 +1,361 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use clap::Args;
+use dirs::home_dir;
+
+use crate::cli::CLI;
+use crate::desired::DesiredTree;
+use crate::exec::Context;
+use crate::overlays::{Overlay, Repository};
+use crate::sync::{self, SyncOptions, SyncOutcome};
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+#[derive(Args, Debug)]
+pub struct Params {
+    #[clap(help = "Name of the overlay to sync (all overlays if omitted)")]
+    name: Option<String>,
+
+    #[clap(short, long, help = "The target root directory (~)")]
+    root: Option<PathBuf>,
+
+    #[clap(long, help = "Do not process uses")]
+    no_uses: bool,
+
+    #[clap(
+        long,
+        conflicts_with = "push_only",
+        help = "Only pull upstream changes into the checkout"
+    )]
+    pull_only: bool,
+
+    #[clap(
+        long,
+        conflicts_with = "pull_only",
+        help = "Only push local commits to the overlay source"
+    )]
+    push_only: bool,
+
+    // Deliberately has no effect on `SyncOptions`: a plain re-run of `over
+    // sync` already behaves identically once conflicts are resolved (git's
+    // own `repo.state()` is what's actually being "continued", not any
+    // over-side flag) — kept purely for discoverability/intent-signaling,
+    // per #110's ask for an explicit `sync --continue` workflow.
+    #[clap(
+        long = "continue",
+        conflicts_with = "abort",
+        help = "Re-attempt a sync after resolving conflicts manually (alias for a plain re-run)"
+    )]
+    continue_: bool,
+
+    #[clap(long, help = "Abort an in-progress merge left by a conflicted sync")]
+    abort: bool,
+
+    #[clap(long, short = 'n', help = "Report what would happen without syncing")]
+    dry_run: bool,
+}
+
+impl Params {
+    fn options(&self) -> SyncOptions {
+        SyncOptions {
+            pull: !self.push_only,
+            push: !self.pull_only,
+            abort: self.abort,
+            dry_run: self.dry_run,
+        }
+    }
+}
+
+pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
+    if cli.debug {
+        tracing::debug!(?cli, ?args, "CLI args");
+    }
+
+    let home = cli.resolve_home()?;
+    let repo = Repository::new(home);
+    let root = args
+        .root
+        .clone()
+        .or_else(home_dir)
+        .ok_or_else(|| anyhow!("could not determine home directory"))?;
+
+    let overlays = match &args.name {
+        Some(name) => vec![repo.get(name)?],
+        None => repo.overlays()?,
+    };
+
+    if overlays.is_empty() {
+        println!("No overlays found.");
+        return Ok(());
+    }
+
+    let opts = args.options();
+    let mut needs_attention = false;
+    for overlay in &overlays {
+        needs_attention |= sync_overlay(cli, &repo, &root, overlay, args.no_uses, &opts).await?;
+    }
+
+    if needs_attention {
+        return Err(anyhow!(
+            "one or more checkouts need attention — see `conflict`/`blocked` entries above"
+        ));
+    }
+    Ok(())
+}
+
+async fn sync_overlay(
+    cli: &CLI,
+    repo: &Repository,
+    root: &Path,
+    overlay: &Overlay,
+    no_uses: bool,
+    opts: &SyncOptions,
+) -> Result<bool> {
+    let ctx = Context::builder()
+        .root(root.to_path_buf())
+        .repository(repo.clone())
+        .overlay(overlay.clone())
+        .no_uses(no_uses)
+        .build();
+    let target = overlay.resolve_target(&ctx)?;
+    let ctx = ctx.with_resolved_overlay(overlay.name.clone(), target.to_string_lossy().to_string());
+
+    // Full `uses` graph (not `build_own`): sync reconciles everything an
+    // overlay pulls in, exactly like `status`/`diff`/`Overlay::apply` do.
+    let desired = DesiredTree::build(&ctx, overlay)?;
+    let outcomes = sync::sync(&desired, opts).await?;
+
+    if outcomes.is_empty() {
+        if cli.verbose {
+            println!(
+                "{} {} {} {}",
+                emojis::PACKAGE,
+                style::white_b("Overlay"),
+                style::cyan(&overlay.name),
+                style::white("has no checkout-materialized root entry"),
+            );
+        }
+        return Ok(false);
+    }
+
+    println!(
+        "{} {} {} {} {}",
+        emojis::PACKAGE,
+        style::white_b("Overlay"),
+        style::cyan(&overlay.name),
+        style::white_b("->"),
+        style::cyan(&short_path(&target.to_string_lossy())),
+    );
+    // Unconditional summary (mirrors `status::Report::counts()`), so a
+    // plain `over sync` still reports e.g. "1 up to date" without needing
+    // `--verbose` — only the noisier per-checkout lines below are gated.
+    println!("  {}", summarize(&outcomes));
+
+    let mut needs_attention = false;
+    for outcome in &outcomes {
+        needs_attention |= outcome.needs_attention();
+        if cli.verbose || !matches!(outcome, SyncOutcome::UpToDate { .. }) {
+            println!("  {outcome}");
+        }
+    }
+    println!();
+
+    Ok(needs_attention)
+}
+
+/// One-line digest of every outcome for an overlay, e.g. "1 up to date, 1
+/// pushed, 1 conflict(s)". Only non-zero counts are listed.
+fn summarize(outcomes: &[SyncOutcome]) -> String {
+    let mut counts: Vec<(&str, usize)> = vec![
+        ("up to date", 0),
+        ("fast-forwarded", 0),
+        ("merged", 0),
+        ("pushed", 0),
+        ("conflict(s)", 0),
+        ("blocked", 0),
+        ("aborted", 0),
+    ];
+    for outcome in outcomes {
+        let idx = match outcome {
+            SyncOutcome::UpToDate { .. } => 0,
+            SyncOutcome::FastForwarded { .. } => 1,
+            SyncOutcome::Merged { .. } => 2,
+            SyncOutcome::Pushed { .. } => 3,
+            SyncOutcome::Conflict { .. } => 4,
+            SyncOutcome::Blocked { .. } => 5,
+            SyncOutcome::Aborted { .. } => 6,
+        };
+        counts[idx].1 += 1;
+    }
+    counts
+        .into_iter()
+        .filter(|(_, n)| *n > 0)
+        .map(|(label, n)| format!("{n} {label}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use clap::Parser;
+    use git2::Signature;
+    use std::fs;
+
+    fn make_cli(home: PathBuf) -> CLI {
+        CLI::parse_from(vec!["over", "--home", home.to_str().unwrap()])
+    }
+
+    fn params(name: Option<&str>, root: PathBuf) -> Params {
+        Params {
+            name: name.map(String::from),
+            root: Some(root),
+            no_uses: false,
+            pull_only: false,
+            push_only: false,
+            continue_: false,
+            abort: false,
+            dry_run: false,
+        }
+    }
+
+    fn init_committed_repo(path: &std::path::Path) {
+        let repo = git2::Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn sync_empty_repository() {
+        let tmp = TempDir::new().unwrap();
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, tmp.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sync_overlay_without_git_reports_nothing_to_sync() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("plain");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sync_up_to_date_checkout_succeeds() {
+        let tmp = TempDir::new().unwrap();
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("dotfiles");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(
+            ov.join("over.toml"),
+            format!(
+                "target = \"~\"\ngit = \"{}\"",
+                source_td.path().to_str().unwrap().replace('\\', "\\\\")
+            ),
+        )
+        .unwrap();
+
+        // Materialize the checkout first (mirrors `over apply`'s clone
+        // step) — `over sync` itself never clones.
+        let root_target = root.path();
+        git2::build::RepoBuilder::new()
+            .clone(source_td.path().to_str().unwrap(), root_target)
+            .unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(Some("dotfiles"), root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sync_unknown_overlay_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(
+            &cli,
+            &params(Some("does-not-exist"), root.path().to_path_buf()),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn options_default_syncs_both_directions() {
+        let p = params(None, PathBuf::from("/tmp"));
+        let opts = p.options();
+        assert!(opts.pull);
+        assert!(opts.push);
+        assert!(!opts.abort);
+        assert!(!opts.dry_run);
+    }
+
+    #[test]
+    fn options_pull_only_disables_push() {
+        let mut p = params(None, PathBuf::from("/tmp"));
+        p.pull_only = true;
+        let opts = p.options();
+        assert!(opts.pull);
+        assert!(!opts.push);
+    }
+
+    #[test]
+    fn options_push_only_disables_pull() {
+        let mut p = params(None, PathBuf::from("/tmp"));
+        p.push_only = true;
+        let opts = p.options();
+        assert!(!opts.pull);
+        assert!(opts.push);
+    }
+
+    #[test]
+    fn summarize_lists_only_non_zero_counts() {
+        let outcomes = vec![
+            SyncOutcome::UpToDate {
+                path: PathBuf::from("/a"),
+            },
+            SyncOutcome::UpToDate {
+                path: PathBuf::from("/b"),
+            },
+            SyncOutcome::Pushed {
+                path: PathBuf::from("/c"),
+            },
+        ];
+        let summary = summarize(&outcomes);
+        assert_eq!(summary, "2 up to date, 1 pushed");
+    }
+
+    #[test]
+    fn summarize_empty_outcomes_is_empty_string() {
+        assert_eq!(summarize(&[]), "");
+    }
+}

--- a/src/desired/entry.rs
+++ b/src/desired/entry.rs
@@ -40,11 +40,13 @@ pub enum MaterializationIntent {
         source: PathBuf,
         link_type: LinkType,
     },
-    /// A Git-managed path (`overlay.git`). Not yet materializable — no
-    /// [`crate::materialize::Materializer`] claims this intent yet, #110
-    /// owns turning this into a real checkout/worktree backend. Carried
-    /// here so a future `Plan`/diff/status (#13/#109/#12) can at least see
-    /// and report on it.
+    /// A Git-managed path (`overlay.git`). Materialized by
+    /// [`crate::materialize::CheckoutMaterializer`] (#110): ensures the
+    /// repository/worktree is present and configured, the same "presence"
+    /// concern `actions::git::clone_repositories` already implements.
+    /// Content-level bidirectional synchronization (fetch/merge/push) is a
+    /// separate, explicit operation (`over sync`, `crate::sync`), not part
+    /// of materialization.
     Checkout,
 }
 

--- a/src/desired/tree.rs
+++ b/src/desired/tree.rs
@@ -56,6 +56,15 @@ impl DesiredTree {
         &self.entries
     }
 
+    /// Test-only: build a tree directly from a list of entries, bypassing
+    /// `Overlay`/config resolution. Used by other modules' tests
+    /// (`crate::sync`) that exercise entry-level behavior without needing
+    /// a full overlay/repository/target-resolution fixture.
+    #[cfg(test)]
+    pub(crate) fn from_entries(entries: Vec<DesiredEntry>) -> Self {
+        Self { entries }
+    }
+
     pub fn len(&self) -> usize {
         self.entries.len()
     }
@@ -142,10 +151,9 @@ fn collect_own_entries(
         intent: MaterializationIntent::Directory,
     });
 
-    // Git-managed paths: not yet materializable (no registered Materializer
-    // claims this intent yet; #110 owns turning these into a real
-    // checkout/worktree backend), but carried so a future Plan/diff/status
-    // (#13/#109/#12) can at least see and report on them.
+    // Git-managed paths: materialized by CheckoutMaterializer (#110), which
+    // ensures presence/configuration only — content-level bidirectional
+    // sync is `over sync` (crate::sync), a separate explicit operation.
     if let Some(git_repos) = &overlay.git {
         for (repo_key, config) in git_repos {
             let repo_target = if repo_key == ROOT_PATH {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod materialize;
 pub mod overlays;
 pub mod plan;
 pub mod status;
+pub mod sync;
 pub mod ui;
 pub mod xdg;
 

--- a/src/materialize/checkout.rs
+++ b/src/materialize/checkout.rs
@@ -1,0 +1,226 @@
+//! Checkout materialization backend (#110).
+//!
+//! Fills the registry seam ADR-012 documented but deliberately left empty:
+//! [`MaterializationIntent::Checkout`] entries now have a real
+//! [`Materializer`]. Content-level bidirectional synchronization (fetch/
+//! merge/push) is *not* implemented here — that's `over sync`
+//! (`crate::sync`). This backend only owns the same "ensure the repository
+//! is present in its configured form" concern
+//! `actions::git::clone_repositories` already implements, wired into the
+//! `DesiredTree` → `Plan` → `Materializer` pipeline like every other intent.
+//!
+//! `Overlay::apply_inner` still calls `actions::git::clone_repositories`
+//! directly, in parallel, before building its `Plan` (unchanged, ADR-014) —
+//! by the time `Plan::build` classifies a `Checkout` entry during a normal
+//! `apply`, the repository already exists and classifies as `Operation::Noop`.
+//! This materializer's `materialize` is therefore a correctness fallback
+//! (any other caller of `Plan::execute`, e.g. tests), not the primary path.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::actions;
+use crate::desired::{DesiredEntry, MaterializationIntent, Provenance};
+use crate::exec::{Action, Ctx};
+use crate::plan::{Operation, PlanStep};
+use crate::status::{self, Status};
+
+use super::Materializer;
+
+/// Owns [`MaterializationIntent::Checkout`]. See the module doc for the
+/// scope split with `over sync`.
+pub struct CheckoutMaterializer;
+
+#[async_trait(?Send)]
+impl Materializer for CheckoutMaterializer {
+    fn handles(&self, intent: &MaterializationIntent) -> bool {
+        matches!(intent, MaterializationIntent::Checkout)
+    }
+
+    /// Reuses `status::git::inspect` verbatim rather than re-deriving
+    /// clean/dirty/ahead/behind/conflict detection — the same read-only
+    /// inspection `over status`/`over diff` already rely on.
+    fn classify(&self, entry: &DesiredEntry) -> Result<Operation> {
+        Ok(match status::git::inspect(entry)? {
+            Status::Missing => Operation::Create,
+            // Applied/Modified/Ahead/Behind/Diverged/Broken/Conflict all
+            // classify as `Noop`: `apply`/`Plan::execute` never mutates an
+            // *existing* checkout's content — only `over sync` does, and
+            // `over status`/`over diff` already surface these states via
+            // the same `status::git::inspect` call directly. Mapping them
+            // to `Operation::Conflict` would route a git checkout through
+            // the filesystem conflict-resolution UI (force/no_prompt/
+            // absorb-diff prompts) built for symlinks/files — the wrong
+            // semantics here, and a violation of "never discard
+            // uncommitted changes implicitly".
+            _ => Operation::Noop,
+        })
+    }
+
+    /// Only ever invoked for `Operation::Create` (`Plan::execute` skips
+    /// `Noop`/`Deferred`) — i.e. only when the repository doesn't exist
+    /// yet. Delegates to the same, unchanged `EnsureGitRepository` action
+    /// `actions::git::clone_repositories` already runs per entry.
+    async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()> {
+        let Provenance::Git {
+            config, overlay, ..
+        } = &step.entry.provenance
+        else {
+            unreachable!(
+                "Checkout entries only ever carry Provenance::Git \
+                 (see desired::tree::collect_own_entries)"
+            );
+        };
+        actions::git::EnsureGitRepository::new(
+            step.entry.target.clone(),
+            (**config).clone(),
+            overlay.clone(),
+        )
+        .execute(ctx)
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::git::config::GitRepoConfig;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use git2::Signature;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn git_config(url: &str) -> GitRepoConfig {
+        GitRepoConfig {
+            url: url.to_string(),
+            branch: None,
+            tag: None,
+            rev: None,
+            recurse_submodules: false,
+            worktree: false,
+            per_worktree_config: false,
+            worktrees: None,
+            remotes: None,
+            config: None,
+            worktree_config: None,
+        }
+    }
+
+    fn entry(target: PathBuf, config: GitRepoConfig) -> DesiredEntry {
+        DesiredEntry {
+            target,
+            provenance: Provenance::Git {
+                overlay: "ov".to_string(),
+                repo_key: ".".to_string(),
+                config: Box::new(config),
+            },
+            intent: MaterializationIntent::Checkout,
+        }
+    }
+
+    fn init_committed_repo(path: &std::path::Path) {
+        let repo = git2::Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+    }
+
+    #[test]
+    fn handles_only_checkout_intent() {
+        let m = CheckoutMaterializer;
+        assert!(m.handles(&MaterializationIntent::Checkout));
+        assert!(!m.handles(&MaterializationIntent::Directory));
+        assert!(!m.handles(&MaterializationIntent::SymlinkFile {
+            source: PathBuf::from("/src"),
+            link_type: crate::actions::symlink::LinkType::Soft,
+        }));
+    }
+
+    #[test]
+    fn classify_missing_checkout_is_create() {
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let e = entry(td.path().join("does-not-exist"), git_config(""));
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Create));
+    }
+
+    #[test]
+    fn classify_clean_checkout_is_noop() {
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        let e = entry(td.path().to_path_buf(), git_config(""));
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    fn classify_dirty_checkout_is_noop_not_conflict() {
+        // A dirty (or ahead/behind/diverged/conflicted/broken) checkout
+        // must never classify as `Operation::Conflict` — that would route
+        // it through filesystem conflict-resolution semantics that could
+        // discard the checkout's content.
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        fs::write(td.path().join("README.md"), "changed").unwrap();
+        let e = entry(td.path().to_path_buf(), git_config(""));
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    fn classify_broken_checkout_is_noop() {
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let dir = td.child("plain");
+        dir.create_dir_all().unwrap();
+        let e = entry(dir.path().to_path_buf(), git_config(""));
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[tokio::test]
+    async fn materialize_clones_missing_repository() {
+        use crate::exec::Context;
+        use crate::overlays::Repository;
+
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+
+        let dest_td = TempDir::new().unwrap();
+        let target = dest_td.path().join("checkout");
+
+        let m = CheckoutMaterializer;
+        let e = entry(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+        );
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Create,
+        };
+
+        let repo = Repository::new(dest_td.path().to_path_buf());
+        let ctx = Context::builder()
+            .root(dest_td.path().to_path_buf())
+            .repository(repo)
+            .build()
+            .with_multiprogress(indicatif::MultiProgress::new());
+
+        m.materialize(ctx, &step).await.unwrap();
+
+        assert!(target.join(".git").exists());
+        assert!(target.join("README.md").exists());
+    }
+}

--- a/src/materialize/mod.rs
+++ b/src/materialize/mod.rs
@@ -18,16 +18,18 @@
 //! Materializer::materialize   — concrete filesystem/Git changes
 //! ```
 //!
-//! Today [`MaterializerRegistry`] registers exactly one backend,
-//! [`SymlinkMaterializer`], which owns every intent except
-//! [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout).
-//! No backend claims `Checkout` yet: [`MaterializerRegistry::find`] returns
-//! `None` for it, and `Plan::build` falls back to `Operation::Deferred`
-//! exactly like before this issue. #110 adds a `CheckoutMaterializer` here
-//! to turn `Checkout` entries into real Git worktrees/checkouts, without
-//! `Plan` changing at all. #113's rule-migration semantics are a later
-//! extension of the same registry.
+//! [`MaterializerRegistry`] registers two backends: [`SymlinkMaterializer`]
+//! (every intent except `Checkout`) and [`CheckoutMaterializer`] (#110),
+//! which owns [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout) —
+//! ensuring a git checkout/worktree is present and configured, exactly like
+//! `actions::git::clone_repositories` already does. It does *not* implement
+//! content-level bidirectional sync (fetch/merge/push): that's `over sync`
+//! (`crate::sync`), a separate, explicit operation — see
+//! [ADR-014](https://github.com/noirbizarre/over/blob/main/docs/adr/014-bidirectional-checkout-synchronization.md).
+//! #113's rule-migration semantics are a later extension of the same
+//! registry.
 
+mod checkout;
 mod symlink;
 
 use anyhow::Result;
@@ -37,6 +39,7 @@ use crate::desired::{DesiredEntry, MaterializationIntent};
 use crate::exec::Ctx;
 use crate::plan::{Operation, PlanStep};
 
+pub use checkout::CheckoutMaterializer;
 pub use symlink::SymlinkMaterializer;
 
 /// A materialization backend: owns both read-only actual-state inspection
@@ -74,9 +77,10 @@ pub struct MaterializerRegistry {
 impl Default for MaterializerRegistry {
     fn default() -> Self {
         Self {
-            // #110 adds `Box::new(CheckoutMaterializer)` here to claim
-            // `MaterializationIntent::Checkout`.
-            backends: vec![Box::new(SymlinkMaterializer)],
+            backends: vec![
+                Box::new(SymlinkMaterializer),
+                Box::new(CheckoutMaterializer),
+            ],
         }
     }
 }
@@ -125,9 +129,9 @@ mod tests {
     }
 
     #[test]
-    fn registry_has_no_backend_for_checkout_yet() {
+    fn registry_finds_checkout_materializer_for_checkout() {
         let registry = MaterializerRegistry::default();
-        assert!(registry.find(&MaterializationIntent::Checkout).is_none());
+        assert!(registry.find(&MaterializationIntent::Checkout).is_some());
     }
 
     #[test]

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -110,16 +110,36 @@ impl fmt::Display for PlanStep {
                 current,
                 short_path(&source.to_string_lossy()),
             ),
-            (MaterializationIntent::Checkout, _) => write!(
+            (MaterializationIntent::Checkout, Operation::Create) => write!(
+                f,
+                "{} {} {}",
+                emojis::THREAD,
+                style::white("clone repository:"),
+                target,
+            ),
+            (MaterializationIntent::Checkout, Operation::Noop) => write!(
                 f,
                 "{} {} {} ({})",
-                emojis::THREAD,
+                emojis::CHECKMARK,
                 style::white("checkout:"),
                 target,
-                style::white("git materialization not yet supported, see #110"),
+                style::white("present (use `over sync` to update)"),
             ),
-            // `Directory`/`SymlinkFile`/`SymlinkDirectory` never produce
-            // `Deferred` (only `Checkout` does, handled above) — unreachable
+            // `CheckoutMaterializer::classify` never returns `Conflict` (git
+            // states are surfaced by `over status`/`over diff`/`over sync`
+            // instead, never routed through filesystem conflict
+            // resolution) — unreachable in practice, but a clear fallback
+            // beats a silently wrong line.
+            (MaterializationIntent::Checkout, Operation::Conflict { current }) => write!(
+                f,
+                "{} {} {} ({})",
+                emojis::WARNING,
+                style::yellow("conflict:"),
+                target,
+                current,
+            ),
+            // Every intent has a registered `Materializer` since #110; no
+            // step should ever classify as `Deferred` anymore — unreachable
             // in practice, but a clear fallback beats a silently wrong line.
             (_, Operation::Deferred) => write!(f, "{} deferred: {}", emojis::WARNING, target),
         }
@@ -224,13 +244,36 @@ mod tests {
     }
 
     #[test]
+    fn create_checkout_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::Checkout),
+            operation: Operation::Create,
+        };
+        let s = format!("{step}");
+        assert!(s.contains("clone repository:"));
+    }
+
+    #[test]
+    fn noop_checkout_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::Checkout),
+            operation: Operation::Noop,
+        };
+        let s = format!("{step}");
+        assert!(s.contains("checkout:"));
+        assert!(s.contains("over sync"));
+    }
+
+    #[test]
     fn deferred_checkout_display() {
+        // Unreachable in practice since #110 (every intent has a
+        // registered Materializer), but the fallback message must still
+        // render something sensible if ever constructed directly.
         let step = PlanStep {
             entry: entry(MaterializationIntent::Checkout),
             operation: Operation::Deferred,
         };
         let s = format!("{step}");
-        assert!(s.contains("checkout:"));
-        assert!(s.contains("#110"));
+        assert!(s.contains("deferred"));
     }
 }

--- a/src/status/git.rs
+++ b/src/status/git.rs
@@ -110,8 +110,9 @@ fn inspect_checkout(path: &Path) -> Result<Status> {
 }
 
 /// Whether the working tree has uncommitted changes (tracked or
-/// untracked, ignored files excluded).
-fn is_dirty(repo: &Repository) -> Result<bool> {
+/// untracked, ignored files excluded). `pub(crate)`: reused by `crate::sync`
+/// to refuse pulling into a dirty checkout.
+pub(crate) fn is_dirty(repo: &Repository) -> Result<bool> {
     let mut opts = git2::StatusOptions::new();
     opts.include_ignored(false).include_untracked(true);
     Ok(!repo.statuses(Some(&mut opts))?.is_empty())
@@ -119,8 +120,10 @@ fn is_dirty(repo: &Repository) -> Result<bool> {
 
 /// Ahead/behind counts of `HEAD` against its upstream tracking branch.
 /// `None` when `HEAD` is detached or has no configured upstream — neither
-/// is an error, just nothing to compare against.
-fn ahead_behind(repo: &Repository) -> Result<Option<(usize, usize)>> {
+/// is an error, just nothing to compare against. `pub(crate)`: reused by
+/// `crate::sync` to decide whether a push is needed after a successful
+/// pull.
+pub(crate) fn ahead_behind(repo: &Repository) -> Result<Option<(usize, usize)>> {
     let head = repo.head()?;
     if !head.is_branch() {
         return Ok(None);

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,0 +1,681 @@
+//! Bidirectional checkout synchronization (#110): `over sync`'s domain
+//! logic, driven by the CLI (`crate::cli::sync`).
+//!
+//! Scope, matching the roadmap (#112): only an overlay's **root** `git`
+//! entry (`overlay.git["."]`, keyed by
+//! [`ROOT_PATH`](crate::actions::git::config::ROOT_PATH)) is a
+//! bidirectional sync surface — "the overlay itself materialized as a
+//! checkout". Any subpath entry (a plugin-manager repo, etc.) is a
+//! "git repository declared inside an overlay": `over` ensures it's
+//! present/configured (`crate::materialize::CheckoutMaterializer`,
+//! `actions::git::clone_repositories`) but never fetches/merges/pushes its
+//! content here.
+//!
+//! Mutating primitives (fetch/merge/push/abort) live in
+//! `actions::git::sync`; this module only orchestrates: finds every root
+//! checkout entry in a [`DesiredTree`], expands a bare+worktrees config
+//! into one independent unit per worktree directory that actually exists
+//! on disk, and drives each unit through those primitives, persisting an
+//! informational checkpoint (`state`) along the way.
+
+pub mod state;
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use git2::{Repository, RepositoryState};
+
+use crate::actions::git::config::ROOT_PATH;
+use crate::actions::git::sync as git_sync;
+use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent, Provenance};
+use crate::status::git as status_git;
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+use crate::xdg::XdgDirs;
+use crate::xdg::state::StateFile;
+
+use state::{CheckoutRecord, SyncState};
+
+/// What `over sync` should attempt for every checkout it finds.
+#[derive(Debug, Clone, Copy)]
+pub struct SyncOptions {
+    pub pull: bool,
+    pub push: bool,
+    /// Abort an in-progress merge instead of syncing. Mutually exclusive
+    /// with `pull`/`push` in practice (the CLI never sets both), but kept
+    /// as a plain flag rather than a separate enum so `SyncOptions` stays
+    /// one small, uniform struct.
+    pub abort: bool,
+    /// Never perform network I/O or mutate anything — mirrors
+    /// `EnsureGitRepository`'s own `!ctx.dry_run` gate on cloning.
+    pub dry_run: bool,
+}
+
+impl Default for SyncOptions {
+    fn default() -> Self {
+        Self {
+            pull: true,
+            push: true,
+            abort: false,
+            dry_run: false,
+        }
+    }
+}
+
+/// What happened to a single checkout/worktree during `over sync`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncOutcome {
+    /// Already level with (or ahead of) its upstream; nothing to pull.
+    UpToDate { path: PathBuf },
+    /// Local branch had no divergent commits; its ref was moved forward.
+    FastForwarded { path: PathBuf },
+    /// A three-way merge was performed and committed cleanly.
+    Merged { path: PathBuf },
+    /// Local commits (from a prior state, or just created by a pull's
+    /// merge/fast-forward) were pushed to `origin`.
+    Pushed { path: PathBuf },
+    /// A merge produced real conflict markers; resolve manually (`git add`
+    /// + `git commit`) and re-run `over sync`, or run `over sync --abort`.
+    Conflict { path: PathBuf },
+    /// Refused to act — dirty working tree, no sync in progress for
+    /// `--abort`, or an unresolved non-conflicted merge state.
+    Blocked { path: PathBuf, reason: String },
+    /// `--abort` cleared an in-progress merge, restoring the pre-merge
+    /// working tree.
+    Aborted { path: PathBuf },
+}
+
+impl SyncOutcome {
+    /// Whether this outcome needs the user's attention — used by the CLI
+    /// to decide the process exit code, mirroring
+    /// `status::Status::needs_attention`.
+    pub fn needs_attention(&self) -> bool {
+        matches!(
+            self,
+            SyncOutcome::Conflict { .. } | SyncOutcome::Blocked { .. }
+        )
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            SyncOutcome::UpToDate { path }
+            | SyncOutcome::FastForwarded { path }
+            | SyncOutcome::Merged { path }
+            | SyncOutcome::Pushed { path }
+            | SyncOutcome::Conflict { path }
+            | SyncOutcome::Blocked { path, .. }
+            | SyncOutcome::Aborted { path } => path,
+        }
+    }
+
+    /// Short, stable label used for both display and the informational
+    /// `state::CheckoutRecord::last_outcome` field.
+    fn label(&self) -> &'static str {
+        match self {
+            SyncOutcome::UpToDate { .. } => "up to date",
+            SyncOutcome::FastForwarded { .. } => "fast-forwarded",
+            SyncOutcome::Merged { .. } => "merged",
+            SyncOutcome::Pushed { .. } => "pushed",
+            SyncOutcome::Conflict { .. } => "conflict",
+            SyncOutcome::Blocked { .. } => "blocked",
+            SyncOutcome::Aborted { .. } => "aborted",
+        }
+    }
+}
+
+impl fmt::Display for SyncOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let target = short_path(&self.path().to_string_lossy());
+        match self {
+            SyncOutcome::UpToDate { .. } => {
+                write!(
+                    f,
+                    "{} {} {}",
+                    emojis::CHECKMARK,
+                    style::white("up to date:"),
+                    target
+                )
+            }
+            SyncOutcome::FastForwarded { .. } => write!(
+                f,
+                "{} {} {}",
+                emojis::CHECKMARK,
+                style::white("fast-forwarded:"),
+                target
+            ),
+            SyncOutcome::Merged { .. } => {
+                write!(
+                    f,
+                    "{} {} {}",
+                    emojis::CHECKMARK,
+                    style::white("merged:"),
+                    target
+                )
+            }
+            SyncOutcome::Pushed { .. } => {
+                write!(
+                    f,
+                    "{} {} {}",
+                    emojis::SPARKLE,
+                    style::white("pushed:"),
+                    target
+                )
+            }
+            SyncOutcome::Conflict { .. } => write!(
+                f,
+                "{} {} {} ({})",
+                emojis::WARNING,
+                style::yellow("conflict:"),
+                target,
+                style::white("resolve manually, then re-run `over sync`, or `over sync --abort`"),
+            ),
+            SyncOutcome::Blocked { reason, .. } => write!(
+                f,
+                "{} {} {} ({})",
+                emojis::WARNING,
+                style::yellow("blocked:"),
+                target,
+                reason,
+            ),
+            SyncOutcome::Aborted { .. } => {
+                write!(
+                    f,
+                    "{} {} {}",
+                    emojis::CROSSMARK,
+                    style::white("aborted:"),
+                    target
+                )
+            }
+        }
+    }
+}
+
+/// One independently-syncable checkout: either the whole (non-bare)
+/// checkout, or one worktree of a bare+worktrees repository.
+struct SyncUnit {
+    path: PathBuf,
+    overlay: String,
+    repo_key: String,
+    worktree: Option<String>,
+}
+
+/// Find every root (`ROOT_PATH`) [`MaterializationIntent::Checkout`] entry
+/// in `desired`, expand each into its sync units, and drive every unit
+/// through [`SyncOptions`]. Never touches subpath `git` entries — those
+/// stay opaque resources, per this module's scope (see module doc).
+pub async fn sync(desired: &DesiredTree, opts: &SyncOptions) -> Result<Vec<SyncOutcome>> {
+    let state_file: StateFile<SyncState> =
+        StateFile::new(XdgDirs::new()?.state_dir().join("sync.toml"));
+
+    let mut outcomes = Vec::new();
+    for entry in desired.entries() {
+        if !matches!(entry.intent, MaterializationIntent::Checkout) {
+            continue;
+        }
+        let Provenance::Git { repo_key, .. } = &entry.provenance else {
+            unreachable!(
+                "Checkout entries only ever carry Provenance::Git \
+                 (see desired::tree::collect_own_entries)"
+            );
+        };
+        if repo_key != ROOT_PATH {
+            continue;
+        }
+
+        for unit in sync_units(entry)? {
+            let outcome = sync_unit(&unit, opts)?;
+            if !opts.dry_run {
+                persist_checkpoint(&state_file, &unit, &outcome).await?;
+            }
+            outcomes.push(outcome);
+        }
+    }
+
+    Ok(outcomes)
+}
+
+/// Expand a root `Checkout` entry into its independent sync units: one for
+/// a plain checkout, or one per worktree directory that actually exists on
+/// disk for a bare+worktrees repository — mirrors
+/// `status::git::inspect`'s own worktree aggregation, except each worktree
+/// is synced on its own rather than reduced to a single severity-ranked
+/// status.
+fn sync_units(entry: &DesiredEntry) -> Result<Vec<SyncUnit>> {
+    let Provenance::Git {
+        overlay,
+        repo_key,
+        config,
+    } = &entry.provenance
+    else {
+        unreachable!(
+            "Checkout entries only ever carry Provenance::Git \
+             (see desired::tree::collect_own_entries)"
+        );
+    };
+
+    let is_bare = config.worktree || config.worktrees.is_some();
+    if !is_bare {
+        return Ok(vec![SyncUnit {
+            path: entry.target.clone(),
+            overlay: overlay.clone(),
+            repo_key: repo_key.clone(),
+            worktree: None,
+        }]);
+    }
+
+    let bare_path = entry.target.join(".git");
+    if !bare_path.exists() {
+        // Not cloned yet — `over apply`/`CheckoutMaterializer` handles
+        // that; nothing to sync until it exists.
+        return Ok(Vec::new());
+    }
+    let repo = Repository::open_bare(&bare_path)
+        .with_context(|| format!("failed to open bare repository at {}", bare_path.display()))?;
+
+    let mut units = Vec::new();
+    for name in repo.worktrees()?.iter().flatten().flatten() {
+        let wt_path = entry.target.join(name);
+        if wt_path.exists() {
+            units.push(SyncUnit {
+                path: wt_path,
+                overlay: overlay.clone(),
+                repo_key: repo_key.clone(),
+                worktree: Some(name.to_string()),
+            });
+        }
+    }
+    Ok(units)
+}
+
+/// Drive a single [`SyncUnit`] through pull/push, never touching anything
+/// if the working tree is dirty or a prior merge is unresolved.
+fn sync_unit(unit: &SyncUnit, opts: &SyncOptions) -> Result<SyncOutcome> {
+    let path = unit.path.clone();
+    let repo = Repository::open(&path)
+        .with_context(|| format!("failed to open git repository at {}", path.display()))?;
+
+    if repo.state() != RepositoryState::Clean {
+        return handle_unresolved_state(&repo, &path, opts);
+    }
+
+    if opts.abort {
+        return Ok(SyncOutcome::Blocked {
+            path,
+            reason: "no sync in progress".to_string(),
+        });
+    }
+
+    if opts.pull && status_git::is_dirty(&repo)? {
+        // Never touch a dirty working tree, implicitly or otherwise.
+        return Ok(SyncOutcome::Blocked {
+            path,
+            reason: "uncommitted changes; commit or stash before syncing".to_string(),
+        });
+    }
+
+    if opts.dry_run {
+        // No network I/O under dry-run (mirrors `EnsureGitRepository`'s own
+        // `!ctx.dry_run` gate on cloning): report using whichever
+        // remote-tracking state is already on disk from the last real
+        // fetch/clone, without contacting the network.
+        let (ahead, behind) = status_git::ahead_behind(&repo)?.unwrap_or((0, 0));
+        return Ok(if opts.pull && behind > 0 {
+            SyncOutcome::FastForwarded { path }
+        } else if opts.push && ahead > 0 {
+            SyncOutcome::Pushed { path }
+        } else {
+            SyncOutcome::UpToDate { path }
+        });
+    }
+
+    let mut outcome = SyncOutcome::UpToDate { path: path.clone() };
+
+    if opts.pull {
+        outcome = match git_sync::pull(&repo)? {
+            git_sync::PullOutcome::NoUpstream | git_sync::PullOutcome::UpToDate => {
+                SyncOutcome::UpToDate { path: path.clone() }
+            }
+            git_sync::PullOutcome::FastForwarded => {
+                SyncOutcome::FastForwarded { path: path.clone() }
+            }
+            git_sync::PullOutcome::Merged => SyncOutcome::Merged { path: path.clone() },
+            // Never push on top of an unresolved conflict.
+            git_sync::PullOutcome::Conflict => {
+                return Ok(SyncOutcome::Conflict { path: path.clone() });
+            }
+        };
+    }
+
+    if opts.push {
+        let ahead = status_git::ahead_behind(&repo)?.map_or(0, |(ahead, _)| ahead);
+        if ahead > 0 {
+            let branch = current_branch_name(&repo)?;
+            git_sync::push_branch(&repo, &branch)?;
+            outcome = SyncOutcome::Pushed { path: path.clone() };
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Handle a repository already mid-merge (or some other non-`Clean`
+/// libgit2 state) when `over sync` starts.
+fn handle_unresolved_state(
+    repo: &Repository,
+    path: &Path,
+    opts: &SyncOptions,
+) -> Result<SyncOutcome> {
+    if opts.abort {
+        git_sync::abort_merge(repo)?;
+        return Ok(SyncOutcome::Aborted {
+            path: path.to_path_buf(),
+        });
+    }
+    if repo.index()?.has_conflicts() {
+        return Ok(SyncOutcome::Conflict {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(SyncOutcome::Blocked {
+        path: path.to_path_buf(),
+        reason: "finish resolving and commit, or run `over sync --abort`".to_string(),
+    })
+}
+
+fn current_branch_name(repo: &Repository) -> Result<String> {
+    repo.head()?
+        .shorthand()
+        .map(str::to_string)
+        .context("current branch name is not valid UTF-8")
+}
+
+/// Best-effort, purely informational: never read back to decide sync
+/// correctness (see module doc and `state`'s own doc comment).
+async fn persist_checkpoint(
+    state_file: &StateFile<SyncState>,
+    unit: &SyncUnit,
+    outcome: &SyncOutcome,
+) -> Result<()> {
+    let key = unit.path.to_string_lossy().to_string();
+    let oid = Repository::open(&unit.path).ok().and_then(|repo| {
+        repo.head()
+            .ok()
+            .and_then(|head| head.peel_to_commit().ok())
+            .map(|commit| commit.id().to_string())
+    });
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    let record = CheckoutRecord {
+        overlay: unit.overlay.clone(),
+        repo_key: unit.repo_key.clone(),
+        worktree: unit.worktree.clone(),
+        last_synced_oid: oid,
+        last_synced_at: Some(now),
+        last_outcome: Some(outcome.label().to_string()),
+    };
+    state_file
+        .update(move |s| {
+            s.checkouts.insert(key, record);
+            Ok(())
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::git::config::GitRepoConfig;
+    use assert_fs::TempDir;
+    use git2::Signature;
+    use std::fs;
+
+    fn git_config(worktree: bool) -> GitRepoConfig {
+        GitRepoConfig {
+            url: String::new(),
+            branch: None,
+            tag: None,
+            rev: None,
+            recurse_submodules: false,
+            worktree,
+            per_worktree_config: false,
+            worktrees: None,
+            remotes: None,
+            config: None,
+            worktree_config: None,
+        }
+    }
+
+    fn checkout_entry(target: PathBuf, repo_key: &str, config: GitRepoConfig) -> DesiredEntry {
+        DesiredEntry {
+            target,
+            provenance: Provenance::Git {
+                overlay: "ov".to_string(),
+                repo_key: repo_key.to_string(),
+                config: Box::new(config),
+            },
+            intent: MaterializationIntent::Checkout,
+        }
+    }
+
+    fn init_committed_repo(path: &std::path::Path) {
+        let repo = Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+    }
+
+    fn clone_with_tracking(source: &std::path::Path, dest: &std::path::Path) -> Repository {
+        let repo = git2::build::RepoBuilder::new()
+            .clone(source.to_str().unwrap(), dest)
+            .unwrap();
+        {
+            let mut branch = repo.find_branch("main", git2::BranchType::Local).unwrap();
+            branch.set_upstream(Some("origin/main")).unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn sync_units_non_bare_is_a_single_unit_at_target() {
+        let td = TempDir::new().unwrap();
+        let entry = checkout_entry(td.path().to_path_buf(), ".", git_config(false));
+        let units = sync_units(&entry).unwrap();
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].path, td.path());
+        assert_eq!(units[0].worktree, None);
+    }
+
+    #[test]
+    fn sync_units_subpath_entry_is_still_expanded_but_never_synced_by_the_caller() {
+        // `sync_units` itself doesn't filter by repo_key (that's `sync`'s
+        // job) — verify it still just expands based on bare-ness.
+        let td = TempDir::new().unwrap();
+        let entry = checkout_entry(td.path().to_path_buf(), ".config/nvim", git_config(false));
+        let units = sync_units(&entry).unwrap();
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].repo_key, ".config/nvim");
+    }
+
+    #[test]
+    fn sync_units_bare_without_clone_yet_is_empty() {
+        let td = TempDir::new().unwrap();
+        let entry = checkout_entry(td.path().join("missing"), ".", git_config(true));
+        let units = sync_units(&entry).unwrap();
+        assert!(units.is_empty());
+    }
+
+    #[test]
+    fn sync_ignores_subpath_git_entries() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let checkout_path = dest_td.path().join("checkout");
+        clone_with_tracking(source_td.path(), &checkout_path);
+
+        let entry = checkout_entry(checkout_path, ".config/nvim", git_config(false));
+        let desired = DesiredTree::from_entries(vec![entry]);
+
+        let outcomes = tokio_test_block_on(sync(&desired, &SyncOptions::default()));
+        assert!(outcomes.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sync_root_entry_up_to_date_reports_up_to_date() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let checkout_path = dest_td.path().join("checkout");
+        clone_with_tracking(source_td.path(), &checkout_path);
+
+        let entry = checkout_entry(checkout_path.clone(), ".", git_config(false));
+        let desired = DesiredTree::from_entries(vec![entry]);
+
+        let outcomes = sync(&desired, &SyncOptions::default()).await.unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(
+            outcomes[0],
+            SyncOutcome::UpToDate {
+                path: checkout_path
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_blocks_on_dirty_working_tree_without_touching_it() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let checkout_path = dest_td.path().join("checkout");
+        clone_with_tracking(source_td.path(), &checkout_path);
+        fs::write(checkout_path.join("README.md"), "dirty").unwrap();
+
+        let entry = checkout_entry(checkout_path.clone(), ".", git_config(false));
+        let desired = DesiredTree::from_entries(vec![entry]);
+
+        let outcomes = sync(&desired, &SyncOptions::default()).await.unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(outcomes[0], SyncOutcome::Blocked { .. }));
+        // Untouched: still reports the dirty content, not reverted/merged.
+        assert_eq!(
+            fs::read_to_string(checkout_path.join("README.md")).unwrap(),
+            "dirty"
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_performs_no_mutation() {
+        let source_td = TempDir::new().unwrap();
+        let source_repo = init_committed_repo_ret(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let checkout_path = dest_td.path().join("checkout");
+        let checkout_repo = clone_with_tracking(source_td.path(), &checkout_path);
+
+        fs::write(source_td.path().join("new.txt"), "new").unwrap();
+        commit_all(&source_repo, "advance");
+        // A real (non-dry-run) fetch beforehand, so the checkout's
+        // remote-tracking ref already knows about the upstream advance —
+        // dry-run itself never performs network I/O (mirrors
+        // `EnsureGitRepository`'s own `!ctx.dry_run` gate), so without this
+        // it would have no way to know a pull is even available.
+        git_sync::fetch_origin(&checkout_repo).unwrap();
+
+        let entry = checkout_entry(checkout_path.clone(), ".", git_config(false));
+        let desired = DesiredTree::from_entries(vec![entry]);
+
+        let opts = SyncOptions {
+            dry_run: true,
+            ..SyncOptions::default()
+        };
+        let outcomes = sync(&desired, &opts).await.unwrap();
+        assert_eq!(outcomes.len(), 1);
+        // Reports what *would* happen (behind its now-fetched upstream)...
+        assert!(matches!(outcomes[0], SyncOutcome::FastForwarded { .. }));
+        // ...without actually updating the checkout's working tree.
+        assert!(!checkout_path.join("new.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn bare_worktrees_are_synced_independently() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        let base = dest_td.path().join("checkout");
+        fs::create_dir_all(&base).unwrap();
+        let bare_path = base.join(".git");
+        let bare_repo = git2::build::RepoBuilder::new()
+            .bare(true)
+            .clone(source_td.path().to_str().unwrap(), &bare_path)
+            .unwrap();
+
+        let main_wt = base.join("main");
+        {
+            let branch_ref = bare_repo
+                .find_branch("main", git2::BranchType::Local)
+                .unwrap()
+                .into_reference();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(&branch_ref));
+            bare_repo.worktree("main", &main_wt, Some(&opts)).unwrap();
+        }
+        {
+            let wt_repo = Repository::open(&main_wt).unwrap();
+            wt_repo
+                .find_branch("main", git2::BranchType::Local)
+                .unwrap()
+                .set_upstream(Some("origin/main"))
+                .unwrap();
+        }
+
+        let entry = checkout_entry(base, ".", git_config(true));
+        let desired = DesiredTree::from_entries(vec![entry]);
+
+        let outcomes = sync(&desired, &SyncOptions::default()).await.unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0], SyncOutcome::UpToDate { path: main_wt });
+    }
+
+    // ── test-only helpers duplicated from `actions::git::sync`'s test
+    // module (kept local rather than shared across `#[cfg(test)]` boundaries) ──
+
+    fn init_committed_repo_ret(path: &std::path::Path) -> Repository {
+        init_committed_repo(path);
+        Repository::open(path).unwrap()
+    }
+
+    fn commit_all(repo: &Repository, message: &str) {
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+            .unwrap();
+    }
+
+    fn tokio_test_block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+}

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -1,0 +1,96 @@
+//! Persisted, informational-only bookkeeping for `over sync` (#110/#111).
+//!
+//! Deliberately **not** authoritative: nothing that decides whether a
+//! checkout can be safely synced, whether a merge is in progress, or how to
+//! recover from a conflict ever reads this file — that all comes from
+//! git's own `repo.state()`/`MERGE_HEAD`/index (see
+//! `actions::git::sync`). This is purely the "overlay source/worktree
+//! association and synchronization checkpoint" the issue asks to persist
+//! under `$XDG_STATE_HOME/over`, read back only to enrich `over sync`'s own
+//! output (e.g. "last synced 3 days ago"). Deleting this file loses none of
+//! that correctness, only the informational history.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::xdg::state::VersionedState;
+
+/// One record per synced checkout/worktree path, keyed by its
+/// canonicalized target path (string form, so it round-trips through TOML
+/// map keys).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SyncState {
+    pub checkouts: HashMap<String, CheckoutRecord>,
+}
+
+impl VersionedState for SyncState {
+    const VERSION: u32 = 1;
+}
+
+/// Informational record for a single checkout/worktree.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CheckoutRecord {
+    pub overlay: String,
+    /// Always `"."` today — `over sync` only ever operates on an overlay's
+    /// root `git` entry (see `crate::sync`'s module doc).
+    pub repo_key: String,
+    /// `Some(name)` for one worktree of a bare+worktrees repo, `None` for a
+    /// plain (non-bare) checkout.
+    pub worktree: Option<String>,
+    pub last_synced_oid: Option<String>,
+    /// Unix timestamp (seconds) of the last sync *attempt* (recorded even
+    /// when the outcome was `Blocked`/`Conflict`, so this reflects "last
+    /// time `over sync` looked at this checkout", not just the last
+    /// success). A plain integer rather than a formatted timestamp so this
+    /// module doesn't need a date/time dependency just to record one.
+    pub last_synced_at: Option<i64>,
+    /// Short human-readable label of the last outcome (e.g. `"merged"`,
+    /// `"conflict"`), for display only.
+    pub last_outcome: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::xdg::state::StateFile;
+
+    #[tokio::test]
+    async fn round_trips_through_state_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file: StateFile<SyncState> = StateFile::new(tmp.path().join("sync.toml"));
+
+        state_file
+            .update(|s| {
+                s.checkouts.insert(
+                    "/home/user/.config/nvim".to_string(),
+                    CheckoutRecord {
+                        overlay: "dotfiles".to_string(),
+                        repo_key: ".".to_string(),
+                        worktree: None,
+                        last_synced_oid: Some("abc123".to_string()),
+                        last_synced_at: Some(1_700_000_000),
+                        last_outcome: Some("merged".to_string()),
+                    },
+                );
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        let loaded = state_file.load().await.unwrap();
+        let record = loaded.checkouts.get("/home/user/.config/nvim").unwrap();
+        assert_eq!(record.overlay, "dotfiles");
+        assert_eq!(record.last_synced_oid.as_deref(), Some("abc123"));
+    }
+
+    #[tokio::test]
+    async fn missing_file_loads_as_empty_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file: StateFile<SyncState> = StateFile::new(tmp.path().join("sync.toml"));
+
+        let loaded = state_file.load().await.unwrap();
+
+        assert!(loaded.checkouts.is_empty());
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -522,6 +522,229 @@ fn diff_empty_repository_reports_no_overlays() -> TestResult {
     Ok(())
 }
 
+// ── sync integration tests ────────────────────────────────────────────────
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .expect("failed to run git");
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
+/// A local "origin" repository with one commit — good enough for git2's
+/// local transport to clone/fetch/push against.
+fn setup_git_origin(path: &Path) {
+    fs::create_dir_all(path).unwrap();
+    git(path, &["init"]);
+    git(
+        path,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+    );
+}
+
+/// A `gitsync`-style overlay whose *root* content is cloned from `origin`
+/// (the `over sync` bidirectional sync surface — see ADR-014).
+fn setup_git_overlay(home: &Path, name: &str, origin: &Path) {
+    let ov = home.join(name);
+    fs::create_dir_all(&ov).unwrap();
+    let origin_str = origin.to_string_lossy().replace('\\', "\\\\");
+    fs::write(
+        ov.join("over.toml"),
+        format!("target = \"~\"\ngit = \"{origin_str}\"\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn sync_unknown_overlay_fails() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .args(["sync", "does-not-exist"])
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[test]
+fn sync_empty_repository_reports_no_overlays() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .arg("sync")
+        .assert()
+        .success()
+        .stdout(contains("No overlays found"));
+    Ok(())
+}
+
+#[test]
+fn sync_overlay_without_git_entry_succeeds_quietly() -> TestResult {
+    let repo = setup_overlay_repo();
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["sync", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success();
+    Ok(())
+}
+
+#[test]
+fn sync_reports_up_to_date_right_after_apply() -> TestResult {
+    let tmp = TempDir::new()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
+    let origin = canonical_tmp.join("origin");
+    setup_git_origin(&origin);
+    setup_git_overlay(&canonical_tmp, "gitsync", &origin);
+
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["apply", "gitsync", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["sync", "gitsync", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("up to date"));
+    Ok(())
+}
+
+#[test]
+fn sync_pulls_and_fast_forwards_after_upstream_advances() -> TestResult {
+    let tmp = TempDir::new()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
+    let origin = canonical_tmp.join("origin");
+    setup_git_origin(&origin);
+    setup_git_overlay(&canonical_tmp, "gitsync2", &origin);
+
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["apply", "gitsync2", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    // Advance "upstream" after the initial clone.
+    fs::write(origin.join("new.txt"), b"new")?;
+    git(&origin, &["add", "new.txt"]);
+    git(
+        &origin,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "advance",
+        ],
+    );
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["sync", "gitsync2", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("fast-forwarded"));
+
+    assert!(root.path().join("new.txt").exists());
+    Ok(())
+}
+
+#[test]
+fn sync_blocks_on_dirty_checkout_without_touching_it() -> TestResult {
+    let tmp = TempDir::new()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
+    let origin = canonical_tmp.join("origin");
+    setup_git_origin(&origin);
+    setup_git_overlay(&canonical_tmp, "gitsync3", &origin);
+
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["apply", "gitsync3", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    fs::write(root.path().join("dirty.txt"), b"uncommitted")?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["sync", "gitsync3", "--root"])
+        .arg(root.path())
+        .assert()
+        .failure()
+        .stdout(contains("blocked"));
+
+    // Untouched: the dirty file is still there, nothing was reverted/merged.
+    assert!(root.path().join("dirty.txt").exists());
+    Ok(())
+}
+
+#[test]
+fn sync_dry_run_reports_without_mutating() -> TestResult {
+    let tmp = TempDir::new()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
+    let origin = canonical_tmp.join("origin");
+    setup_git_origin(&origin);
+    setup_git_overlay(&canonical_tmp, "gitsync4", &origin);
+
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["apply", "gitsync4", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["sync", "gitsync4", "--root"])
+        .arg(root.path())
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(contains("up to date"));
+    Ok(())
+}
+
 // ── show integration tests ──────────────────────────────────────────────
 
 #[test]

--- a/zensical.toml
+++ b/zensical.toml
@@ -32,6 +32,7 @@ nav = [
     { "over completion" = "usage/completion.md" },
     { "over status" = "usage/status.md" },
     { "over diff" = "usage/diff.md" },
+    { "over sync" = "usage/sync.md" },
     { "git over mount" = "usage/git-over-mount.md" },
     { "git over add" = "usage/git-over-add.md" },
     { "git over status" = "usage/git-over-status.md" },


### PR DESCRIPTION
Implements bidirectional synchronization between an overlay's checkout-materialized root content and its git source, completing the checkout-materialization workflow started by #108.

- `CheckoutMaterializer` fills the `Materializer` registry seam for `MaterializationIntent::Checkout`, ensuring a git checkout is present/configured through the same `Plan`/`Materializer` pipeline as symlinks.
- A new `over sync` command reconciles a checkout with its origin: fetch + fast-forward/merge upstream changes, push local commits, and a `--continue`/`--abort` workflow for resolving conflicts with ordinary git tooling. Only an overlay's root `git` entry is a sync surface — nested/declared repositories stay untouched, exactly as before.
- Sync never touches a dirty working tree or auto-resolves conflicts; git's own merge machinery and repository state remain authoritative. A small, informational checkpoint is persisted under `$XDG_STATE_HOME/over` purely for display, never for correctness.

See ADR-014 for the full design rationale.

Closes #110
