### PR TITLE
feat(unapply): add over unapply to remove an overlay's own entries

### DIFF
--- a/docs/adr/015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md
+++ b/docs/adr/015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md
@@ -1,0 +1,106 @@
+# ADR-015: `unapply` reuses `Plan`'s classification and only ever removes safely reversible state
+
+**Status:** accepted
+
+## Context
+
+Issue #64 asks for `over unapply`: a reverse reconciliation from an
+overlay's desired state and actual filesystem/git state, explicitly
+*without* relying on an authoritative serialized `ApplyState` — "Respect
+the desired-vs-actual model rather than introducing a separate imperative
+removal mechanism." ADR-011 already anticipated this: `Plan`/`DesiredTree`
+were built as the shared vocabulary `status`/`diff`/`unapply` (#12/#109/#64)
+would each build on, and ADR-013 established the precedent that each of
+these commands defines its own result taxonomy rather than forcing a
+shared one.
+
+Without a persisted apply-time record, `unapply` has no way to know
+whether it created a given directory or whether it already existed (e.g.
+the user's home directory, when `target = "~"`), nor whether a git
+checkout has commits or edits that only exist locally. The issue is
+explicit that this must never be guessed: "never implicitly discard
+uncommitted changes or local commits", and destructive transitions must be
+"explicit and previewable".
+
+## Decision
+
+**Scope: the named overlay's own entries only, no `uses` recursion.**
+`DesiredTree::build_own` is used, mirroring `Overlay::apply_inner`'s
+per-node scope. Unlike `apply`, `unapply` does not recurse into `uses`:
+removing a shared dependency's entries here could break another,
+still-applied overlay that also `uses` it (a diamond dependency). A used
+overlay is unapplied by naming it explicitly.
+
+**Classification reuses `Plan::build`'s existing `Operation`, unmodified.**
+For `Directory`/`SymlinkFile`/`SymlinkDirectory` intents, `Operation::Noop`
+already means exactly "the target still matches what this overlay would
+materialize here" (including a dangling soft symlink whose source has
+since vanished — still *our* link, just broken) and `Operation::Conflict`
+already means "something else occupies the target". `crate::unapply::Outcome`
+maps these directly: `Noop → Removed`, `Conflict → NotOwned`, `Create →
+AlreadyAbsent`. No new read pass over the filesystem, and no changes to
+`Plan`/`PlanStep`/`Operation` were needed — confirming ADR-011's original
+promise. `Outcome` is its own enum, not a reuse of `status::Status` or
+`diff::Change`, per ADR-013's "own taxonomy" precedent.
+
+`Plan`'s classification is deliberately too coarse for `Checkout` entries
+(`CheckoutMaterializer::classify` collapses every non-`Missing` git state
+to `Operation::Noop` by design, ADR-014, to avoid routing git state through
+filesystem conflict-resolution UI). `unapply` calls `status::git::inspect`
+directly instead — exactly like `status`/`diff` already do — and only
+removes a checkout when it reports `Status::Applied`: fully in sync with
+its upstream, nothing uncommitted, nothing unpushed. Every other status
+(`Modified`/`Ahead`/`Behind`/`Diverged`/`Conflict`/`Broken`) is left
+untouched, unconditionally — there is no `--force` override, because there
+is nothing here that should ever be forced. This directly reuses #110's
+own safety primitive rather than re-deriving a notion of "clean enough to
+delete".
+
+**No persisted apply-state is needed for directories either.** A directory
+is only ever removed with a non-recursive `fs::remove_dir`
+(`unapply::remove_dir_if_empty`), never `remove_dir_all`, ignoring
+`NotFound`/`DirectoryNotEmpty` as success rather than error. Combined with
+bottom-up removal order (`DesiredTree` sorts entries ascending by target —
+a directory's entry always precedes anything nested under it, so
+`Report::execute` walks `.rev()` to remove children before parents), this
+means a directory disappears exactly when, and only when, it turns out to
+hold nothing but what this overlay put there. A user's home directory
+(`target = "~"`) or any directory holding unrelated content is never at
+risk: it is simply never empty, so removal is always silently skipped —
+no ownership tracking, no special-casing the root target, required.
+
+**No new interactive confirmation gate.** Because every removal is
+already gated to exactly-matching, safe-to-lose state, every removal is
+also reversible: symlinks/directories come back with a plain `over apply`
+(overlay source content is never touched by `unapply`), and a checkout is
+only ever removed when there was nothing local-only left to lose. `--dry-run`
+is therefore sufficient preview, mirroring `apply`'s own UX — no `--force`/
+`--no-prompt` equivalents exist, since there is nothing left to force
+through once non-owned/dirty entries are always skipped.
+
+**Kept out of the `Materializer` trait.** `crate::unapply` calls
+`status::git::inspect`/`actions::fs`/the `symlink` crate directly for its
+own removal primitives, the same way `status`/`diff`/`sync` already bypass
+`Materializer::materialize` for their own concerns (git status inspection,
+content diffing, fetch/merge/push) rather than growing that trait with
+methods only one caller needs.
+
+## Consequences
+
+`Plan`/`PlanStep`/`Operation`/`ActualState`/`Materializer` are all
+unchanged — `unapply` is a new top-level module (`crate::unapply`, plus
+`crate::cli::unapply`) built entirely on existing read-only primitives.
+Nothing here implements #113's rule-aware migrations (symlink ↔ checkout,
+file-level ↔ directory-level symlink transitions): that remains a
+`Plan`/`Operation` extension for a later issue, untouched by this one.
+`uses`-aware/cascading unapply (removing a whole dependency graph safely,
+accounting for shared use across overlays) is also left for a future
+issue — the current scope is deliberately the single, explicitly named
+overlay.
+
+The main cost is conservatism: a directory containing even one unrelated
+file, or a checkout with a single uncommitted line, is left exactly as-is
+rather than cleaned up further. This is intentional — the alternative
+requires either persisted apply-time provenance (the exact "authoritative
+`ApplyState`" the issue asks to avoid) or destructive assumptions the issue
+explicitly forbids.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,5 @@ by editing the old one. The history is the value.
 | [011](011-plan-then-execute-reconciliation.md) | Plan-then-execute reconciliation, amending ADR-005 and ADR-006 |
 | [012](012-materializer-backend-registry.md) | Materializer backend registry, amending ADR-011 |
 | [013](013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md) | `diff` has its own taxonomy and uses `similar` for content diffs, amending ADR-011 |
+| [014](014-bidirectional-checkout-synchronization.md) | Bidirectional checkout synchronization is `over sync`, scoped to an overlay's root git entry |
+| [015](015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md) | `unapply` reuses `Plan`'s classification and only ever removes safely reversible state |

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -19,6 +19,7 @@ integrates the same overlay model with git workflows — Git resolves
 | [`over status`](status.md) | Get the current repository/directory overlays status |
 | [`over diff`](diff.md) | Show differences between desired and actual overlay state |
 | [`over sync`](sync.md) | Reconcile a checkout-materialized overlay with its git source |
+| [`over unapply`](unapply.md) | Remove a given overlay's own entries from the target |
 
 ## `git-over`
 

--- a/docs/usage/unapply.md
+++ b/docs/usage/unapply.md
@@ -1,0 +1,71 @@
+# `over unapply`
+
+Remove a given overlay's own entries from the target: unlink files and
+directories `over apply` created there, and remove a fully-synced git
+checkout. The overlay source itself is never touched, so a plain `over
+apply` afterwards fully restores everything.
+
+```
+Usage: over unapply [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]  Name of the overlay to unapply
+
+Options:
+  -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
+  -r, --root <ROOT>  The target root directory (~)
+  -d, --debug        Toggle debug traces
+  -n, --dry-run      Report what would be removed without removing anything
+  -v, --verbose      Toggle verbose output
+  -h, --help         Print help
+```
+
+## What it does
+
+`unapply` never trusts a persisted record of what a previous `apply` did.
+Instead it re-walks the overlay's current desired state and compares it,
+read-only, against actual filesystem/git state — the same
+`DesiredTree`/`Plan` model `apply`/`status`/`diff` already share — and only
+removes an entry that *still* matches exactly what the overlay would
+materialize there right now:
+
+- A file or directory symlink is removed only if it still points at the
+  overlay's source. Anything else there (a real file, a symlink pointing
+  elsewhere, a plain directory where a symlink was expected) is left
+  untouched and reported.
+- A directory is removed only if it's already empty (a non-recursive
+  removal) — never `rm -rf`. A directory that still holds anything else
+  (unrelated user files, another overlay's content) is silently left in
+  place.
+- A git checkout (the overlay's own root checkout, or any nested `git`
+  entry) is removed only when it's fully in sync with its upstream: no
+  uncommitted changes, no unpushed commits, no merge/rebase in progress.
+  Anything else is left untouched — resolve with `over sync` or plain git
+  first.
+
+Removal proceeds deepest-target-first, so a directory that only ever held
+overlay-managed content becomes empty (and is then removed) once its
+contents are gone.
+
+## What it never does
+
+- Recurse into `uses`. Only the named overlay's own entries are
+  considered — unapplying a shared dependency could otherwise break
+  another overlay that still `uses` it. Unapply a used overlay explicitly
+  by name if that's what you want.
+- Remove anything not recognizably its own: a foreign file, a changed
+  symlink target, or a non-empty directory are always left alone, with no
+  `--force` escape hatch (there's nothing to force through).
+- Discard uncommitted changes or local commits in a git checkout —
+  reusing the exact same read-only inspection `over sync`/`over status`
+  rely on (see
+  [ADR-014](../adr/014-bidirectional-checkout-synchronization.md)).
+
+Because unapply only ever removes exactly-matching, safe state, every
+removal is reversible: symlinks and directories come back with a plain
+`over apply`, and a checkout is only ever removed when there was nothing
+local-only left to lose.
+
+See
+[ADR-015](../adr/015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md)
+for the full design rationale.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@ mod new;
 mod show;
 mod status;
 mod sync;
+mod unapply;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -89,6 +90,12 @@ pub enum Commands {
         about = "Reconcile a checkout-materialized overlay with its git source"
     )]
     Sync(sync::Params),
+
+    #[clap(
+        name = "unapply",
+        about = "Remove a given overlay's own entries from the target"
+    )]
+    Unapply(unapply::Params),
 }
 
 impl CLI {
@@ -135,6 +142,9 @@ pub async fn main() -> Result<()> {
         }
         Some(Commands::Sync(ref opt)) => {
             sync::execute(&args, opt).await?;
+        }
+        Some(Commands::Unapply(ref opt)) => {
+            unapply::execute(&args, opt).await?;
         }
         None => {
             use clap::CommandFactory;
@@ -254,6 +264,12 @@ mod tests {
     fn cli_diff_subcommand() {
         let args = CLI::parse_from(["over", "diff"]);
         assert!(matches!(args.cmd, Some(Commands::Diff(_))));
+    }
+
+    #[test]
+    fn cli_unapply_subcommand() {
+        let args = CLI::parse_from(["over", "unapply", "myoverlay"]);
+        assert!(matches!(args.cmd, Some(Commands::Unapply(_))));
     }
 
     #[test]

--- a/src/cli/unapply.rs
+++ b/src/cli/unapply.rs
@@ -1,0 +1,256 @@
+use std::path::PathBuf;
+
+use anyhow::{Result, anyhow};
+use clap::Args;
+use dialoguer::FuzzySelect;
+use dirs::home_dir;
+
+use crate::cli::CLI;
+use crate::desired::DesiredTree;
+use crate::exec::Context;
+use crate::overlays::Repository;
+use crate::ui::style::DialogTheme;
+use crate::ui::{emojis, style};
+use crate::unapply::{Outcome, Report};
+use crate::utils::short_path;
+
+#[derive(Args, Debug)]
+pub struct Params {
+    #[clap(help = "Name of the overlay to unapply")]
+    name: Option<String>,
+
+    #[clap(short, long, help = "The target root directory (~)")]
+    root: Option<PathBuf>,
+
+    #[clap(
+        long,
+        short = 'n',
+        help = "Report what would be removed without removing anything"
+    )]
+    dry_run: bool,
+}
+
+pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
+    if cli.debug {
+        tracing::debug!(?cli, ?args, "CLI args");
+    }
+
+    let home = cli.resolve_home()?;
+    let repo = Repository::new(home);
+    let overlay = match &args.name {
+        Some(name) => repo.get(name)?,
+        None => {
+            let overlays = repo.overlays()?;
+            if overlays.is_empty() {
+                return Err(anyhow!("no overlays found in repository"));
+            }
+            let selection = FuzzySelect::with_theme(&DialogTheme::default())
+                .with_prompt("Choose the overlay to unapply")
+                .default(0)
+                .items(&overlays[..])
+                .interact()
+                .map_err(|e| anyhow!("overlay selection cancelled: {}", e))?;
+            overlays[selection].clone()
+        }
+    };
+    if cli.debug {
+        tracing::debug!(?overlay, "resolved overlay");
+    }
+
+    let root = args
+        .root
+        .clone()
+        .or_else(home_dir)
+        .ok_or_else(|| anyhow!("could not determine home directory"))?;
+
+    let ctx = Context::builder()
+        .dry_run(args.dry_run)
+        .debug(cli.debug)
+        .verbose(cli.verbose)
+        .root(root)
+        .repository(repo)
+        .overlay(overlay.clone())
+        .build();
+    let target = overlay.resolve_target(&ctx)?;
+    let ctx = ctx.with_resolved_overlay(overlay.name.clone(), target.to_string_lossy().to_string());
+
+    // This overlay's own entries only — no `uses` recursion. Unapplying a
+    // dependency here could silently break another overlay that still
+    // `uses` it (a diamond dependency): removing a shared dependency's
+    // entries is left to explicitly unapplying it by name.
+    let desired = DesiredTree::build_own(&ctx, &overlay)?;
+    let report = Report::build(&desired)?;
+
+    println!(
+        "{} {} {} {} {}",
+        emojis::PACKAGE,
+        style::white_b("Overlay"),
+        style::cyan(&overlay.name),
+        style::white_b("->"),
+        style::cyan(&short_path(&target.to_string_lossy())),
+    );
+    println!("  {}", report.counts());
+
+    for entry_outcome in report.entries() {
+        if cli.verbose || !matches!(entry_outcome.outcome, Outcome::AlreadyAbsent) {
+            println!("  {entry_outcome}");
+        }
+    }
+    println!();
+
+    report.execute(ctx).await?;
+
+    if report.needs_attention() {
+        return Err(anyhow!(
+            "one or more entries were left untouched — see `skip:` lines above"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overlays::Repository as OverlayRepository;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use clap::Parser;
+    use std::fs;
+
+    fn make_cli(home: PathBuf) -> CLI {
+        CLI::parse_from(vec!["over", "--home", home.to_str().unwrap()])
+    }
+
+    fn params(name: Option<&str>, root: PathBuf, dry_run: bool) -> Params {
+        Params {
+            name: name.map(String::from),
+            root: Some(root),
+            dry_run,
+        }
+    }
+
+    /// Apply `name` from the repository rooted at `home` into `root`,
+    /// bypassing the CLI layer (mirrors the pattern already used by
+    /// `plan::reconcile`/`status`/`diff`'s own tests).
+    async fn apply_overlay(home: &std::path::Path, root: &std::path::Path, name: &str) {
+        let repo = OverlayRepository::new(home.to_path_buf());
+        let overlay = repo.get(name).unwrap();
+        let ctx = Context::builder()
+            .root(root.to_path_buf())
+            .repository(repo)
+            .overlay(overlay.clone())
+            .build();
+        overlay.apply(&ctx).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unapply_unknown_overlay_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(
+            &cli,
+            &params(Some("does-not-exist"), root.path().to_path_buf(), false),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn unapply_missing_target_reports_already_absent() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~/sub\"").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(
+            &cli,
+            &params(Some("myoverlay"), root.path().to_path_buf(), false),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn unapply_removes_applied_symlink_end_to_end() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        fs::write(ov.join("file.txt"), "content").unwrap();
+
+        apply_overlay(tmp.path(), root.path(), "myoverlay").await;
+        let cli = make_cli(tmp.path().to_path_buf());
+        let target = root.path().join("file.txt");
+        assert!(target.is_symlink());
+
+        let result = execute(
+            &cli,
+            &params(Some("myoverlay"), root.path().to_path_buf(), false),
+        )
+        .await;
+        assert!(result.is_ok(), "unapply should succeed: {:?}", result.err());
+        assert!(!target.exists() && !target.is_symlink());
+        // Overlay source untouched.
+        assert!(ov.join("file.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn unapply_dry_run_does_not_touch_filesystem() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        fs::write(ov.join("file.txt"), "content").unwrap();
+
+        apply_overlay(tmp.path(), root.path(), "myoverlay").await;
+        let cli = make_cli(tmp.path().to_path_buf());
+        let target = root.path().join("file.txt");
+        assert!(target.is_symlink());
+
+        let result = execute(
+            &cli,
+            &params(Some("myoverlay"), root.path().to_path_buf(), true),
+        )
+        .await;
+        assert!(result.is_ok());
+        assert!(target.is_symlink(), "dry-run must not remove anything");
+    }
+
+    #[tokio::test]
+    async fn unapply_leaves_foreign_file_untouched() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        let ov = tmp.path().join("conflicted");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        fs::write(ov.join("file.txt"), "overlay").unwrap();
+        fs::write(root.path().join("file.txt"), "existing").unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(
+            &cli,
+            &params(Some("conflicted"), root.path().to_path_buf(), false),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "not-owned entries should be reported as needing attention"
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("file.txt")).unwrap(),
+            "existing"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod plan;
 pub mod status;
 pub mod sync;
 pub mod ui;
+pub mod unapply;
 pub mod xdg;
 
 pub mod utils;

--- a/src/ui/emojis.rs
+++ b/src/ui/emojis.rs
@@ -11,6 +11,7 @@ pub static GREEN_CIRCLE: Emoji<'_, '_> = Emoji("🟢", "");
 pub static SPARKLE: Emoji<'_, '_> = Emoji("✨", "");
 pub static MOVE_FILE: Emoji<'_, '_> = Emoji("📃", "");
 pub static WARNING: Emoji<'_, '_> = Emoji("⚠️", "");
+pub static TRASH: Emoji<'_, '_> = Emoji("🗑️", "");
 // static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍  ", "");
 // static TRUCK: Emoji<'_, '_> = Emoji("🚚  ", "");
 // static CLIP: Emoji<'_, '_> = Emoji("🔗  ", "");

--- a/src/unapply/mod.rs
+++ b/src/unapply/mod.rs
@@ -1,0 +1,838 @@
+//! `over unapply` (#64): reverses `over apply` by reconciling actual
+//! filesystem/git state back toward "nothing" — the same `DesiredTree`/
+//! [`Plan`] vocabulary `apply`/`status`/`diff`/`sync` already share
+//! (ADR-011).
+//!
+//! Deliberately does not rely on any persisted apply-time state: everything
+//! here is derived by re-walking the overlay's current `DesiredTree` and
+//! comparing it, read-only, against actual state — exactly like
+//! [`Plan::build`] — before removing anything. An entry is only ever
+//! removed when it *still* matches exactly what the overlay would
+//! materialize there right now ([`Operation::Noop`]); anything else (a
+//! [`Operation::Conflict`], or a checkout that isn't fully in sync) is left
+//! untouched and reported, never forced — see [`Outcome`].
+//!
+//! Two safety properties fall out of this on their own, without any extra
+//! bookkeeping:
+//!
+//! - Directories are only ever removed with a non-recursive `fs::remove_dir`
+//!   (never `remove_dir_all`), so a directory that still holds anything
+//!   else — another overlay's files, unrelated user content, or simply a
+//!   user's home directory (`target = "~"`) — is silently left alone. There
+//!   is no need to track "did `over` create this directory or did it
+//!   already exist": emptiness is the only signal, and it's always
+//!   re-checked at removal time.
+//! - A git checkout is only ever removed when [`status::git::inspect`]
+//!   reports [`Status::Applied`] (fully in sync with its upstream, nothing
+//!   uncommitted or unpushed) — reusing the exact same read-only inspection
+//!   `over sync`/`over status` already rely on, per ADR-014's "never
+//!   discard uncommitted changes or local commits implicitly".
+//!
+//! Everything unapply removes is therefore also reversible: symlinks and
+//! directories come back with a plain `over apply` (overlay source content
+//! is never touched), and a checkout is only ever removed when there was
+//! nothing local-only left to lose.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use tokio::task::spawn_blocking;
+
+use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
+use crate::exec::Ctx;
+use crate::plan::actual::{self, ActualState};
+use crate::plan::{Operation, Plan};
+use crate::status::{self, Status};
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+/// What happened (or would happen) to a single [`DesiredEntry`] when
+/// reconciling it back toward "nothing". Its own taxonomy, not a reuse of
+/// [`status::Status`]/`crate::diff::Change` — per ADR-013's precedent, each
+/// command answers a different question about the same underlying
+/// `DesiredTree`/[`Plan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Target still matches exactly what this overlay would materialize
+    /// there — safe to remove (or already removed, under `--dry-run`).
+    Removed,
+    /// Nothing exists at the target — already unapplied, or never applied.
+    AlreadyAbsent,
+    /// Target exists but doesn't match what this overlay would create
+    /// there (a foreign file, a symlink pointing elsewhere, a type
+    /// mismatch...). Never touched.
+    NotOwned { current: ActualState },
+    /// A git checkout that isn't fully in sync with its upstream
+    /// (uncommitted changes, unpushed commits, ahead/behind/diverged, a
+    /// merge in progress, or not a valid repo). Never touched — resolve
+    /// with `over sync` or plain git first.
+    CheckoutNotClean { status: Status },
+}
+
+impl Outcome {
+    /// Whether this outcome needs the user's attention — something was
+    /// deliberately left untouched. Used by the CLI to decide what to show
+    /// without `--verbose`, and to decide the process exit code.
+    pub fn needs_attention(&self) -> bool {
+        matches!(
+            self,
+            Outcome::NotOwned { .. } | Outcome::CheckoutNotClean { .. }
+        )
+    }
+}
+
+/// Short, human-readable word for a checkout [`Status`] — `Status` itself
+/// has no `Display` impl (only `status::EntryStatus` does, tied to its own
+/// message shape), so this is a small local rendering instead of reaching
+/// into that module's formatting.
+fn status_word(status: &Status) -> String {
+    match status {
+        Status::Applied => "applied".to_string(),
+        Status::Missing => "missing".to_string(),
+        Status::Modified => "modified".to_string(),
+        Status::Broken => "broken".to_string(),
+        Status::Conflict => "conflict".to_string(),
+        Status::Ahead(n) => format!("ahead {n}"),
+        Status::Behind(n) => format!("behind {n}"),
+        Status::Diverged { ahead, behind } => format!("diverged +{ahead}/-{behind}"),
+    }
+}
+
+/// One [`DesiredEntry`] paired with its unapply [`Outcome`].
+#[derive(Debug, Clone)]
+pub struct EntryOutcome {
+    pub entry: DesiredEntry,
+    pub outcome: Outcome,
+}
+
+impl fmt::Display for EntryOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let target = short_path(&self.entry.target.to_string_lossy());
+        match &self.outcome {
+            Outcome::Removed => write!(
+                f,
+                "{} {} {}",
+                emojis::TRASH,
+                style::white("remove:"),
+                target
+            ),
+            Outcome::AlreadyAbsent => write!(
+                f,
+                "{} {} {}",
+                emojis::CHECKMARK,
+                style::white("already absent:"),
+                target
+            ),
+            Outcome::NotOwned { current } => write!(
+                f,
+                "{} {} {} ({current} — not created by this overlay, left untouched)",
+                emojis::WARNING,
+                style::yellow("skip:"),
+                target,
+            ),
+            Outcome::CheckoutNotClean { status } => write!(
+                f,
+                "{} {} {} ({} — run `over sync` or resolve manually first)",
+                emojis::WARNING,
+                style::yellow("skip:"),
+                target,
+                status_word(status),
+            ),
+        }
+    }
+}
+
+/// Per-`Outcome` counts of a [`Report`], in the same order [`Outcome`] is
+/// declared.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Counts {
+    pub removed: usize,
+    pub already_absent: usize,
+    pub not_owned: usize,
+    pub checkout_needs_attention: usize,
+}
+
+impl fmt::Display for Counts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} to remove, {} already absent, {} not owned, {} checkout(s) need attention",
+            self.removed, self.already_absent, self.not_owned, self.checkout_needs_attention,
+        )
+    }
+}
+
+/// The unapply reconciliation of a whole [`DesiredTree`]: one
+/// [`EntryOutcome`] per [`DesiredEntry`], in the same order `DesiredTree`
+/// produces them (ascending by target — parents before children).
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    entries: Vec<EntryOutcome>,
+}
+
+impl Report {
+    /// Classify every entry in `desired` against current state. Read-only —
+    /// reuses [`Plan::build`]'s own classification for
+    /// `Directory`/`SymlinkFile`/`SymlinkDirectory` intents (`Noop` means
+    /// "still exactly what this overlay would create here", safe to
+    /// remove; `Conflict` means "something else is there", never touched).
+    ///
+    /// [`Plan`]'s classification is deliberately too coarse for
+    /// `Checkout` entries (`CheckoutMaterializer` collapses everything but
+    /// `Missing` to `Noop`, ADR-014) — [`status::git::inspect`] is used
+    /// directly instead, exactly like `status`/`diff` already do, so only a
+    /// fully-in-sync checkout (`Status::Applied`) is ever removed.
+    pub fn build(desired: &DesiredTree) -> Result<Self> {
+        let plan = Plan::build(desired)?;
+        let mut entries = Vec::with_capacity(plan.len());
+        for step in plan.steps() {
+            let outcome = match (&step.entry.intent, &step.operation) {
+                (MaterializationIntent::Checkout, _) => match status::git::inspect(&step.entry)? {
+                    Status::Missing => Outcome::AlreadyAbsent,
+                    Status::Applied => Outcome::Removed,
+                    other => Outcome::CheckoutNotClean { status: other },
+                },
+                (_, Operation::Create) => Outcome::AlreadyAbsent,
+                (_, Operation::Noop) => Outcome::Removed,
+                (_, Operation::Conflict { current }) => Outcome::NotOwned {
+                    current: current.clone(),
+                },
+                // Every intent has a registered `Materializer` since #110;
+                // no step should ever classify as `Deferred` — unreachable
+                // in practice, but treated as "leave it alone" rather than
+                // panicking on a stale/future classification.
+                (_, Operation::Deferred) => Outcome::NotOwned {
+                    current: ActualState::Missing,
+                },
+            };
+            entries.push(EntryOutcome {
+                entry: step.entry.clone(),
+                outcome,
+            });
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn entries(&self) -> &[EntryOutcome] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn counts(&self) -> Counts {
+        let mut counts = Counts::default();
+        for e in &self.entries {
+            match e.outcome {
+                Outcome::Removed => counts.removed += 1,
+                Outcome::AlreadyAbsent => counts.already_absent += 1,
+                Outcome::NotOwned { .. } => counts.not_owned += 1,
+                Outcome::CheckoutNotClean { .. } => counts.checkout_needs_attention += 1,
+            }
+        }
+        counts
+    }
+
+    /// Whether anything is actually queued for removal.
+    pub fn has_pending_removals(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|e| matches!(e.outcome, Outcome::Removed))
+    }
+
+    /// Whether anything in this report needs attention (something was
+    /// deliberately left untouched).
+    pub fn needs_attention(&self) -> bool {
+        self.entries.iter().any(|e| e.outcome.needs_attention())
+    }
+
+    /// Remove every entry classified [`Outcome::Removed`]. No-ops entirely
+    /// under `ctx.dry_run` — never touches the filesystem/git, exactly like
+    /// every `Action::execute` already does.
+    ///
+    /// Iterates deepest-target-first (`DesiredTree` sorts ascending by
+    /// target, so a directory's entry always precedes anything nested
+    /// under it — reversing that order removes children/files before the
+    /// directories that contain them, giving a formerly overlay-only
+    /// directory a chance to become empty before its own removal is
+    /// attempted).
+    pub async fn execute(&self, ctx: Ctx) -> Result<()> {
+        if ctx.dry_run {
+            return Ok(());
+        }
+        for entry_outcome in self.entries.iter().rev() {
+            if matches!(entry_outcome.outcome, Outcome::Removed) {
+                dematerialize(&entry_outcome.entry).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Tear down a single entry classified [`Outcome::Removed`]. Dispatches on
+/// intent, mirroring `materialize::symlink::build_action`'s own dispatch —
+/// the removal-side counterpart, kept in this module rather than added to
+/// the [`crate::materialize::Materializer`] trait since none of
+/// `status`/`diff`/`sync` route their own concerns through it either (they
+/// call `status::git`/`actions::git` directly for what they need).
+async fn dematerialize(entry: &DesiredEntry) -> Result<()> {
+    match &entry.intent {
+        MaterializationIntent::Directory => remove_dir_if_empty(entry.target.clone()).await,
+        MaterializationIntent::SymlinkFile { source, .. }
+        | MaterializationIntent::SymlinkDirectory { source, .. } => {
+            remove_symlink_if_unchanged(entry.target.clone(), source.clone()).await
+        }
+        MaterializationIntent::Checkout => remove_checkout_if_clean(entry.clone()).await,
+    }
+}
+
+/// Remove `path` only if it's already empty — never recursive. `NotFound`
+/// (already gone) and `DirectoryNotEmpty` (still holds something else) are
+/// both treated as success: there's nothing more to do, and it is never an
+/// error for unapply to leave a non-empty directory in place.
+async fn remove_dir_if_empty(path: PathBuf) -> Result<()> {
+    spawn_blocking(move || match fs::remove_dir(&path) {
+        Ok(()) => Ok(()),
+        Err(e)
+            if matches!(
+                e.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::DirectoryNotEmpty
+            ) =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    })
+    .await?
+}
+
+/// Remove the symlink at `target` only if it still points exactly at
+/// `source` — re-inspected here (not just trusted from classification) as
+/// defense against a race between `Report::build` and `Report::execute`.
+/// Anything else (already gone, or changed to point somewhere else since
+/// classification) is silently left alone: never remove something that no
+/// longer matches exactly what this overlay would have linked here.
+async fn remove_symlink_if_unchanged(target: PathBuf, source: PathBuf) -> Result<()> {
+    spawn_blocking(move || match actual::inspect(&target)? {
+        ActualState::Symlink { points_to } if points_to == source => {
+            if target.is_dir() {
+                symlink::remove_symlink_dir(&target)?;
+            } else {
+                symlink::remove_symlink_file(&target)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    })
+    .await?
+}
+
+/// Remove a git checkout's whole target directory, only if
+/// [`status::git::inspect`] still reports [`Status::Applied`] right now —
+/// re-checked here (not just trusted from classification) for the same
+/// classify→execute race-safety reason as
+/// [`remove_symlink_if_unchanged`]. Anything else is left alone.
+async fn remove_checkout_if_clean(entry: DesiredEntry) -> Result<()> {
+    spawn_blocking(move || {
+        if !matches!(status::git::inspect(&entry)?, Status::Applied) {
+            return Ok(());
+        }
+        fs::remove_dir_all(&entry.target)?;
+        Ok(())
+    })
+    .await?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::symlink::LinkType;
+    use crate::desired::Provenance;
+    use crate::exec::Context;
+    use crate::overlays::Repository;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use git2::Signature;
+    use rstest::rstest;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn repo_and_root() -> (TempDir, Repository) {
+        let td = TempDir::new().unwrap();
+        let repo = Repository::new(td.path().to_path_buf());
+        (td, repo)
+    }
+
+    fn ctx(root: PathBuf, repo: Repository, overlay: Option<crate::overlays::Overlay>) -> Ctx {
+        let mut builder = Context::builder().root(root).repository(repo);
+        if let Some(o) = overlay {
+            builder = builder.overlay(o);
+        }
+        builder.build()
+    }
+
+    // ── classification ──────────────────────────────────────────────────
+
+    #[rstest]
+    fn missing_target_is_already_absent() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~/sub\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+
+        assert_eq!(report.entries().len(), 1);
+        assert_eq!(report.entries()[0].outcome, Outcome::AlreadyAbsent);
+        assert_eq!(report.counts().already_absent, 1);
+        assert!(!report.has_pending_removals());
+    }
+
+    #[tokio::test]
+    async fn applied_symlink_classifies_as_removed() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(c.clone())
+            .await
+            .unwrap();
+
+        let desired2 = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        let file_outcome = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+        assert_eq!(file_outcome.outcome, Outcome::Removed);
+        assert!(report.has_pending_removals());
+    }
+
+    #[test]
+    fn conflicting_file_is_not_owned() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("overlay").unwrap();
+        fs::write(td.path().join("file.txt"), "existing").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let file_outcome = report
+            .entries()
+            .iter()
+            .find(|e| e.entry.target == td.path().join("file.txt"))
+            .unwrap();
+        assert!(matches!(file_outcome.outcome, Outcome::NotOwned { .. }));
+        assert_eq!(report.counts().not_owned, 1);
+    }
+
+    #[test]
+    fn dangling_soft_symlink_still_classifies_as_removed() {
+        // A soft symlink whose source has since disappeared is still
+        // exactly what the overlay linked there — `status::Report`
+        // reports this as `Broken` for attention, but unapply should just
+        // clean it up like any other still-matching link.
+        //
+        // `DesiredTree` itself never produces this entry once the source
+        // is gone (it won't turn up in `walk_overlay_tree` anymore, see
+        // `status::tests::dangling_soft_symlink_noop_is_broken`), so build
+        // the tree directly instead of round-tripping through `apply`.
+        let td = TempDir::new().unwrap();
+        let source = td.path().join("gone.txt");
+        let target = td.path().join("linked.txt");
+        symlink::symlink_file(&source, &target).unwrap();
+
+        let entry = DesiredEntry {
+            target,
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: source.clone(),
+            },
+            intent: MaterializationIntent::SymlinkFile {
+                source,
+                link_type: LinkType::Soft,
+            },
+        };
+        let desired = DesiredTree::from_entries(vec![entry]);
+        let report = Report::build(&desired).unwrap();
+        assert_eq!(report.entries()[0].outcome, Outcome::Removed);
+    }
+
+    #[test]
+    fn empty_desired_tree_produces_empty_report() {
+        let report = Report::build(&DesiredTree::default()).unwrap();
+        assert!(report.is_empty());
+        assert!(!report.has_pending_removals());
+        assert!(!report.needs_attention());
+    }
+
+    #[rstest]
+    fn git_checkout_missing_is_already_absent() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"\n[git]\n\".config/nvim\" = \"https://example.com/nvim.git\"")
+            .unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        let checkout_outcome = report
+            .entries()
+            .iter()
+            .find(|e| matches!(e.entry.intent, MaterializationIntent::Checkout))
+            .unwrap();
+        assert_eq!(checkout_outcome.outcome, Outcome::AlreadyAbsent);
+    }
+
+    fn init_committed_repo(path: &std::path::Path) {
+        let repo = git2::Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+    }
+
+    fn checkout_entry(target: PathBuf) -> DesiredEntry {
+        DesiredEntry {
+            target,
+            provenance: Provenance::Git {
+                overlay: "ov".to_string(),
+                repo_key: ".".to_string(),
+                config: Box::new(crate::actions::git::config::GitRepoConfig {
+                    url: String::new(),
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    recurse_submodules: false,
+                    worktree: false,
+                    per_worktree_config: false,
+                    worktrees: None,
+                    remotes: None,
+                    config: None,
+                    worktree_config: None,
+                }),
+            },
+            intent: MaterializationIntent::Checkout,
+        }
+    }
+
+    #[test]
+    fn clean_checkout_classifies_as_removed() {
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        let desired = DesiredTree::from_entries(vec![checkout_entry(td.path().to_path_buf())]);
+        let report = Report::build(&desired).unwrap();
+        assert_eq!(report.entries()[0].outcome, Outcome::Removed);
+    }
+
+    #[test]
+    fn dirty_checkout_needs_attention() {
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        fs::write(td.path().join("README.md"), "changed").unwrap();
+        let desired = DesiredTree::from_entries(vec![checkout_entry(td.path().to_path_buf())]);
+        let report = Report::build(&desired).unwrap();
+        assert!(matches!(
+            report.entries()[0].outcome,
+            Outcome::CheckoutNotClean {
+                status: Status::Modified
+            }
+        ));
+        assert!(report.needs_attention());
+    }
+
+    // ── execute ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_removes_matching_symlink() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(c.clone())
+            .await
+            .unwrap();
+        let target = td.path().join("file.txt");
+        assert!(target.is_symlink());
+
+        let desired2 = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        report.execute(c.clone()).await.unwrap();
+
+        assert!(!target.exists() && !target.is_symlink());
+        // Overlay source is untouched — reversible.
+        assert!(overlay.root.join("file.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn execute_leaves_foreign_file_untouched() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("overlay").unwrap();
+        fs::write(td.path().join("file.txt"), "existing").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired).unwrap();
+        report.execute(c.clone()).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(td.path().join("file.txt")).unwrap(),
+            "existing"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_removes_directory_once_empty() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~/sub\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(c.clone())
+            .await
+            .unwrap();
+        let sub_dir = td.path().join("sub");
+        assert!(sub_dir.is_dir());
+
+        let desired2 = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        report.execute(c.clone()).await.unwrap();
+
+        // Bottom-up removal: file.txt's symlink goes first, emptying
+        // `sub`, which is then removed too.
+        assert!(!sub_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn execute_keeps_non_empty_directory() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~/sub\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(c.clone())
+            .await
+            .unwrap();
+        let sub_dir = td.path().join("sub");
+        // A foreign file lands in the overlay's target directory after
+        // apply — unrelated to any DesiredEntry.
+        fs::write(sub_dir.join("unrelated.txt"), "keep me").unwrap();
+
+        let desired2 = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        report.execute(c.clone()).await.unwrap();
+
+        assert!(
+            sub_dir.is_dir(),
+            "directory with foreign content must remain"
+        );
+        assert!(sub_dir.join("unrelated.txt").exists());
+        assert!(!sub_dir.join("file.txt").is_symlink());
+    }
+
+    #[tokio::test]
+    async fn dry_run_execute_does_not_touch_filesystem() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(c.clone())
+            .await
+            .unwrap();
+        let target = td.path().join("file.txt");
+        assert!(target.is_symlink());
+
+        let dry_ctx = Context::builder()
+            .dry_run(true)
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+        let desired2 = DesiredTree::build(&c, &overlay).unwrap();
+        let report = Report::build(&desired2).unwrap();
+        assert!(report.has_pending_removals());
+        report.execute(dry_ctx).await.unwrap();
+
+        assert!(target.is_symlink(), "dry-run must not remove anything");
+    }
+
+    #[tokio::test]
+    async fn execute_removes_clean_checkout() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        git2::build::RepoBuilder::new()
+            .clone(source_td.path().to_str().unwrap(), dest_td.path())
+            .unwrap();
+
+        let desired = DesiredTree::from_entries(vec![checkout_entry(dest_td.path().to_path_buf())]);
+        let report = Report::build(&desired).unwrap();
+        assert_eq!(report.entries()[0].outcome, Outcome::Removed);
+
+        let ctx = Context::builder().build();
+        report.execute(ctx).await.unwrap();
+        assert!(!dest_td.path().join(".git").exists());
+    }
+
+    #[tokio::test]
+    async fn execute_keeps_dirty_checkout() {
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+        let dest_td = TempDir::new().unwrap();
+        git2::build::RepoBuilder::new()
+            .clone(source_td.path().to_str().unwrap(), dest_td.path())
+            .unwrap();
+        fs::write(dest_td.path().join("README.md"), "changed").unwrap();
+
+        let desired = DesiredTree::from_entries(vec![checkout_entry(dest_td.path().to_path_buf())]);
+        let report = Report::build(&desired).unwrap();
+        assert!(report.needs_attention());
+
+        let ctx = Context::builder().build();
+        report.execute(ctx).await.unwrap();
+        assert!(
+            dest_td.path().join(".git").exists(),
+            "dirty checkout must be kept"
+        );
+        assert_eq!(
+            fs::read_to_string(dest_td.path().join("README.md")).unwrap(),
+            "changed"
+        );
+    }
+
+    #[rstest]
+    fn counts_display_lists_every_outcome() {
+        let counts = Counts {
+            removed: 1,
+            already_absent: 2,
+            not_owned: 3,
+            checkout_needs_attention: 4,
+        };
+        let s = format!("{counts}");
+        assert!(s.contains("1 to remove"));
+        assert!(s.contains("2 already absent"));
+        assert!(s.contains("3 not owned"));
+        assert!(s.contains("4 checkout(s) need attention"));
+    }
+
+    #[test]
+    fn entry_outcome_display_covers_every_variant() {
+        fn entry_outcome(outcome: Outcome) -> EntryOutcome {
+            EntryOutcome {
+                entry: DesiredEntry {
+                    target: PathBuf::from("/tmp/target"),
+                    provenance: Provenance::Overlay {
+                        overlay: "ov".to_string(),
+                        source: PathBuf::from("/repo/ov"),
+                    },
+                    intent: MaterializationIntent::SymlinkFile {
+                        source: PathBuf::from("/repo/ov/target"),
+                        link_type: LinkType::Soft,
+                    },
+                },
+                outcome,
+            }
+        }
+
+        assert!(format!("{}", entry_outcome(Outcome::Removed)).contains("remove:"));
+        assert!(format!("{}", entry_outcome(Outcome::AlreadyAbsent)).contains("already absent:"));
+        let not_owned = entry_outcome(Outcome::NotOwned {
+            current: ActualState::File,
+        });
+        assert!(format!("{not_owned}").contains("skip:"));
+        assert!(format!("{not_owned}").contains("not created by this overlay"));
+        let checkout = entry_outcome(Outcome::CheckoutNotClean {
+            status: Status::Modified,
+        });
+        assert!(format!("{checkout}").contains("skip:"));
+        assert!(format!("{checkout}").contains("modified"));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -745,6 +745,141 @@ fn sync_dry_run_reports_without_mutating() -> TestResult {
     Ok(())
 }
 
+// ── unapply integration tests ────────────────────────────────────────────
+
+#[test]
+fn unapply_unknown_overlay_fails() -> TestResult {
+    let tmp = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .args(["unapply", "does-not-exist"])
+        .assert()
+        .failure();
+    Ok(())
+}
+
+#[test]
+fn unapply_before_apply_reports_already_absent() -> TestResult {
+    let repo = setup_overlay_repo();
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["unapply", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("already absent"));
+    Ok(())
+}
+
+#[test]
+fn unapply_removes_applied_symlink_and_apply_restores_it() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"content")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "dev", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+    assert!(root.path().join("file.txt").is_symlink());
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["unapply", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("remove:"));
+    assert!(!root.path().join("file.txt").exists());
+    // Overlay source is untouched.
+    assert!(repo.path().join("dev").join("file.txt").exists());
+
+    // Reversible: a plain `over apply` restores it fully.
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "dev", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+    assert!(root.path().join("file.txt").is_symlink());
+    Ok(())
+}
+
+#[test]
+fn unapply_leaves_foreign_file_untouched_and_fails() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"overlay")?;
+    let root = TempDir::new()?;
+    fs::write(root.path().join("file.txt"), b"existing")?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["unapply", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .failure()
+        .stdout(contains("skip:"));
+
+    assert_eq!(fs::read(root.path().join("file.txt"))?, b"existing");
+    Ok(())
+}
+
+#[test]
+fn unapply_dry_run_reports_without_mutating() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("dev").join("file.txt"), b"content")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "dev", "--root"])
+        .arg(root.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["unapply", "dev", "--root"])
+        .arg(root.path())
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(contains("remove:"));
+
+    assert!(root.path().join("file.txt").is_symlink());
+    Ok(())
+}
+
+#[test]
+fn unapply_debug_output() -> TestResult {
+    let repo = setup_overlay_repo();
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .arg("--debug")
+        .args(["unapply", "dev", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stderr(contains("CLI args"));
+    Ok(())
+}
+
 // ── show integration tests ──────────────────────────────────────────────
 
 #[test]

--- a/zensical.toml
+++ b/zensical.toml
@@ -33,6 +33,7 @@ nav = [
     { "over status" = "usage/status.md" },
     { "over diff" = "usage/diff.md" },
     { "over sync" = "usage/sync.md" },
+    { "over unapply" = "usage/unapply.md" },
     { "git over mount" = "usage/git-over-mount.md" },
     { "git over add" = "usage/git-over-add.md" },
     { "git over status" = "usage/git-over-status.md" },


### PR DESCRIPTION
Adds `over unapply <overlay>`, the reverse of `over apply`: it removes a symlink, directory, or git checkout only when it still matches exactly what the overlay would materialize there, walking the overlay's current desired state against actual filesystem/git state rather than relying on any persisted apply-time record.

Safety comes from three properties rather than bookkeeping:
- A symlink is only removed if it still points at the overlay's source.
- A directory is only removed non-recursively, when it's already empty — never `rm -rf`, so a directory holding anything else (including a user's home directory) is always left alone.
- A git checkout is only removed when fully in sync with its upstream (no uncommitted or unpushed content), reusing the same safety checks `over sync`/`over status` already rely on.

Everything removed is therefore reversible: a plain `over apply` restores symlinks/directories, and a checkout is only ever removed when there was nothing local-only to lose. Scope is intentionally limited to the named overlay's own entries (no `uses` recursion), to avoid breaking a shared dependency still used elsewhere.

See ADR-015 for the full design rationale.

Closes #64
