### PR TITLE
feat(partial): add partial file management via managed blocks

### DIFF
--- a/docs/adr/016-partial-file-managed-blocks.md
+++ b/docs/adr/016-partial-file-managed-blocks.md
@@ -1,0 +1,124 @@
+# ADR-016: Partial files are managed blocks injected via a sidecar, not a stem-plus-sidecar pair
+
+**Status:** accepted
+
+## Context
+
+Issue #66 asks for partial file management: modifying part of an existing
+(possibly foreign) file rather than symlinking the whole thing, with
+conflict detection against actual content and a safe, explicit unapply.
+Its dependencies (#107 desired state, #13 plan/reconcile, #64 unapply) are
+closed; it is explicitly scoped independent of #113 (hierarchical
+rules/migration) and doesn't depend on #61 (full file templating) — content
+is used verbatim, the same way `.link.*` sidecar `target` strings were
+before #61 renders anything (ADR-010).
+
+`.link.*` sidecars (ADR-006) are the only existing per-path configuration
+mechanism: a `<stem>.link.{toml,yaml,yml}` file declares an arbitrary extra
+symlink, with the payload (a `target` string) living inline in the config,
+not in a separate same-stem file — there is no expectation that a file
+named `<stem>` exists anywhere in the overlay tree.
+
+## Decision
+
+A new `*.partial.{toml,yaml,yml}` sidecar convention, discovered and parsed
+exactly like `.link.*` (`actions::partial::discover_partials` mirrors
+`actions::symlink::discover_symlinks` field-for-field: same glob, same stem
+derivation, same TOML > YAML > YML precedence-with-warning on duplicates).
+Its payload is inline, like `.link.*`'s `target`:
+
+```toml
+target = "~/.zshrc"
+content = "alias ll='ls -la'\n"
+# marker = "aliases"   # optional; defaults to the sidecar's own stem
+```
+
+This is a deliberate rejection of a stem-file-plus-sidecar pair (where a
+same-named file's content would be the block body): it would need a new
+walk-exclusion rule to keep that stem file from *also* becoming its own
+`SymlinkFile` entry, and would only pay for itself once #61 needs to render
+that content — which is explicitly out of scope here. Inline `content`
+needs no new exclusion beyond the sidecar file itself (mirroring
+`walk_overlay_tree`'s existing `symlink_config` glob), and is trivially
+extensible later: #61 can add a `content_file`/render step without
+breaking this shape.
+
+The block is delimited by fixed marker lines:
+
+```text
+# >>> over: <marker> >>>
+<content>
+# <<< over: <marker> <<<
+```
+
+Fixed to `#`-comments, not configurable — the dominant dotfile case (shell
+rc files, ini-style configs, gitconfig, ssh config). A target file that
+can't contain `#` comments (JSON, for instance) isn't a good fit for this
+feature yet; a configurable comment style is left for a future issue if
+demand appears, rather than speculatively building it now.
+
+**New model surface**, mirroring every existing intent/provenance pair:
+
+- `MaterializationIntent::PartialFile { content, marker }` — the first
+  intent to ever produce `EntryKind::File` (reserved since #107/#61, never
+  produced until now).
+- `Provenance::PartialSidecar { overlay, config }`.
+- `DesiredTree::build`'s target for a partial entry is the **rendered path
+  itself** (`symlink::render_symlink_target` reused as-is — it's already a
+  generic path-template renderer, not symlink-specific), not
+  `target_root.join(stem)`: a managed block's target is an arbitrary
+  external file, not something living under the overlay's own target root
+  by naming convention (unlike `.link.*`, whose target root placement
+  mirrors a real symlink's expected location).
+
+**Classification is content-aware**, the one materializer backend for
+which "actual state" means more than `symlink_metadata`
+(`PartialFileMaterializer::classify` reads the target file when it's a
+plain file): missing target or missing block → `Operation::Create`
+(purely additive — inserting a block never touches existing content);
+block present and matching → `Operation::Noop`; block present but drifted,
+or markers malformed (a begin without a matching end, or vice versa) →
+`Operation::Conflict`, resolved at execute time through the same
+force/no_prompt/interactive gate every other conflict uses, with its own
+choice set (Skip/Overwrite/Diff — no "Absorb": there's no single overlay
+source file to adopt hand-edited content into, only a `content` string in
+the sidecar). A directory or symlink occupying the target is a *structural*
+conflict, resolved separately (Skip/Overwrite only), reusing
+`actions::fs::remove_target` (promoted to `pub(crate)`) rather than
+duplicating it.
+
+**Unapply strips only the block.** `unapply::dematerialize`'s new
+`PartialFile` arm re-reads the target immediately before acting (same
+classify→execute race-safety every other removal path already has) and
+only removes the block if it *still* matches exactly what this entry would
+write. If stripping leaves nothing behind, the file itself is removed
+(mirroring "a directory disappears exactly when it turns out to hold
+nothing but what this overlay put there," ADR-015) — otherwise the file is
+rewritten with just the block gone, every other byte preserved. No new
+`Outcome` variant needed: `Operation::Noop` on a `PartialFile` entry already
+falls through the existing generic `(_, Operation::Noop) => Outcome::Removed`
+arm.
+
+## Consequences
+
+`EntryKind`/`MaterializationIntent`/`Provenance` gain one new variant each,
+which is a breaking change for every exhaustive match over them —
+`desired::entry::kind()`, `materialize::symlink`'s `classify`/`build_action`
+(both gain an `unreachable!()` arm, `handles()` excludes the new intent),
+and `plan::step::PlanStep`'s `Display` (three new arms) all had to be
+updated for the crate to keep compiling; `plan::reconcile::Plan` itself
+needed no change (it dispatches through `MaterializerRegistry`, never
+matches on `MaterializationIntent` directly, confirming ADR-012's registry
+promise). `unapply::Report::build`'s classification needed no change either
+(its match is not exhaustive over intent) — only `dematerialize` gained an
+arm.
+
+The main cost is the fixed `#`-comment marker format: files that can't
+carry `#` comments aren't supported. A hand-edited block inside the
+markers is always caught as drift (never silently overwritten without
+`--force`/a prompt) — the same conservatism ADR-015 chose for unapply
+applies here to apply/materialize too. This is independent of #113: there
+is no rule/hierarchy resolution here, the sidecar is, like `.link.*`,
+today's only per-path configuration mechanism; #113 may later let a block's
+`marker`/`content` be resolved from inherited configuration instead of a
+literal sidecar field, without needing this ADR's model to change shape.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ by editing the old one. The history is the value.
 | [013](013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md) | `diff` has its own taxonomy and uses `similar` for content diffs, amending ADR-011 |
 | [014](014-bidirectional-checkout-synchronization.md) | Bidirectional checkout synchronization is `over sync`, scoped to an overlay's root git entry |
 | [015](015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md) | `unapply` reuses `Plan`'s classification and only ever removes safely reversible state |
+| [016](016-partial-file-managed-blocks.md) | Partial files are managed blocks injected via a sidecar, not a stem-plus-sidecar pair |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,3 +32,38 @@ Format resolution priority (highest to lowest):
 This preference only governs what `over new` **writes**. Reading an overlay
 tolerates any of `.toml`/`.yaml`/`.yml` regardless of this setting — see
 [ADR-003](adr/003-overlay-descriptors-tolerate-any-format-on-read.md).
+
+## Partial Files
+
+A `<name>.partial.{toml,yaml,yml}` sidecar file, placed anywhere in an
+overlay, injects a managed block into an existing (possibly foreign) file
+instead of symlinking it whole — useful for a single alias, export, or
+config stanza that must coexist with content `over` doesn't otherwise
+manage.
+
+```toml
+# aliases.partial.toml
+target = "~/.zshrc"
+content = "alias ll='ls -la'\n"
+# marker = "aliases"   # optional; defaults to the sidecar's own stem
+```
+
+- `target`: the file to modify. Templated the same way an overlay's own
+  `target` field is (`{{ env.* }}`, `{{ machine.* }}`, `{{ overlays[...] }}`).
+- `content`: the literal block body, used verbatim (not templated).
+- `marker`: identifies the block, so more than one sidecar can manage
+  distinct blocks in the same target file. Defaults to the sidecar's stem.
+
+The block is delimited by fixed `#`-comment marker lines:
+
+```text
+# >>> over: aliases >>>
+alias ll='ls -la'
+# <<< over: aliases <<<
+```
+
+A hand-edited block (content between the markers no longer matching what
+the overlay declares) is always reported as a conflict, never silently
+overwritten, exactly like any other `apply` conflict — see
+[ADR-016](adr/016-partial-file-managed-blocks.md). `over unapply` removes
+only the block, leaving the rest of the target file untouched.

--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -127,7 +127,12 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 }
 
 /// Remove a target path (file, symlink, or directory).
-fn remove_target(target: &Path) -> Result<()> {
+///
+/// `pub(crate)`: reused by `actions::partial::EnsurePartialBlock` (#66) for
+/// its own structural-conflict resolution (a directory/symlink sitting
+/// where a partial-managed file should be), rather than duplicating this
+/// logic.
+pub(crate) fn remove_target(target: &Path) -> Result<()> {
     if target.is_symlink() {
         // Determine if it's a file or dir symlink
         if target.is_dir() {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,10 +1,12 @@
 pub mod fs;
 pub mod git;
 pub mod install;
+pub mod partial;
 pub mod symlink;
 
 pub use fs::{EnsureDir, EnsureLink};
 pub use git::EnsureGitRepository;
+pub use partial::{EnsurePartialBlock, PartialConfig, discover_partials};
 pub use symlink::{
     EnsureSymlink, LinkType, SymlinkConfig, discover_symlinks, render_symlink_target,
 };

--- a/src/actions/partial.rs
+++ b/src/actions/partial.rs
@@ -1,0 +1,962 @@
+//! Partial file management (#66): a managed block injected into an
+//! existing (possibly foreign) file, delimited by marker comment lines,
+//! discovered from `*.partial.{toml,yaml,yml}` sidecars — mirroring the
+//! `.link.*` sidecar convention (`src/actions/symlink.rs`) as closely as
+//! possible.
+//!
+//! Deliberately independent of #61 (full file templating) and #113
+//! (hierarchical rules): `content` is used verbatim, never rendered, and
+//! there is no per-path rule resolution here — the sidecar is, like
+//! `.link.*`, today's only per-path configuration mechanism.
+//!
+//! v1 assumes a `#`-comment target file (shell rc files, ini-style
+//! configs, gitconfig, ssh config...) — the marker line format is fixed,
+//! not configurable. A target file that can't contain `#` comments (JSON,
+//! for instance) simply isn't a good fit for this feature yet.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as AnyhowContext, Result};
+use async_trait::async_trait;
+use dialoguer::Select;
+
+use noyalib::compat::serde_yaml as serde_yml;
+use serde::{Deserialize, Serialize};
+use tokio::task::spawn_blocking;
+
+use crate::diff::ContentDiff;
+use crate::exec::{Action, Ctx};
+use crate::plan::actual::{self, ActualState};
+use crate::ui::style::DialogTheme;
+use crate::ui::{emojis, style};
+use crate::utils::short_path;
+
+use super::fs::remove_target;
+
+/// A `*.partial.{toml,yaml,yml}` sidecar's contents.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PartialConfig {
+    pub target: String,
+    pub content: String,
+    /// Identifies this block among possibly several managed in the same
+    /// target file. Defaults to the sidecar's own stem (see
+    /// `discover_partials`) when absent.
+    #[serde(default)]
+    pub marker: Option<String>,
+}
+
+/// Discover every `*.partial.{toml,yaml,yml}` sidecar under `overlay_root`,
+/// returning `(stem, config)` pairs sorted by stem. Mirrors
+/// `symlink::discover_symlinks` exactly: same glob, same stem derivation,
+/// same TOML > YAML > YML precedence-with-warning on duplicates, same
+/// skip-with-warning on an empty `target` (plus, here, an empty `content`
+/// too — a managed block with nothing in it is a no-op that shouldn't
+/// exist).
+pub fn discover_partials(overlay_root: &Path) -> Result<Vec<(String, PartialConfig)>> {
+    use globset::GlobBuilder;
+    use walkdir::WalkDir;
+
+    let glob = GlobBuilder::new("**/*.partial.{toml,yaml,yml}")
+        .literal_separator(true)
+        .build()?
+        .compile_matcher();
+
+    let mut results: Vec<(String, PartialConfig)> = Vec::new();
+    let mut seen_names: HashMap<String, PathBuf> = HashMap::new();
+
+    for entry in WalkDir::new(overlay_root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        let rel = path.strip_prefix(overlay_root)?;
+
+        if !glob.is_match(rel) {
+            continue;
+        }
+
+        // Normalize to `/` so partial names are portable identifiers that
+        // don't leak the platform's native path separator (`\` on Windows).
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        let stem = rel_str
+            .strip_suffix(".partial.toml")
+            .or_else(|| rel_str.strip_suffix(".partial.yaml"))
+            .or_else(|| rel_str.strip_suffix(".partial.yml"))
+            .map(String::from)
+            .ok_or_else(|| anyhow::anyhow!("unexpected partial config file: {}", rel.display()))?;
+
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("failed to read partial config: {}", rel.display()))?;
+
+        let config: PartialConfig = if rel_str.ends_with(".toml") {
+            toml::from_str(&raw).with_context(|| format!("failed to parse {}", rel.display()))?
+        } else {
+            serde_yml::from_str(&raw)
+                .with_context(|| format!("failed to parse {}", rel.display()))?
+        };
+
+        if config.target.is_empty() {
+            tracing::warn!(
+                name = %stem,
+                path = %rel.display(),
+                "empty target in partial config, skipping",
+            );
+            continue;
+        }
+        if config.content.is_empty() {
+            tracing::warn!(
+                name = %stem,
+                path = %rel.display(),
+                "empty content in partial config, skipping",
+            );
+            continue;
+        }
+
+        if let Some(existing_path) = seen_names.get(&stem) {
+            let (toml_path, yaml_path) = if rel.to_string_lossy().ends_with(".toml") {
+                (rel.to_path_buf(), existing_path.clone())
+            } else {
+                (existing_path.clone(), rel.to_path_buf())
+            };
+            tracing::warn!(
+                name = %stem,
+                toml = %toml_path.display(),
+                yaml = %yaml_path.display(),
+                "both TOML and YAML partial configs exist; TOML takes precedence",
+            );
+            if rel.to_string_lossy().ends_with(".toml") {
+                results.retain(|(name, _)| name != &stem);
+                seen_names.insert(stem.clone(), rel.to_path_buf());
+                results.push((stem, config));
+            }
+            continue;
+        }
+
+        seen_names.insert(stem.clone(), rel.to_path_buf());
+        results.push((stem, config));
+    }
+
+    results.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(results)
+}
+
+// ── marker lines & pure block operations ────────────────────────────────
+
+fn begin_line(marker: &str) -> String {
+    format!("# >>> over: {marker} >>>")
+}
+
+fn end_line(marker: &str) -> String {
+    format!("# <<< over: {marker} <<<")
+}
+
+/// Whether — and how — a managed block for `marker` currently exists in a
+/// target file's content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockState<'a> {
+    /// No begin or end marker line found — nothing to reconcile against;
+    /// inserting a fresh block is purely additive.
+    Absent,
+    /// A complete, well-formed block found; carries its exact content
+    /// (excluding the marker lines themselves).
+    Found(&'a str),
+    /// A begin marker without a matching end marker (or vice versa) —
+    /// never touched automatically; always reported as a conflict.
+    Malformed,
+}
+
+/// Find the byte range `(start, end)` of the first line in `text` (at or
+/// after byte offset `from`) whose content exactly equals `needle`. `end`
+/// includes the line's trailing `\n`, if any.
+fn find_line(text: &str, needle: &str, from: usize) -> Option<(usize, usize)> {
+    let mut pos = from;
+    while pos <= text.len() {
+        let rest = &text[pos..];
+        let line_len = match rest.find('\n') {
+            Some(i) => i + 1,
+            None => rest.len(),
+        };
+        if line_len == 0 {
+            break; // `rest` is empty: reached the end of `text`.
+        }
+        let line = &rest[..line_len];
+        let trimmed = line.strip_suffix('\n').unwrap_or(line);
+        if trimmed == needle {
+            return Some((pos, pos + line_len));
+        }
+        pos += line_len;
+    }
+    None
+}
+
+/// Locate the current managed block for `marker` inside `text`. Read-only,
+/// pure — used both by classification (does the file already match?) and
+/// by unapply (does it still match what we last wrote, right before
+/// removing it?).
+pub fn find_block<'a>(text: &'a str, marker: &str) -> BlockState<'a> {
+    let begin = begin_line(marker);
+    let end = end_line(marker);
+    match find_line(text, &begin, 0) {
+        None => {
+            // An end marker with no matching begin is just as unsafe to
+            // touch automatically as the reverse.
+            if find_line(text, &end, 0).is_some() {
+                BlockState::Malformed
+            } else {
+                BlockState::Absent
+            }
+        }
+        Some((_, begin_end)) => match find_line(text, &end, begin_end) {
+            None => BlockState::Malformed,
+            Some((end_start, _)) => {
+                let content = &text[begin_end..end_start];
+                // `end_start` is the byte offset of the end-marker line
+                // itself, so `content` always carries the newline that
+                // terminated its own last line — strip exactly one.
+                BlockState::Found(content.strip_suffix('\n').unwrap_or(content))
+            }
+        },
+    }
+}
+
+/// Render a standalone block (marker lines plus `content`), with no
+/// surrounding file content — used to create a brand-new target file.
+fn block_only(marker: &str, content: &str) -> String {
+    append_block("", marker, content)
+}
+
+/// Append a fresh block for `marker` to the end of `text` (additive —
+/// only ever called when [`find_block`] reported [`BlockState::Absent`]).
+/// Adds a separating newline only if `text` is non-empty and doesn't
+/// already end in one, so existing content is never disturbed.
+pub fn append_block(text: &str, marker: &str, content: &str) -> String {
+    let mut out = text.to_string();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&begin_line(marker));
+    out.push('\n');
+    if !content.is_empty() {
+        out.push_str(content);
+        if !content.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    out.push_str(&end_line(marker));
+    out.push('\n');
+    out
+}
+
+/// Replace an existing block's content in place, preserving every other
+/// byte of `text` untouched. Only meaningful after [`find_block`] reported
+/// [`BlockState::Found`] — if the markers can't be found (a defensive
+/// check against a caller that didn't verify first), `text` is returned
+/// unchanged rather than guessing.
+pub fn replace_block(text: &str, marker: &str, content: &str) -> String {
+    let begin = begin_line(marker);
+    let end = end_line(marker);
+    let Some((_, begin_end)) = find_line(text, &begin, 0) else {
+        return text.to_string();
+    };
+    let Some((end_start, _)) = find_line(text, &end, begin_end) else {
+        return text.to_string();
+    };
+    let mut out = String::with_capacity(text.len() + content.len());
+    out.push_str(&text[..begin_end]);
+    if !content.is_empty() {
+        out.push_str(content);
+        if !content.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    out.push_str(&text[end_start..]);
+    out
+}
+
+/// Strip a block (marker lines included) from `text`, leaving every other
+/// byte untouched. Used only by `unapply`. A no-op (returns `text`
+/// unchanged) if the markers can't be found.
+pub fn remove_block(text: &str, marker: &str) -> String {
+    let begin = begin_line(marker);
+    let end = end_line(marker);
+    let Some((begin_start, _)) = find_line(text, &begin, 0) else {
+        return text.to_string();
+    };
+    let Some((_, end_end)) = find_line(text, &end, begin_start) else {
+        return text.to_string();
+    };
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..begin_start]);
+    out.push_str(&text[end_end..]);
+    out
+}
+
+// ── conflict resolution (interactive, force/no_prompt-gated) ────────────
+
+/// Choices for a structural conflict — a directory or symlink sits where
+/// a partial-managed file should be. Deliberately smaller than
+/// `actions::fs`'s `ConflictChoice`: no "Absorb" (there's no single
+/// overlay source file to adopt target content into — the desired content
+/// is a literal string in a sidecar) and no "Diff" (nothing file-shaped to
+/// diff against yet).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StructuralChoice {
+    Skip,
+    Overwrite,
+}
+
+impl StructuralChoice {
+    const ALL: &[StructuralChoice] = &[StructuralChoice::Skip, StructuralChoice::Overwrite];
+}
+
+impl fmt::Display for StructuralChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StructuralChoice::Skip => write!(f, "Skip"),
+            StructuralChoice::Overwrite => write!(f, "Overwrite (replace with a fresh file)"),
+        }
+    }
+}
+
+fn resolve_structural_conflict(ctx: &Ctx, target: &Path) -> Result<bool> {
+    if ctx.force {
+        remove_target(target)?;
+        return Ok(true);
+    }
+    if ctx.no_prompt {
+        return Err(anyhow::anyhow!(
+            "partial-file conflict: '{}' is a directory or symlink, not a plain file \
+             (use --force to replace it or run interactively to choose)",
+            target.display()
+        ));
+    }
+    // No "loop back and ask again" choice exists here (unlike the block-
+    // level conflict below, which has "Diff") — a single prompt suffices.
+    let prompt = format!(
+        "Conflict: {} exists and isn't a plain file",
+        style::yellow(short_path(&target.to_string_lossy())),
+    );
+    let selection = Select::with_theme(&DialogTheme::default())
+        .with_prompt(prompt)
+        .default(0)
+        .items(StructuralChoice::ALL)
+        .interact()
+        .map_err(|e| anyhow::anyhow!("prompt failed: {}", e))?;
+    match StructuralChoice::ALL[selection] {
+        StructuralChoice::Skip => Ok(false),
+        StructuralChoice::Overwrite => {
+            remove_target(target)?;
+            Ok(true)
+        }
+    }
+}
+
+/// Choices for a block-level conflict — the target file exists and has a
+/// managed block for this `marker`, but its content doesn't match (or the
+/// markers are malformed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BlockChoice {
+    Skip,
+    Overwrite,
+    Diff,
+}
+
+impl BlockChoice {
+    const ALL: &[BlockChoice] = &[BlockChoice::Skip, BlockChoice::Overwrite, BlockChoice::Diff];
+}
+
+impl fmt::Display for BlockChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockChoice::Skip => write!(f, "Skip"),
+            BlockChoice::Overwrite => write!(f, "Overwrite (replace the managed block)"),
+            BlockChoice::Diff => write!(f, "Diff (show differences, then decide)"),
+        }
+    }
+}
+
+fn resolve_block_conflict(
+    ctx: &Ctx,
+    target: &Path,
+    marker: &str,
+    current: &str,
+    desired: &str,
+) -> Result<bool> {
+    if ctx.force {
+        return Ok(true);
+    }
+    if ctx.no_prompt {
+        return Err(anyhow::anyhow!(
+            "partial-file conflict: managed block '{}' in '{}' doesn't match the overlay's \
+             content (use --force to overwrite or run interactively to choose)",
+            marker,
+            target.display()
+        ));
+    }
+    loop {
+        let prompt = format!(
+            "Conflict: managed block '{}' in {} doesn't match",
+            marker,
+            style::yellow(short_path(&target.to_string_lossy())),
+        );
+        let selection = Select::with_theme(&DialogTheme::default())
+            .with_prompt(prompt)
+            .default(0)
+            .items(BlockChoice::ALL)
+            .interact()
+            .map_err(|e| anyhow::anyhow!("prompt failed: {}", e))?;
+        match BlockChoice::ALL[selection] {
+            BlockChoice::Skip => return Ok(false),
+            BlockChoice::Overwrite => return Ok(true),
+            BlockChoice::Diff => {
+                let existing = match find_block(current, marker) {
+                    BlockState::Found(x) => x,
+                    _ => current,
+                };
+                println!("{}", ContentDiff::from_texts(existing, desired));
+                // Loop back to prompt.
+            }
+        }
+    }
+}
+
+// ── the Action itself ────────────────────────────────────────────────────
+
+pub struct EnsurePartialBlock {
+    pub target: PathBuf,
+    pub marker: String,
+    pub content: String,
+}
+
+impl EnsurePartialBlock {
+    pub fn new(target: PathBuf, marker: String, content: String) -> Self {
+        Self {
+            target,
+            marker,
+            content,
+        }
+    }
+}
+
+impl fmt::Display for EnsurePartialBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {} ({})",
+            emojis::BLOCK,
+            style::white("partial block:"),
+            short_path(&self.target.to_string_lossy()),
+            self.marker,
+        )
+    }
+}
+
+#[async_trait]
+impl Action for EnsurePartialBlock {
+    async fn execute(&self, ctx: Ctx) -> Result<()> {
+        if ctx.dry_run {
+            return Ok(());
+        }
+        let target = self.target.clone();
+        let marker = self.marker.clone();
+        let content = self.content.clone();
+        let ctx2 = ctx.clone();
+        spawn_blocking(move || -> Result<()> {
+            match actual::inspect(&target)? {
+                ActualState::Missing => {
+                    if let Some(parent) = target.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    fs::write(&target, block_only(&marker, &content))?;
+                    Ok(())
+                }
+                ActualState::Directory | ActualState::Symlink { .. } => {
+                    if !resolve_structural_conflict(&ctx2, &target)? {
+                        return Ok(()); // Skipped.
+                    }
+                    fs::write(&target, block_only(&marker, &content))?;
+                    Ok(())
+                }
+                ActualState::File => {
+                    let current = fs::read_to_string(&target)?;
+                    match find_block(&current, &marker) {
+                        BlockState::Absent => {
+                            fs::write(&target, append_block(&current, &marker, &content))?;
+                        }
+                        BlockState::Found(existing) if existing == content => {
+                            // Already correct — `materialize` is only ever
+                            // invoked for `Create`/`Conflict` steps, so this
+                            // is a defensive no-op against a classify→
+                            // execute race, not the expected path.
+                        }
+                        BlockState::Found(_) | BlockState::Malformed => {
+                            if !resolve_block_conflict(&ctx2, &target, &marker, &current, &content)?
+                            {
+                                return Ok(()); // Skipped.
+                            }
+                            let updated = match find_block(&current, &marker) {
+                                BlockState::Found(_) => replace_block(&current, &marker, &content),
+                                // Malformed: never delete the stray marker
+                                // line(s) automatically — append a fresh,
+                                // well-formed block after them instead.
+                                _ => append_block(&current, &marker, &content),
+                            };
+                            fs::write(&target, updated)?;
+                        }
+                    }
+                    Ok(())
+                }
+            }
+        })
+        .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use rstest::rstest;
+
+    fn init_test_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_max_level(tracing::Level::TRACE)
+            .try_init();
+    }
+
+    // ── find_block ───────────────────────────────────────────────────────
+
+    #[test]
+    fn find_block_absent_in_empty_text() {
+        assert_eq!(find_block("", "m"), BlockState::Absent);
+    }
+
+    #[test]
+    fn find_block_absent_when_unrelated_content_present() {
+        assert_eq!(
+            find_block("just some file\ncontent\n", "m"),
+            BlockState::Absent
+        );
+    }
+
+    #[test]
+    fn find_block_found_returns_exact_content() {
+        let text = "before\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\nafter\n";
+        assert_eq!(find_block(text, "m"), BlockState::Found("alias x=y"));
+    }
+
+    #[test]
+    fn find_block_found_with_multiline_content() {
+        let text = "# >>> over: m >>>\nline1\nline2\n# <<< over: m <<<\n";
+        assert_eq!(find_block(text, "m"), BlockState::Found("line1\nline2"));
+    }
+
+    #[test]
+    fn find_block_found_empty_content() {
+        let text = "# >>> over: m >>>\n# <<< over: m <<<\n";
+        assert_eq!(find_block(text, "m"), BlockState::Found(""));
+    }
+
+    #[test]
+    fn find_block_malformed_begin_without_end() {
+        let text = "# >>> over: m >>>\nalias x=y\n";
+        assert_eq!(find_block(text, "m"), BlockState::Malformed);
+    }
+
+    #[test]
+    fn find_block_malformed_end_without_begin() {
+        let text = "alias x=y\n# <<< over: m <<<\n";
+        assert_eq!(find_block(text, "m"), BlockState::Malformed);
+    }
+
+    #[test]
+    fn find_block_distinguishes_different_markers() {
+        let text = "# >>> over: a >>>\nfor-a\n# <<< over: a <<<\n# >>> over: b >>>\nfor-b\n# <<< over: b <<<\n";
+        assert_eq!(find_block(text, "a"), BlockState::Found("for-a"));
+        assert_eq!(find_block(text, "b"), BlockState::Found("for-b"));
+    }
+
+    // ── append_block ─────────────────────────────────────────────────────
+
+    #[test]
+    fn append_block_to_empty_text() {
+        let out = append_block("", "m", "alias x=y");
+        assert_eq!(out, "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n");
+    }
+
+    #[test]
+    fn append_block_adds_separating_newline() {
+        let out = append_block("existing content", "m", "alias x=y");
+        assert_eq!(
+            out,
+            "existing content\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+
+    #[test]
+    fn append_block_does_not_duplicate_trailing_newline() {
+        let out = append_block("existing content\n", "m", "alias x=y");
+        assert_eq!(
+            out,
+            "existing content\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+
+    #[test]
+    fn append_block_with_empty_content() {
+        let out = append_block("", "m", "");
+        assert_eq!(out, "# >>> over: m >>>\n# <<< over: m <<<\n");
+    }
+
+    // ── replace_block ────────────────────────────────────────────────────
+
+    #[test]
+    fn replace_block_preserves_surrounding_content() {
+        let text = "before\n# >>> over: m >>>\nold\n# <<< over: m <<<\nafter\n";
+        let out = replace_block(text, "m", "new");
+        assert_eq!(
+            out,
+            "before\n# >>> over: m >>>\nnew\n# <<< over: m <<<\nafter\n"
+        );
+    }
+
+    #[test]
+    fn replace_block_no_op_when_markers_absent() {
+        let text = "no markers here\n";
+        assert_eq!(replace_block(text, "m", "new"), text);
+    }
+
+    #[test]
+    fn replace_block_no_op_when_end_marker_missing() {
+        let text = "before\n# >>> over: m >>>\nold, no end marker\n";
+        assert_eq!(replace_block(text, "m", "new"), text);
+    }
+
+    #[test]
+    fn replace_block_with_empty_content() {
+        let text = "before\n# >>> over: m >>>\nold\n# <<< over: m <<<\nafter\n";
+        let out = replace_block(text, "m", "");
+        assert_eq!(out, "before\n# >>> over: m >>>\n# <<< over: m <<<\nafter\n");
+    }
+
+    // ── remove_block ─────────────────────────────────────────────────────
+
+    #[test]
+    fn remove_block_strips_markers_and_content() {
+        let text = "before\n# >>> over: m >>>\nold\n# <<< over: m <<<\nafter\n";
+        assert_eq!(remove_block(text, "m"), "before\nafter\n");
+    }
+
+    #[test]
+    fn remove_block_leaves_only_content_when_block_is_everything() {
+        let text = "# >>> over: m >>>\nold\n# <<< over: m <<<\n";
+        assert_eq!(remove_block(text, "m"), "");
+    }
+
+    #[test]
+    fn remove_block_no_op_when_markers_absent() {
+        let text = "no markers here\n";
+        assert_eq!(remove_block(text, "m"), text);
+    }
+
+    #[test]
+    fn remove_block_no_op_when_end_marker_missing() {
+        let text = "before\n# >>> over: m >>>\nold, no end marker\n";
+        assert_eq!(remove_block(text, "m"), text);
+    }
+
+    // ── discover_partials ────────────────────────────────────────────────
+
+    #[test]
+    fn discover_partials_finds_files() {
+        let td = TempDir::new().unwrap();
+        td.child("aliases.partial.toml")
+            .write_str("target = \"/home/user/.zshrc\"\ncontent = \"alias x=y\"")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "aliases");
+        assert_eq!(results[0].1.target, "/home/user/.zshrc");
+        assert_eq!(results[0].1.content, "alias x=y");
+    }
+
+    #[test]
+    fn discover_partials_yaml_also_found() {
+        let td = TempDir::new().unwrap();
+        td.child("aliases.partial.yaml")
+            .write_str("target: /home/user/.zshrc\ncontent: alias x=y")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "aliases");
+    }
+
+    #[test]
+    fn discover_partials_toml_takes_precedence_over_yaml() {
+        init_test_tracing();
+        let td = TempDir::new().unwrap();
+        td.child("aliases.partial.toml")
+            .write_str("target = \"/from-toml\"\ncontent = \"x\"")
+            .unwrap();
+        td.child("aliases.partial.yaml")
+            .write_str("target: /from-yaml\ncontent: x")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1.target, "/from-toml");
+    }
+
+    #[test]
+    fn discover_partials_yaml_first_toml_second_toml_wins() {
+        // Same assertion as the test above, but with the files written in
+        // the opposite order — `WalkDir` doesn't sort, so which file is
+        // encountered first (and therefore which side of the
+        // seen-names/duplicate branch each one exercises) depends on the
+        // OS's own directory order, not write order. Mirrors
+        // `symlink::discover_symlinks_yaml_first_toml_second_toml_wins`.
+        init_test_tracing();
+        let td = TempDir::new().unwrap();
+        td.child("aliases.partial.yaml")
+            .write_str("target: /from-yaml\ncontent: x")
+            .unwrap();
+        td.child("aliases.partial.toml")
+            .write_str("target = \"/from-toml\"\ncontent = \"x\"")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1.target, "/from-toml");
+    }
+
+    #[test]
+    fn discover_partials_skips_empty_target() {
+        init_test_tracing();
+        let td = TempDir::new().unwrap();
+        td.child("bad.partial.toml")
+            .write_str("target = \"\"\ncontent = \"x\"")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn discover_partials_skips_empty_content() {
+        init_test_tracing();
+        let td = TempDir::new().unwrap();
+        td.child("bad.partial.toml")
+            .write_str("target = \"/foo\"\ncontent = \"\"")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn discover_partials_optional_marker_field() {
+        let td = TempDir::new().unwrap();
+        td.child("aliases.partial.toml")
+            .write_str("target = \"/foo\"\ncontent = \"x\"\nmarker = \"custom\"")
+            .unwrap();
+
+        let results = discover_partials(td.path()).unwrap();
+        assert_eq!(results[0].1.marker, Some("custom".to_string()));
+    }
+
+    #[test]
+    fn discover_partials_empty_dir() {
+        let td = TempDir::new().unwrap();
+        let results = discover_partials(td.path()).unwrap();
+        assert!(results.is_empty());
+    }
+
+    // ── EnsurePartialBlock ───────────────────────────────────────────────
+
+    fn ctx_force(force: bool, no_prompt: bool, dry_run: bool) -> Ctx {
+        crate::exec::Context::builder()
+            .force(force)
+            .no_prompt(no_prompt)
+            .dry_run(dry_run)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_creates_missing_file() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("nested/dir/.zshrc");
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action
+            .execute(ctx_force(false, false, false))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_appends_to_existing_file() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        fs::write(&target, "export FOO=bar\n").unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action
+            .execute(ctx_force(false, false, false))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "export FOO=bar\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_dry_run_does_not_touch_filesystem() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action.execute(ctx_force(false, false, true)).await.unwrap();
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_force_overwrites_drifted_block() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        fs::write(
+            &target,
+            "before\n# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\nafter\n",
+        )
+        .unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action.execute(ctx_force(true, false, false)).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "before\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\nafter\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_no_prompt_errors_on_drift() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        fs::write(
+            &target,
+            "# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\n",
+        )
+        .unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        let result = action.execute(ctx_force(false, true, false)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_force_replaces_directory_in_the_way() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("blocked");
+        fs::create_dir_all(&target).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action.execute(ctx_force(true, false, false)).await.unwrap();
+
+        assert!(target.is_file());
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_no_prompt_errors_on_structural_conflict() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("blocked");
+        fs::create_dir_all(&target).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        let result = action.execute(ctx_force(false, true, false)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_already_correct_is_a_no_op() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        let original = "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n";
+        fs::write(&target, original).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action
+            .execute(ctx_force(false, false, false))
+            .await
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_force_appends_after_malformed_markers() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        fs::write(&target, "# >>> over: m >>>\nstray\n").unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action.execute(ctx_force(true, false, false)).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "# >>> over: m >>>\nstray\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+
+    // ── Display ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn structural_choice_display() {
+        assert_eq!(format!("{}", StructuralChoice::Skip), "Skip");
+        assert!(format!("{}", StructuralChoice::Overwrite).contains("Overwrite"));
+    }
+
+    #[test]
+    fn block_choice_display() {
+        assert_eq!(format!("{}", BlockChoice::Skip), "Skip");
+        assert!(format!("{}", BlockChoice::Overwrite).contains("Overwrite"));
+        assert!(format!("{}", BlockChoice::Diff).contains("Diff"));
+    }
+
+    #[rstest]
+    fn ensure_partial_block_display() {
+        let action = EnsurePartialBlock::new(
+            PathBuf::from("/home/user/.zshrc"),
+            "aliases".to_string(),
+            "alias x=y".to_string(),
+        );
+        let display = format!("{}", action);
+        assert!(display.contains("partial block:"));
+        assert!(display.contains(".zshrc"));
+        assert!(display.contains("aliases"));
+    }
+}

--- a/src/desired/entry.rs
+++ b/src/desired/entry.rs
@@ -48,6 +48,14 @@ pub enum MaterializationIntent {
     /// separate, explicit operation (`over sync`, `crate::sync`), not part
     /// of materialization.
     Checkout,
+    /// A managed block injected into an existing (possibly foreign) file,
+    /// delimited by marker lines unique to `marker` (#66). The first intent
+    /// to ever produce [`EntryKind::File`]: unlike every other intent, the
+    /// target isn't replaced wholesale — only the delimited region is
+    /// written/compared, so unrelated content in the same file is never
+    /// touched. `content` is used verbatim (no template rendering — that's
+    /// #61's job, kept independent per #66's own scope).
+    PartialFile { content: String, marker: String },
 }
 
 impl MaterializationIntent {
@@ -59,6 +67,7 @@ impl MaterializationIntent {
             }
             MaterializationIntent::SymlinkFile { .. }
             | MaterializationIntent::SymlinkDirectory { .. } => EntryKind::Symlink,
+            MaterializationIntent::PartialFile { .. } => EntryKind::File,
         }
     }
 }
@@ -90,6 +99,9 @@ pub enum Provenance {
         repo_key: String,
         config: Box<GitRepoConfig>,
     },
+    /// A `*.partial.{toml,yaml,yml}` sidecar declaring a managed block
+    /// injected into an external file (#66).
+    PartialSidecar { overlay: String, config: PathBuf },
 }
 
 /// A single desired filesystem node — the canonical unit [`super::DesiredTree`]
@@ -137,6 +149,15 @@ mod tests {
             link_type: LinkType::Soft,
         };
         assert_eq!(intent.kind(), EntryKind::Symlink);
+    }
+
+    #[test]
+    fn partial_file_intent_kind_is_file() {
+        let intent = MaterializationIntent::PartialFile {
+            content: "alias ll='ls -la'".to_string(),
+            marker: "aliases".to_string(),
+        };
+        assert_eq!(intent.kind(), EntryKind::File);
     }
 
     #[test]

--- a/src/desired/mod.rs
+++ b/src/desired/mod.rs
@@ -25,11 +25,11 @@
 //!
 //! [`DesiredTree::build`] walks an [`Overlay`](crate::overlays::Overlay) and
 //! everything it transitively `uses`, translating today's *implicit*
-//! symlink-first rules (`link_dirs`, `exclude`, `.link.*` sidecars, `git`)
-//! into an explicit list of [`DesiredEntry`] values. It never touches the
-//! filesystem beyond read-only inspection already required by that
-//! resolution (e.g. checking whether a `.link.*` sidecar target is a
-//! directory).
+//! symlink-first rules (`link_dirs`, `exclude`, `.link.*` sidecars,
+//! `.partial.*` sidecars (#66), `git`) into an explicit list of
+//! [`DesiredEntry`] values. It never touches the filesystem beyond
+//! read-only inspection already required by that resolution (e.g.
+//! checking whether a `.link.*` sidecar target is a directory).
 //!
 //! ## What's deliberately *not* here
 //!

--- a/src/desired/tree.rs
+++ b/src/desired/tree.rs
@@ -6,7 +6,7 @@ use globset::GlobBuilder;
 use walkdir::WalkDir;
 
 use crate::actions::git::config::ROOT_PATH;
-use crate::actions::symlink;
+use crate::actions::{partial, symlink};
 use crate::exec;
 use crate::overlays::{self, Overlay};
 
@@ -181,6 +181,7 @@ fn collect_own_entries(
     let ctx_with_target =
         ctx.with_resolved_overlay(overlay.name.clone(), target.to_string_lossy().to_string());
     build_symlink_sidecars(&ctx_with_target, overlay, target, &mut entries)?;
+    build_partial_sidecars(&ctx_with_target, overlay, &mut entries)?;
 
     Ok(entries)
 }
@@ -202,6 +203,10 @@ fn walk_overlay_tree(
         .literal_separator(true)
         .build()?
         .compile_matcher();
+    let partial_config = GlobBuilder::new("**/*.partial.{toml,yaml,yml}")
+        .literal_separator(true)
+        .build()?
+        .compile_matcher();
 
     let mut walker = WalkDir::new(&overlay.root).min_depth(1).into_iter();
     while let Some(entry) = walker.next() {
@@ -214,7 +219,8 @@ fn walk_overlay_tree(
         };
         let path = entry.path();
 
-        if exclude.is_match(path) || symlink_config.is_match(path) {
+        if exclude.is_match(path) || symlink_config.is_match(path) || partial_config.is_match(path)
+        {
             continue;
         }
 
@@ -333,6 +339,55 @@ fn sidecar_config_path(overlay_root: &Path, stem: &str) -> PathBuf {
     // these three files. Fall back to the canonical (TOML) form for a
     // stable, if slightly inaccurate, diagnostic path.
     overlay_root.join(format!("{stem}.link.toml"))
+}
+
+/// Resolve `.partial.{toml,yaml,yml}` sidecars into
+/// [`MaterializationIntent::PartialFile`] entries (#66): a managed block
+/// injected into `target` (rendered the same way a `.link.*` sidecar's
+/// `target` is — this reuses `symlink::render_symlink_target` directly,
+/// since it's already a generic path-template renderer, not
+/// symlink-specific in implementation).
+///
+/// Unlike `.link.*` sidecars, the entry's target is the rendered path
+/// *itself*, not `target_root.join(stem)`: a managed block's target is an
+/// arbitrary external file (e.g. `~/.zshrc`), not something living under
+/// the overlay's own target root by naming convention.
+fn build_partial_sidecars(
+    ctx: &exec::Context,
+    overlay: &Overlay,
+    entries: &mut Vec<DesiredEntry>,
+) -> Result<()> {
+    let partials = partial::discover_partials(&overlay.root)?;
+    for (name, config) in partials {
+        let resolved = symlink::render_symlink_target(&config.target, ctx)?;
+        let config_path = partial_sidecar_config_path(&overlay.root, &name);
+        let marker = config.marker.unwrap_or_else(|| name.clone());
+
+        entries.push(DesiredEntry {
+            target: PathBuf::from(resolved),
+            provenance: Provenance::PartialSidecar {
+                overlay: overlay.name.clone(),
+                config: config_path,
+            },
+            intent: MaterializationIntent::PartialFile {
+                content: config.content,
+                marker,
+            },
+        });
+    }
+    Ok(())
+}
+
+/// Reconstruct the sidecar file path for a partial `stem`, mirroring
+/// [`sidecar_config_path`]'s own TOML > YAML > YML precedence.
+fn partial_sidecar_config_path(overlay_root: &Path, stem: &str) -> PathBuf {
+    for ext in ["toml", "yaml", "yml"] {
+        let candidate = overlay_root.join(format!("{stem}.partial.{ext}"));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    overlay_root.join(format!("{stem}.partial.toml"))
 }
 
 #[cfg(test)]
@@ -619,6 +674,118 @@ mod tests {
             }
             other => panic!("unexpected intent: {other:?}"),
         }
+    }
+
+    #[rstest]
+    fn partial_sidecar_produces_partial_file_entry_at_rendered_target() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        let external = td.child("external.zshrc");
+        external.write_str("export FOO=bar\n").unwrap();
+        let target_toml = external.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("aliases.partial.toml")
+            .write_str(&format!(
+                "target = \"{}\"\ncontent = \"alias x=y\"",
+                target_toml
+            ))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == external.path().to_path_buf())
+            .expect("partial entry present at the rendered target");
+        match &entry.intent {
+            MaterializationIntent::PartialFile { content, marker } => {
+                assert_eq!(content, "alias x=y");
+                assert_eq!(marker, "aliases");
+            }
+            other => panic!("unexpected intent: {other:?}"),
+        }
+        match &entry.provenance {
+            Provenance::PartialSidecar { config, .. } => {
+                assert_eq!(config, &overlay.root.join("aliases.partial.toml"));
+            }
+            other => panic!("unexpected provenance: {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn partial_sidecar_custom_marker_is_used() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        let target_toml = td
+            .path()
+            .join("out.txt")
+            .to_string_lossy()
+            .replace('\\', "\\\\");
+        overlay_dir
+            .child("aliases.partial.toml")
+            .write_str(&format!(
+                "target = \"{}\"\ncontent = \"x\"\nmarker = \"custom\"",
+                target_toml
+            ))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == td.path().join("out.txt"))
+            .expect("partial entry present");
+        match &entry.intent {
+            MaterializationIntent::PartialFile { marker, .. } => assert_eq!(marker, "custom"),
+            other => panic!("unexpected intent: {other:?}"),
+        }
+    }
+
+    #[rstest]
+    fn partial_sidecar_config_files_are_not_entries() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        let target_toml = td
+            .path()
+            .join("out.txt")
+            .to_string_lossy()
+            .replace('\\', "\\\\");
+        overlay_dir
+            .child("aliases.partial.toml")
+            .write_str(&format!("target = \"{}\"\ncontent = \"x\"", target_toml))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        assert!(
+            !tree
+                .entries()
+                .iter()
+                .any(|e| e.target == overlay.root.join("aliases.partial.toml"))
+        );
     }
 
     #[rstest]

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -35,6 +35,7 @@ use std::path::Path;
 
 use anyhow::Result;
 
+use crate::actions::partial::{self, BlockState};
 use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
 use crate::plan::{ActualState, Operation, Plan};
 use crate::status::{self, Status};
@@ -223,6 +224,23 @@ fn classify_conflict(entry: &DesiredEntry, current: &ActualState) -> Result<Chan
         (MaterializationIntent::Checkout, _) => {
             unreachable!("Checkout entries never reach Plan::build's Conflict classification")
         }
+        // A partial-managed block drifted (or its markers are malformed):
+        // diff just the block's content, not the whole file — the rest of
+        // the target is never `over`'s concern.
+        (MaterializationIntent::PartialFile { content, marker }, ActualState::File) => {
+            let current_text = fs::read_to_string(&entry.target)?;
+            let existing_block = match partial::find_block(&current_text, marker) {
+                BlockState::Found(x) => x.to_string(),
+                // Absent/malformed: nothing block-shaped to diff against —
+                // fall back to the whole file so at least something useful
+                // is shown.
+                _ => current_text,
+            };
+            Ok(Change::Modified(ContentDiff::from_texts(
+                &existing_block,
+                content,
+            )))
+        }
         // Everything else structurally mismatched (a directory expected,
         // or a directory-symlink expected but a real file/directory
         // found): nothing meaningful to diff.
@@ -371,6 +389,68 @@ mod tests {
             other => panic!("expected Modified, got {other:?}"),
         }
         assert!(report.has_changes());
+    }
+
+    #[test]
+    fn drifted_partial_block_produces_block_level_diff() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(
+            &target,
+            "before\n# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\nafter\n",
+        )
+        .unwrap();
+        let entry = DesiredEntry {
+            target: target.clone(),
+            provenance: crate::desired::Provenance::PartialSidecar {
+                overlay: "ov".to_string(),
+                config: std::path::PathBuf::from("/repo/ov/aliases.partial.toml"),
+            },
+            intent: MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "m".to_string(),
+            },
+        };
+        let change = classify_conflict(&entry, &ActualState::File).unwrap();
+        match change {
+            Change::Modified(diff) => {
+                let s = format!("{diff}");
+                assert!(s.contains("hand-edited"));
+                assert!(s.contains("alias x=y"));
+                assert!(!s.contains("before"));
+                assert!(!s.contains("after"));
+            }
+            other => panic!("expected Modified, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_partial_block_falls_back_to_whole_file_diff() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        // Begin marker with no matching end marker: `find_block` reports
+        // `Malformed`, which has no block-shaped region to diff against.
+        fs::write(&target, "# >>> over: m >>>\nstray, no end marker\n").unwrap();
+        let entry = DesiredEntry {
+            target: target.clone(),
+            provenance: crate::desired::Provenance::PartialSidecar {
+                overlay: "ov".to_string(),
+                config: std::path::PathBuf::from("/repo/ov/aliases.partial.toml"),
+            },
+            intent: MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "m".to_string(),
+            },
+        };
+        let change = classify_conflict(&entry, &ActualState::File).unwrap();
+        match change {
+            Change::Modified(diff) => {
+                let s = format!("{diff}");
+                assert!(s.contains("stray, no end marker"));
+                assert!(s.contains("alias x=y"));
+            }
+            other => panic!("expected Modified, got {other:?}"),
+        }
     }
 
     #[rstest]

--- a/src/lint/checks.rs
+++ b/src/lint/checks.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use globset::GlobBuilder;
 
+use crate::actions::partial::discover_partials;
 use crate::actions::symlink::{LinkType, discover_symlinks};
 use crate::overlays::Overlay;
 
@@ -18,6 +19,7 @@ pub fn check_overlay(overlay: &Overlay) -> Vec<Diagnostic> {
     diagnostics.extend(check_invalid_link_dirs_globs(overlay));
     diagnostics.extend(check_git(overlay));
     diagnostics.extend(check_symlinks(overlay));
+    diagnostics.extend(check_partials(overlay));
 
     diagnostics
 }
@@ -268,6 +270,40 @@ fn check_symlinks(overlay: &Overlay) -> Vec<Diagnostic> {
                 )
                 .with_hint("hard links are not supported for directories on most filesystems"),
             );
+        }
+    }
+
+    diagnostics
+}
+
+// ── partial-file checks (#66) ────────────────────────────────────────────
+
+fn check_partials(overlay: &Overlay) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    let partials = match discover_partials(&overlay.root) {
+        Ok(p) => p,
+        Err(e) => {
+            diagnostics.push(Diagnostic::error(
+                &overlay.name,
+                format!("failed to discover partial configs: {e}"),
+            ));
+            return diagnostics;
+        }
+    };
+
+    for (name, config) in &partials {
+        // `discover_partials` already skips (with a `tracing::warn!`) any
+        // entry with an empty `target`/`content` before it ever reaches
+        // `partials`, so neither can ever be empty here — the only thing
+        // left worth flagging statically is a `target` template that
+        // won't render.
+        let test_state = std::collections::HashMap::<String, String>::new();
+        if let Err(e) = crate::exec::templates::render_string(&config.target, &test_state) {
+            diagnostics.push(Diagnostic::error(
+                &overlay.name,
+                format!("partial `{name}`: invalid template in `target`: {e}"),
+            ));
         }
     }
 
@@ -562,5 +598,42 @@ worktree = true
                 .iter()
                 .any(|d| d.severity == Severity::Error && d.message.contains("invalid template"))
         );
+    }
+
+    // ── partial checks (#66) ─────────────────────────────────────────────
+
+    #[rstest]
+    fn test_check_partials_valid_no_diagnostics() {
+        let overlay = setup_overlay("target = \"~\"");
+        let partial_file = overlay.root.join("test.partial.toml");
+        std::fs::write(&partial_file, "target = \"/foo\"\ncontent = \"x\"").unwrap();
+        let diags = check_partials(&overlay);
+        assert!(diags.is_empty());
+    }
+
+    #[rstest]
+    fn test_check_partials_invalid_template() {
+        let overlay = setup_overlay("target = \"~\"");
+        let partial_file = overlay.root.join("test.partial.toml");
+        std::fs::write(&partial_file, "target = \"{{ invalid\"\ncontent = \"x\"").unwrap();
+        let diags = check_partials(&overlay);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.severity == Severity::Error && d.message.contains("invalid template"))
+        );
+    }
+
+    #[rstest]
+    fn test_check_partials_discover_error() {
+        let overlay = setup_overlay("target = \"~\"");
+        let partial_file = overlay.root.join("bad.partial.toml");
+        // Malformed TOML syntax (not just a missing/empty field) makes
+        // `discover_partials` itself return an `Err`, not just skip an
+        // entry.
+        std::fs::write(&partial_file, "not valid toml [[[").unwrap();
+        let diags = check_partials(&overlay);
+        assert!(diags.iter().any(|d| d.severity == Severity::Error
+            && d.message.contains("failed to discover partial configs")));
     }
 }

--- a/src/materialize/mod.rs
+++ b/src/materialize/mod.rs
@@ -18,9 +18,11 @@
 //! Materializer::materialize   — concrete filesystem/Git changes
 //! ```
 //!
-//! [`MaterializerRegistry`] registers two backends: [`SymlinkMaterializer`]
-//! (every intent except `Checkout`) and [`CheckoutMaterializer`] (#110),
-//! which owns [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout) —
+//! [`MaterializerRegistry`] registers three backends: [`PartialFileMaterializer`]
+//! (#66, [`MaterializationIntent::PartialFile`](crate::desired::MaterializationIntent::PartialFile)),
+//! [`SymlinkMaterializer`] (every remaining intent except `Checkout`), and
+//! [`CheckoutMaterializer`] (#110), which owns
+//! [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout) —
 //! ensuring a git checkout/worktree is present and configured, exactly like
 //! `actions::git::clone_repositories` already does. It does *not* implement
 //! content-level bidirectional sync (fetch/merge/push): that's `over sync`
@@ -30,6 +32,7 @@
 //! registry.
 
 mod checkout;
+mod partial;
 mod symlink;
 
 use anyhow::Result;
@@ -40,6 +43,7 @@ use crate::exec::Ctx;
 use crate::plan::{Operation, PlanStep};
 
 pub use checkout::CheckoutMaterializer;
+pub use partial::PartialFileMaterializer;
 pub use symlink::SymlinkMaterializer;
 
 /// A materialization backend: owns both read-only actual-state inspection
@@ -78,6 +82,10 @@ impl Default for MaterializerRegistry {
     fn default() -> Self {
         Self {
             backends: vec![
+                // Must come before `SymlinkMaterializer`: `PartialFile` is
+                // a distinct intent, but registration order matters for
+                // any future intent whose `handles()` might overlap.
+                Box::new(PartialFileMaterializer),
                 Box::new(SymlinkMaterializer),
                 Box::new(CheckoutMaterializer),
             ],
@@ -132,6 +140,16 @@ mod tests {
     fn registry_finds_checkout_materializer_for_checkout() {
         let registry = MaterializerRegistry::default();
         assert!(registry.find(&MaterializationIntent::Checkout).is_some());
+    }
+
+    #[test]
+    fn registry_finds_partial_file_materializer_for_partial_file() {
+        let registry = MaterializerRegistry::default();
+        let intent = MaterializationIntent::PartialFile {
+            content: "alias x=y".to_string(),
+            marker: "m".to_string(),
+        };
+        assert!(registry.find(&intent).is_some());
     }
 
     #[test]

--- a/src/materialize/partial.rs
+++ b/src/materialize/partial.rs
@@ -1,0 +1,201 @@
+//! Partial-file materialization backend (#66).
+//!
+//! Owns [`MaterializationIntent::PartialFile`]: a managed block injected
+//! into an existing (possibly foreign) file, rather than a whole-target
+//! symlink/directory/checkout. Classification is content-aware (it reads
+//! the target file, unlike [`super::symlink::SymlinkMaterializer`]'s
+//! purely structural `symlink_metadata` comparison) but still strictly
+//! read-only — actual writes stay in
+//! [`crate::actions::partial::EnsurePartialBlock`].
+
+use std::fs;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::actions::partial::{BlockState, EnsurePartialBlock, find_block};
+use crate::desired::{DesiredEntry, MaterializationIntent};
+use crate::exec::{Action, Ctx};
+use crate::plan::actual::{self, ActualState};
+use crate::plan::{Operation, PlanStep};
+
+use super::Materializer;
+
+/// Owns [`MaterializationIntent::PartialFile`]. See the module docs for
+/// how this differs from [`super::symlink::SymlinkMaterializer`].
+pub struct PartialFileMaterializer;
+
+#[async_trait(?Send)]
+impl Materializer for PartialFileMaterializer {
+    fn handles(&self, intent: &MaterializationIntent) -> bool {
+        matches!(intent, MaterializationIntent::PartialFile { .. })
+    }
+
+    /// Reads the target's content (when it's a plain file) to compare the
+    /// managed block, not just its `symlink_metadata` — the one
+    /// materializer backend for which "actual state" must mean more than
+    /// structural type, since two different `PartialFile` entries can
+    /// legitimately share the same target file (distinct `marker`s).
+    fn classify(&self, entry: &DesiredEntry) -> Result<Operation> {
+        let MaterializationIntent::PartialFile { content, marker } = &entry.intent else {
+            unreachable!("MaterializerRegistry only calls classify() after handles() passed")
+        };
+        match actual::inspect(&entry.target)? {
+            ActualState::Missing => Ok(Operation::Create),
+            ActualState::File => {
+                let current = fs::read_to_string(&entry.target)?;
+                Ok(match find_block(&current, marker) {
+                    // No block yet: inserting one is purely additive, same
+                    // "nothing here yet" spirit as `Operation::Create`.
+                    BlockState::Absent => Operation::Create,
+                    BlockState::Found(existing) if existing == content => Operation::Noop,
+                    // Drifted (hand-edited, or another overlay's stale
+                    // write) or malformed markers: never touched
+                    // automatically — surfaced as a conflict exactly like
+                    // `SymlinkMaterializer` does for a mismatched symlink.
+                    BlockState::Found(_) | BlockState::Malformed => Operation::Conflict {
+                        current: ActualState::File,
+                    },
+                })
+            }
+            // A directory or symlink sits where a plain file was expected.
+            other => Ok(Operation::Conflict { current: other }),
+        }
+    }
+
+    async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()> {
+        let MaterializationIntent::PartialFile { content, marker } = &step.entry.intent else {
+            unreachable!("MaterializerRegistry only calls materialize() after handles() passed")
+        };
+        EnsurePartialBlock::new(step.entry.target.clone(), marker.clone(), content.clone())
+            .execute(ctx)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::desired::Provenance;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use std::path::PathBuf;
+
+    fn entry(target: PathBuf, content: &str, marker: &str) -> DesiredEntry {
+        DesiredEntry {
+            target,
+            provenance: Provenance::PartialSidecar {
+                overlay: "ov".to_string(),
+                config: PathBuf::from("/repo/ov/aliases.partial.toml"),
+            },
+            intent: MaterializationIntent::PartialFile {
+                content: content.to_string(),
+                marker: marker.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn handles_only_partial_file_intent() {
+        let m = PartialFileMaterializer;
+        assert!(m.handles(&MaterializationIntent::PartialFile {
+            content: "x".to_string(),
+            marker: "m".to_string(),
+        }));
+        assert!(!m.handles(&MaterializationIntent::Directory));
+        assert!(!m.handles(&MaterializationIntent::Checkout));
+    }
+
+    #[test]
+    fn classify_missing_target_is_create() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let e = entry(td.path().join("does-not-exist"), "alias x=y", "m");
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Create));
+    }
+
+    #[test]
+    fn classify_file_without_block_is_create() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target.write_str("unrelated content\n").unwrap();
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Create));
+    }
+
+    #[test]
+    fn classify_file_with_matching_block_is_noop() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target
+            .write_str("# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n")
+            .unwrap();
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    fn classify_file_with_drifted_block_is_conflict() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target
+            .write_str("# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\n")
+            .unwrap();
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_malformed_markers_is_conflict() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target
+            .write_str("# >>> over: m >>>\nstray, no end marker\n")
+            .unwrap();
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_directory_in_the_way_is_conflict() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("adir");
+        target.create_dir_all().unwrap();
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict {
+                current: ActualState::Directory
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn materialize_creates_missing_target() {
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        let e = entry(target.clone(), "alias x=y", "m");
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Create,
+        };
+        let ctx = crate::exec::Context::builder().build();
+        m.materialize(ctx, &step).await.unwrap();
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
+        );
+    }
+}

--- a/src/materialize/symlink.rs
+++ b/src/materialize/symlink.rs
@@ -24,7 +24,10 @@ pub struct SymlinkMaterializer;
 #[async_trait(?Send)]
 impl Materializer for SymlinkMaterializer {
     fn handles(&self, intent: &MaterializationIntent) -> bool {
-        !matches!(intent, MaterializationIntent::Checkout)
+        !matches!(
+            intent,
+            MaterializationIntent::Checkout | MaterializationIntent::PartialFile { .. }
+        )
     }
 
     /// Classify a single entry against current filesystem state. Read-only.
@@ -49,7 +52,7 @@ impl Materializer for SymlinkMaterializer {
                     other => Operation::Conflict { current: other },
                 })
             }
-            MaterializationIntent::Checkout => {
+            MaterializationIntent::Checkout | MaterializationIntent::PartialFile { .. } => {
                 unreachable!("MaterializerRegistry only calls classify() after handles() passed")
             }
         }
@@ -104,8 +107,8 @@ fn build_action(ctx: Ctx, entry: &DesiredEntry) -> Box<dyn Action> {
                 ))
             }
         }
-        MaterializationIntent::Checkout => {
-            unreachable!("SymlinkMaterializer::handles filters out Checkout entries")
+        MaterializationIntent::Checkout | MaterializationIntent::PartialFile { .. } => {
+            unreachable!("SymlinkMaterializer::handles filters out Checkout/PartialFile entries")
         }
     }
 }
@@ -132,6 +135,15 @@ mod tests {
     fn handles_returns_false_for_checkout() {
         let m = SymlinkMaterializer;
         assert!(!m.handles(&MaterializationIntent::Checkout));
+    }
+
+    #[test]
+    fn handles_returns_false_for_partial_file() {
+        let m = SymlinkMaterializer;
+        assert!(!m.handles(&MaterializationIntent::PartialFile {
+            content: "x".to_string(),
+            marker: "m".to_string(),
+        }));
     }
 
     #[test]

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -138,6 +138,39 @@ impl fmt::Display for PlanStep {
                 target,
                 current,
             ),
+            (MaterializationIntent::PartialFile { marker, .. }, Operation::Create) => write!(
+                f,
+                "{} {} {} ({} '{}')",
+                emojis::BLOCK,
+                style::white("insert block:"),
+                target,
+                style::white("marker"),
+                marker,
+            ),
+            (MaterializationIntent::PartialFile { marker, .. }, Operation::Noop) => write!(
+                f,
+                "{} {} {} ({} '{}' {})",
+                emojis::CHECKMARK,
+                style::white("block:"),
+                target,
+                style::white("marker"),
+                marker,
+                style::white("already present"),
+            ),
+            (
+                MaterializationIntent::PartialFile { marker, .. },
+                Operation::Conflict { current },
+            ) => {
+                write!(
+                    f,
+                    "{} {} block '{}' in {} doesn't match ({})",
+                    emojis::WARNING,
+                    style::yellow("conflict:"),
+                    marker,
+                    target,
+                    current,
+                )
+            }
             // Every intent has a registered `Materializer` since #110; no
             // step should ever classify as `Deferred` anymore — unreachable
             // in practice, but a clear fallback beats a silently wrong line.
@@ -262,6 +295,49 @@ mod tests {
         let s = format!("{step}");
         assert!(s.contains("checkout:"));
         assert!(s.contains("over sync"));
+    }
+
+    #[test]
+    fn create_partial_file_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "aliases".to_string(),
+            }),
+            operation: Operation::Create,
+        };
+        let s = format!("{step}");
+        assert!(s.contains("insert block:"));
+        assert!(s.contains("aliases"));
+    }
+
+    #[test]
+    fn noop_partial_file_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "aliases".to_string(),
+            }),
+            operation: Operation::Noop,
+        };
+        let s = format!("{step}");
+        assert!(s.contains("already present"));
+    }
+
+    #[test]
+    fn conflict_partial_file_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "aliases".to_string(),
+            }),
+            operation: Operation::Conflict {
+                current: ActualState::File,
+            },
+        };
+        let s = format!("{step}");
+        assert!(s.contains("conflict:"));
+        assert!(s.contains("aliases"));
     }
 
     #[test]

--- a/src/ui/emojis.rs
+++ b/src/ui/emojis.rs
@@ -12,6 +12,7 @@ pub static SPARKLE: Emoji<'_, '_> = Emoji("✨", "");
 pub static MOVE_FILE: Emoji<'_, '_> = Emoji("📃", "");
 pub static WARNING: Emoji<'_, '_> = Emoji("⚠️", "");
 pub static TRASH: Emoji<'_, '_> = Emoji("🗑️", "");
+pub static BLOCK: Emoji<'_, '_> = Emoji("🧩", "");
 // static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍  ", "");
 // static TRUCK: Emoji<'_, '_> = Emoji("🚚  ", "");
 // static CLIP: Emoji<'_, '_> = Emoji("🔗  ", "");

--- a/src/unapply/mod.rs
+++ b/src/unapply/mod.rs
@@ -41,6 +41,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use tokio::task::spawn_blocking;
 
+use crate::actions::partial::{self, BlockState};
 use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
 use crate::exec::Ctx;
 use crate::plan::actual::{self, ActualState};
@@ -287,6 +288,10 @@ async fn dematerialize(entry: &DesiredEntry) -> Result<()> {
             remove_symlink_if_unchanged(entry.target.clone(), source.clone()).await
         }
         MaterializationIntent::Checkout => remove_checkout_if_clean(entry.clone()).await,
+        MaterializationIntent::PartialFile { content, marker } => {
+            remove_partial_block_if_unchanged(entry.target.clone(), marker.clone(), content.clone())
+                .await
+        }
     }
 }
 
@@ -327,6 +332,45 @@ async fn remove_symlink_if_unchanged(target: PathBuf, source: PathBuf) -> Result
             Ok(())
         }
         _ => Ok(()),
+    })
+    .await?
+}
+
+/// Strip the managed block for `marker` from `target`, but only if it
+/// *still* matches `expected` exactly right now — re-read here (not just
+/// trusted from classification) for the same classify→execute
+/// race-safety reason as [`remove_symlink_if_unchanged`]. A block that's
+/// drifted (hand-edited) or gone malformed since classification is left
+/// untouched, never forced.
+///
+/// If stripping the block leaves nothing (or only whitespace) behind, the
+/// file itself is removed — mirroring [`remove_dir_if_empty`]'s "a
+/// directory disappears exactly when it turns out to hold nothing but
+/// what this overlay put there". Otherwise the file is rewritten with
+/// just the block removed, every other byte preserved.
+async fn remove_partial_block_if_unchanged(
+    target: PathBuf,
+    marker: String,
+    expected: String,
+) -> Result<()> {
+    spawn_blocking(move || {
+        let current = match fs::read_to_string(&target) {
+            Ok(s) => s,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e.into()),
+        };
+        match partial::find_block(&current, &marker) {
+            BlockState::Found(existing) if existing == expected => {
+                let stripped = partial::remove_block(&current, &marker);
+                if stripped.trim().is_empty() {
+                    fs::remove_file(&target)?;
+                } else {
+                    fs::write(&target, stripped)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()), // Drifted, malformed, or already gone — leave alone.
+        }
     })
     .await?
 }
@@ -492,6 +536,169 @@ mod tests {
         assert!(report.is_empty());
         assert!(!report.has_pending_removals());
         assert!(!report.needs_attention());
+    }
+
+    fn partial_entry(target: PathBuf, content: &str, marker: &str) -> DesiredEntry {
+        DesiredEntry {
+            target,
+            provenance: Provenance::PartialSidecar {
+                overlay: "ov".to_string(),
+                config: PathBuf::from("/repo/ov/aliases.partial.toml"),
+            },
+            intent: MaterializationIntent::PartialFile {
+                content: content.to_string(),
+                marker: marker.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn matching_partial_block_classifies_as_removed() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(
+            &target,
+            "before\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\nafter\n",
+        )
+        .unwrap();
+        let desired = DesiredTree::from_entries(vec![partial_entry(target, "alias x=y", "m")]);
+        let report = Report::build(&desired).unwrap();
+        assert_eq!(report.entries()[0].outcome, Outcome::Removed);
+    }
+
+    #[test]
+    fn drifted_partial_block_is_not_owned() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(
+            &target,
+            "# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\n",
+        )
+        .unwrap();
+        let desired = DesiredTree::from_entries(vec![partial_entry(target, "alias x=y", "m")]);
+        let report = Report::build(&desired).unwrap();
+        assert!(matches!(
+            report.entries()[0].outcome,
+            Outcome::NotOwned { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_strips_block_and_keeps_surrounding_content() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(
+            &target,
+            "before\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\nafter\n",
+        )
+        .unwrap();
+        let desired =
+            DesiredTree::from_entries(vec![partial_entry(target.clone(), "alias x=y", "m")]);
+        let report = Report::build(&desired).unwrap();
+        report.execute(Context::builder().build()).await.unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "before\nafter\n");
+    }
+
+    #[tokio::test]
+    async fn execute_removes_file_when_block_was_all_it_contained() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(&target, "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n").unwrap();
+        let desired =
+            DesiredTree::from_entries(vec![partial_entry(target.clone(), "alias x=y", "m")]);
+        let report = Report::build(&desired).unwrap();
+        report.execute(Context::builder().build()).await.unwrap();
+
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    async fn execute_leaves_drifted_block_untouched() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        let original = "# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\n";
+        fs::write(&target, original).unwrap();
+        let desired =
+            DesiredTree::from_entries(vec![partial_entry(target.clone(), "alias x=y", "m")]);
+        let report = Report::build(&desired).unwrap();
+        report.execute(Context::builder().build()).await.unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn remove_partial_block_if_unchanged_missing_target_is_a_no_op() {
+        // Simulates a classify→execute race: the target vanished between
+        // `Report::build` and `Report::execute` (e.g. removed by something
+        // else entirely). Never an error — nothing left to strip.
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("does-not-exist.txt");
+        remove_partial_block_if_unchanged(target.clone(), "m".to_string(), "alias x=y".to_string())
+            .await
+            .unwrap();
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn remove_partial_block_if_unchanged_propagates_read_errors() {
+        // A non-`NotFound` I/O error (permission denied) must propagate,
+        // not be silently swallowed like a genuine "already gone" race —
+        // mirrors `desired::tree::tests::unreadable_subdirectory_is_skipped_with_a_warning`'s
+        // own permission-based error injection.
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(&target, "content").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = remove_partial_block_if_unchanged(
+            target.clone(),
+            "m".to_string(),
+            "alias x=y".to_string(),
+        )
+        .await;
+
+        // Restore permissions so the `TempDir` can clean up regardless of
+        // the assertion outcome.
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_partial_block_if_unchanged_leaves_drifted_block_untouched() {
+        // Direct call (bypassing `Report::build`/`execute`, which would
+        // never even reach this function for a drifted block — it
+        // classifies as `Conflict`/`NotOwned` and is skipped upstream):
+        // exercises the race-safety re-check on its own terms.
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        let original = "# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\n";
+        fs::write(&target, original).unwrap();
+        remove_partial_block_if_unchanged(target.clone(), "m".to_string(), "alias x=y".to_string())
+            .await
+            .unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn dry_run_execute_does_not_touch_partial_block() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        let original = "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n";
+        fs::write(&target, original).unwrap();
+        let desired =
+            DesiredTree::from_entries(vec![partial_entry(target.clone(), "alias x=y", "m")]);
+        let report = Report::build(&desired).unwrap();
+        report
+            .execute(Context::builder().dry_run(true).build())
+            .await
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), original);
     }
 
     #[rstest]


### PR DESCRIPTION
Implements partial file management (#66): a way to inject a managed block into an existing (possibly foreign) file — a single alias, export, or config stanza — without symlinking the whole file.

## What's new

A `*.partial.{toml,yaml,yml}` sidecar, discovered and parsed exactly like the existing `.link.*` convention, declares a block:

```toml
target = "~/.zshrc"
content = "alias ll='ls -la'\n"
# marker = "aliases"   # optional; defaults to the sidecar's own stem
```

The block is delimited by fixed marker lines and reconciled through the same `DesiredTree` → `Plan` → `Materializer` pipeline every other entry uses:

- inserting a block is purely additive (never touches existing content)
- a block that's drifted from what the overlay declares (hand-edited, or malformed markers) is always surfaced as a conflict, never silently overwritten
- `over unapply` removes only the block, deleting the file itself only when nothing else is left

See [ADR-016](docs/adr/016-partial-file-managed-blocks.md) for the full design rationale, including why this stays independent of #61 (content templating) and #113 (hierarchical rules).

Closes #66
