### PR TITLE
refactor: fix inconsistencies found by a full-project consistency review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,18 @@ src/
 ├── actions/      filesystem, symlink, install and git side effects
 ├── cli/          argument types for both binaries
 ├── desired/      the DesiredTree/DesiredEntry desired-state model
+├── diff/         `over diff` desired-vs-actual comparison
 ├── exec/         execution context and templating
 ├── lint/         `over lint` diagnostics
 ├── materialize/  Materializer backends (registry, symlink)
 ├── overlays/     the Overlay/Repository domain model
 ├── plan/         the Plan/PlanStep reconciliation model
-└── ui/           logging, styling, emojis
+├── status/       `over status` desired-state classification
+├── sync/         `over sync` bidirectional checkout synchronization
+├── ui/           logging, styling, emojis
+├── unapply/      `over unapply` reversal of an overlay's own entries
+├── xdg/          XDG state/cache layout and persistence
+└── utils/        shared helpers
 ```
 
 Dependencies point inward. Nothing in the library knows a command exists.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ over --help
 | `over lint` | Check overlays for configuration issues |
 | `over completion` | Generate shell completion scripts |
 | `over status` | Get the current repository/directory overlays status |
+| `over diff` | Show differences between desired and actual overlay state |
+| `over sync` | Reconcile a checkout-materialized overlay with its git source |
+| `over unapply` | Remove a given overlay's own entries from the target |
 
 A companion binary `git-over` integrates with git workflows:
 

--- a/docs/adr/002-overlay-is-a-directory-not-a-repository.md
+++ b/docs/adr/002-overlay-is-a-directory-not-a-repository.md
@@ -32,7 +32,13 @@ can use, not what an overlay is.
 Nothing requires the overlay repository itself to be under version control
 — `over` has no opinion on it. Most users do put `~/.dotfiles` under git
 anyway, but that's outside `over`'s model entirely: there is no built-in
-history, diffing, or sync for the overlay content.
+history for the *overlay repository itself* (no commit log of `~/.dotfiles`
+managed by `over`). This predates and is unrelated to `over diff`
+([ADR-013](013-diff-has-its-own-taxonomy-and-uses-similar-for-content-diffs.md))
+and `over sync` ([ADR-014](014-bidirectional-checkout-synchronization.md)),
+which compare/reconcile desired vs. actual *target* state and
+checkout-materialized git repositories declared via `git:`, not the overlay
+repository's own history.
 
 Because identity is filesystem path, renaming or moving an overlay directory
 renames the overlay — and breaks anything that referenced its old name

--- a/docs/usage/apply.md
+++ b/docs/usage/apply.md
@@ -30,3 +30,7 @@ Options:
   links files.
 - A file that already exists at the target triggers an interactive prompt
   (skip, overwrite, absorb, diff) unless `--force` or `--no-prompt` is given.
+- `--dry-run`/`--verbose` print the structured reconciliation plan (one line
+  per entry: create/no-op/conflict) before executing it, rather than just
+  reporting success or failure. See
+  [ADR-011](../adr/011-plan-then-execute-reconciliation.md).

--- a/docs/usage/apply.md
+++ b/docs/usage/apply.md
@@ -1,7 +1,8 @@
 # `over apply`
 
-Apply a given overlay: symlink its files into the target root, clone any
-declared git repositories, and optionally install packages.
+Apply a given overlay: optionally install packages first (`--install`), then
+clone any declared git repositories and symlink its files into the target
+root.
 
 ```
 Usage: over apply [OPTIONS] [NAME]

--- a/docs/usage/status.md
+++ b/docs/usage/status.md
@@ -3,11 +3,16 @@
 Get the current repository/directory overlays status.
 
 ```
-Usage: over status [OPTIONS]
+Usage: over status [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]  Name of the overlay to check (all overlays if omitted)
 
 Options:
   -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
+  -r, --root <ROOT>  The target root directory (~)
   -d, --debug        Toggle debug traces
+      --no-uses      Do not process uses
   -v, --verbose      Toggle verbose output
   -h, --help         Print help
 ```

--- a/docs/usage/status.md
+++ b/docs/usage/status.md
@@ -16,3 +16,20 @@ Options:
   -v, --verbose      Toggle verbose output
   -h, --help         Print help
 ```
+
+Each entry is classified into one of 8 statuses (referenced by `over diff`
+and `over unapply` too):
+
+| Status | Meaning |
+|--------|---------|
+| `Applied` | Target matches desired intent — nothing to do. |
+| `Missing` | Target doesn't exist yet. |
+| `Modified` | A git checkout has uncommitted changes. |
+| `Broken` | A dangling soft symlink, or a checkout path that isn't a valid git repo. |
+| `Conflict` | Target exists and doesn't match desired intent, or a git checkout has a merge/rebase/cherry-pick in progress. |
+| `Ahead` | A git checkout is ahead of its upstream. |
+| `Behind` | A git checkout is behind its upstream. |
+| `Diverged` | A git checkout has diverged from its upstream. |
+
+Without `--verbose`, only entries other than `Applied` are printed; pass
+`--verbose` to also print unchanged entries.

--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -16,6 +16,7 @@ use walkdir::WalkDir;
 
 use crate::exec::{Action, Ctx};
 use crate::overlays::Overlay;
+use crate::ui;
 use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
@@ -227,11 +228,11 @@ pub async fn add_file(ctx: Ctx, overlay: &Overlay, file: &PathBuf) -> Result<()>
         file
     };
     if ctx.debug {
-        println!("{:#?}", src);
+        ui::info(format!("{:#?}", src)).ok();
     }
     let root = overlay.resolve_target(&ctx)?;
     if ctx.debug {
-        println!("{:#?}", root);
+        ui::info(format!("{:#?}", root)).ok();
     }
     let rel_path = match src.strip_prefix(&root) {
         Ok(tail) => tail,
@@ -251,7 +252,7 @@ pub async fn add_file(ctx: Ctx, overlay: &Overlay, file: &PathBuf) -> Result<()>
     {
         let dir_action = EnsureDir::new(parent.to_path_buf());
         if ctx.verbose || ctx.dry_run {
-            println!("{}", dir_action);
+            ui::info(format!("{}", dir_action)).ok();
         }
         dir_action.execute(ctx.clone()).await?;
     }
@@ -260,12 +261,12 @@ pub async fn add_file(ctx: Ctx, overlay: &Overlay, file: &PathBuf) -> Result<()>
     let link_action = EnsureLink::new(ctx.clone(), target.clone(), src.to_path_buf());
 
     if ctx.verbose || ctx.dry_run {
-        println!("{}", move_action);
+        ui::info(format!("{}", move_action)).ok();
     }
     move_action.execute(ctx.clone()).await?;
 
     if ctx.verbose || ctx.dry_run {
-        println!("{}", link_action);
+        ui::info(format!("{}", link_action)).ok();
     }
     if let Err(e) = link_action.execute(ctx.clone()).await {
         // Rollback: move file back to original location
@@ -315,7 +316,7 @@ pub async fn add_dir(ctx: Ctx, overlay: &Overlay, dir: &Path) -> Result<()> {
         {
             let dir_action = EnsureDir::new(parent.to_path_buf());
             if ctx.verbose || ctx.dry_run {
-                println!("{}", dir_action);
+                ui::info(format!("{}", dir_action)).ok();
             }
             dir_action.execute(ctx.clone()).await?;
         }
@@ -324,12 +325,12 @@ pub async fn add_dir(ctx: Ctx, overlay: &Overlay, dir: &Path) -> Result<()> {
         let link_action = EnsureDirLink::new(ctx.clone(), target, src);
 
         if ctx.verbose || ctx.dry_run {
-            println!("{}", move_action);
+            ui::info(format!("{}", move_action)).ok();
         }
         move_action.execute(ctx.clone()).await?;
 
         if ctx.verbose || ctx.dry_run {
-            println!("{}", link_action);
+            ui::info(format!("{}", link_action)).ok();
         }
         link_action.execute(ctx.clone()).await?;
     } else {

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, Result, anyhow};
 use async_trait::async_trait;
-use config::{GitRepoConfig, ROOT_PATH};
 use futures::future::join_all;
 use git2::{Progress, Repository};
 use git2_credentials::CredentialHandler;
@@ -20,6 +19,7 @@ use tokio::{
     task::spawn_blocking,
 };
 
+use crate::actions::git::config::{GitRepoConfig, ROOT_PATH};
 use crate::overlays::Overlay;
 use crate::{
     exec::{Action, Ctx},

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod sync;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context as _, Result, anyhow};
 use async_trait::async_trait;
@@ -12,7 +12,6 @@ use futures::future::join_all;
 use git2::{Progress, Repository};
 use git2_credentials::CredentialHandler;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::sync::LazyLock;
 use tokio::{
     spawn,
     sync::mpsc::{self, Sender},

--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -32,7 +32,8 @@ pub async fn clone_repositories(ctx: Ctx, overlay: &Overlay, to: &Path) -> Resul
             "{} {}",
             emojis::THREAD,
             style::white("Cloning repositories"),
-        ))?;
+        ))
+        .ok();
         let subctx = ctx.with_multiprogress(MultiProgress::new());
         let results = join_all(git_repos.iter().map(|(path, repo_config)| {
             let target = if path == ROOT_PATH {
@@ -269,7 +270,11 @@ fn ensure_remotes(
             if existing.url().ok() != Some(remote_config.url.as_str()) {
                 repo.remote_set_url(name, &remote_config.url)?;
                 if verbose {
-                    println!("  Updated remote {name} URL to {}", remote_config.url);
+                    ui::info(format!(
+                        "  Updated remote {name} URL to {}",
+                        remote_config.url
+                    ))
+                    .ok();
                 }
             }
             drop(existing);
@@ -281,7 +286,7 @@ fn ensure_remotes(
                 repo.remote(name, &remote_config.url)?;
             }
             if verbose {
-                println!("  Added remote {name} -> {}", remote_config.url);
+                ui::info(format!("  Added remote {name} -> {}", remote_config.url)).ok();
             }
         }
 
@@ -432,10 +437,11 @@ fn create_worktree(
             )
         })?;
         if verbose {
-            println!(
+            ui::info(format!(
                 "  Created worktree '{name}' at {} (branch: {branch})",
                 wt_path.display()
-            );
+            ))
+            .ok();
         }
     } else {
         return Err(anyhow!("branch '{branch}' not found for worktree '{name}'"));
@@ -456,7 +462,7 @@ fn apply_git_config(
             .set_str(key, value)
             .with_context(|| format!("failed to set git config {key}"))?;
         if verbose {
-            println!("  Set config {key} = {value}");
+            ui::info(format!("  Set config {key} = {value}")).ok();
         }
     }
     Ok(())
@@ -479,7 +485,7 @@ fn apply_config_to_file(
         cfg.set_str(key, value)
             .with_context(|| format!("failed to set {key} in {}", path.display()))?;
         if verbose {
-            println!("  Set {} {key} = {value}", path.display());
+            ui::info(format!("  Set {} {key} = {value}", path.display())).ok();
         }
     }
     Ok(())
@@ -509,7 +515,7 @@ fn apply_per_worktree_config(
         .set_str("extensions.worktreeConfig", "true")
         .context("failed to set extensions.worktreeConfig")?;
     if verbose {
-        println!("  Set config extensions.worktreeConfig = true");
+        ui::info("  Set config extensions.worktreeConfig = true").ok();
     }
 
     let is_bare = config.worktree || config.worktrees.is_some();
@@ -518,7 +524,7 @@ fn apply_per_worktree_config(
             .set_str("core.bare", "false")
             .context("failed to set core.bare = false in shared config")?;
         if verbose {
-            println!("  Set config core.bare = false");
+            ui::info("  Set config core.bare = false").ok();
         }
     }
     drop(git_cfg);

--- a/src/actions/install.rs
+++ b/src/actions/install.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashSet};
 use std::env::consts::OS;
 
+use crate::ui;
 use crate::{exec::Ctx, overlays::Overlay, utils::detect_linux_distro_id};
 use anyhow::{Context as AnyhowContext, Result};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -96,7 +97,7 @@ where
 async fn run_cmd(ctx: &Ctx, program: &str, args: &[&str]) -> Result<()> {
     use tokio::process::Command;
     if ctx.verbose || ctx.dry_run {
-        println!("$ {} {}", program, args.join(" "));
+        ui::info(format!("$ {} {}", program, args.join(" "))).ok();
     }
     if ctx.dry_run {
         return Ok(());

--- a/src/actions/install.rs
+++ b/src/actions/install.rs
@@ -1,11 +1,12 @@
 use std::collections::{BTreeSet, HashSet};
 use std::env::consts::OS;
 
-use crate::ui;
-use crate::{exec::Ctx, overlays::Overlay, utils::detect_linux_distro_id};
 use anyhow::{Context as AnyhowContext, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use which::which;
+
+use crate::ui;
+use crate::{exec::Ctx, overlays::Overlay, utils::detect_linux_distro_id};
 
 /// Serde helper: accept either a single string or a list of strings for
 /// `Option<Vec<String>>` fields, normalising both to `Some(vec![…])`.

--- a/src/actions/partial.rs
+++ b/src/actions/partial.rs
@@ -468,23 +468,32 @@ impl Action for EnsurePartialBlock {
             match actual::inspect(&target)? {
                 ActualState::Missing => {
                     if let Some(parent) = target.parent() {
-                        fs::create_dir_all(parent)?;
+                        fs::create_dir_all(parent).with_context(|| {
+                            format!(
+                                "failed to create parent directories for {}",
+                                target.display()
+                            )
+                        })?;
                     }
-                    fs::write(&target, block_only(&marker, &content))?;
+                    fs::write(&target, block_only(&marker, &content))
+                        .with_context(|| format!("failed to write {}", target.display()))?;
                     Ok(())
                 }
                 ActualState::Directory | ActualState::Symlink { .. } => {
                     if !resolve_structural_conflict(&ctx2, &target)? {
                         return Ok(()); // Skipped.
                     }
-                    fs::write(&target, block_only(&marker, &content))?;
+                    fs::write(&target, block_only(&marker, &content))
+                        .with_context(|| format!("failed to write {}", target.display()))?;
                     Ok(())
                 }
                 ActualState::File => {
-                    let current = fs::read_to_string(&target)?;
+                    let current = fs::read_to_string(&target)
+                        .with_context(|| format!("failed to read {}", target.display()))?;
                     match find_block(&current, &marker) {
                         BlockState::Absent => {
-                            fs::write(&target, append_block(&current, &marker, &content))?;
+                            fs::write(&target, append_block(&current, &marker, &content))
+                                .with_context(|| format!("failed to write {}", target.display()))?;
                         }
                         BlockState::Found(existing) if existing == content => {
                             // Already correct — `materialize` is only ever
@@ -504,7 +513,8 @@ impl Action for EnsurePartialBlock {
                                 // well-formed block after them instead.
                                 _ => append_block(&current, &marker, &content),
                             };
-                            fs::write(&target, updated)?;
+                            fs::write(&target, updated)
+                                .with_context(|| format!("failed to write {}", target.display()))?;
                         }
                     }
                     Ok(())
@@ -803,6 +813,101 @@ mod tests {
             fs::read_to_string(&target).unwrap(),
             "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_partial_block_reports_context_when_parent_cannot_be_created() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        // `target` itself is missing (so `actual::inspect` reports
+        // `Missing` rather than erroring), but its read-only parent
+        // rejects creating the still-missing `nested/` component —
+        // exercises the `.with_context` wrapping added to name the
+        // offending path.
+        let readonly = td.path().join("readonly");
+        fs::create_dir_all(&readonly).unwrap();
+        let target = readonly.join("nested/.zshrc");
+        fs::set_permissions(&readonly, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        let result = action.execute(ctx_force(false, false, false)).await;
+
+        fs::set_permissions(&readonly, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("failed to create parent directories")
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_partial_block_reports_context_when_write_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let dir = td.path().join("readonly");
+        fs::create_dir_all(&dir).unwrap();
+        let target = dir.join(".zshrc");
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        let result = action.execute(ctx_force(false, false, false)).await;
+
+        // Restore permissions so the `TempDir` can clean up regardless of
+        // the assertion outcome.
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to write"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_partial_block_reports_context_when_read_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        fs::write(&target, "export FOO=bar\n").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        let result = action.execute(ctx_force(false, false, false)).await;
+
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to read"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_partial_block_reports_context_when_append_write_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        // Readable (so the block-detection read succeeds and finds no
+        // existing block) but not writable, so appending the new block
+        // fails.
+        fs::write(&target, "export FOO=bar\n").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o444)).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        let result = action.execute(ctx_force(false, false, false)).await;
+
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to write"));
     }
 
     #[tokio::test]

--- a/src/actions/partial.rs
+++ b/src/actions/partial.rs
@@ -30,6 +30,7 @@ use tokio::task::spawn_blocking;
 use crate::diff::ContentDiff;
 use crate::exec::{Action, Ctx};
 use crate::plan::actual::{self, ActualState};
+use crate::ui;
 use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
@@ -416,7 +417,7 @@ fn resolve_block_conflict(
                     BlockState::Found(x) => x,
                     _ => current,
                 };
-                println!("{}", ContentDiff::from_texts(existing, desired));
+                ui::info(format!("{}", ContentDiff::from_texts(existing, desired))).ok();
                 // Loop back to prompt.
             }
         }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -8,6 +8,7 @@ use crate::cli::CLI;
 use crate::cli::common::resolve_inputs;
 use crate::exec::Context;
 use crate::overlays::Repository;
+use crate::ui;
 use crate::ui::emojis;
 use crate::ui::style::{self, DialogTheme};
 use anyhow::{Result, anyhow};
@@ -93,13 +94,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             .add_files(&ctx, &regular_paths)
             .await
             .inspect_err(|e| {
-                eprintln!(
+                let _ = ui::warn(format!(
                     "{} {} {}: {}",
                     emojis::CROSSMARK,
                     style::white_b("Failed to add to overlay"),
                     style::cyan(&overlay.name),
                     e,
-                );
+                ));
             })?;
     }
 
@@ -141,13 +142,14 @@ fn add_symlink(
     let toml_content = toml::to_string_pretty(&config)?;
     std::fs::write(&config_path, toml_content)?;
 
-    println!(
+    ui::info(format!(
         "{} {} {} {}",
         emojis::CHECKMARK,
         style::white_b("Created symlink config"),
         style::cyan(config_path.display()),
         style::white_b("in overlay"),
-    );
+    ))
+    .ok();
 
     Ok(())
 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::{Result, anyhow};
 use clap::Args;
-use dialoguer::Input;
+use dialoguer::{FuzzySelect, Input};
+use dirs::home_dir;
 
 use crate::actions::symlink::SymlinkConfig;
 use crate::cli::CLI;
@@ -11,9 +13,6 @@ use crate::overlays::Repository;
 use crate::ui;
 use crate::ui::emojis;
 use crate::ui::style::{self, DialogTheme};
-use anyhow::{Result, anyhow};
-use dialoguer::FuzzySelect;
-use dirs::home_dir;
 
 #[derive(Args, Debug)]
 pub struct Params {

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -9,6 +9,7 @@ use crate::actions;
 use crate::cli::CLI;
 use crate::exec::Context;
 use crate::overlays::Repository;
+use crate::ui;
 use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 #[derive(Args, Debug)]
@@ -87,13 +88,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     }
 
     overlay.apply(&ctx).await.inspect_err(|e| {
-        eprintln!(
+        let _ = ui::warn(format!(
             "{} {} {}: {}",
             emojis::CROSSMARK,
             style::white_b("Failed to apply overlay"),
             style::cyan(&overlay.name),
             e,
-        );
+        ));
     })?;
 
     Ok(())

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -84,12 +84,12 @@ fn print_overlay_diff(
         style::cyan(&short_path(&target.to_string_lossy())),
     );
 
-    if !report.has_changes() {
+    if !report.needs_attention() {
         println!("  {}", style::white("no differences"));
     }
 
     for diff_entry in report.entries() {
-        if cli.verbose || diff_entry.has_diff() {
+        if cli.verbose || diff_entry.needs_attention() {
             println!("  {diff_entry}");
         }
     }

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -9,6 +9,7 @@ use crate::desired::DesiredTree;
 use crate::diff::Report;
 use crate::exec::Context;
 use crate::overlays::{Overlay, Repository};
+use crate::ui;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -43,7 +44,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     };
 
     if overlays.is_empty() {
-        println!("No overlays found.");
+        ui::info("No overlays found.").ok();
         return Ok(());
     }
 
@@ -75,25 +76,26 @@ fn print_overlay_diff(
     let desired = DesiredTree::build(&ctx, overlay)?;
     let report = Report::build(&desired)?;
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {}",
         emojis::PACKAGE,
         style::white_b("Overlay"),
         style::cyan(&overlay.name),
         style::white_b("->"),
         style::cyan(&short_path(&target.to_string_lossy())),
-    );
+    ))
+    .ok();
 
     if !report.needs_attention() {
-        println!("  {}", style::white("no differences"));
+        ui::info(format!("  {}", style::white("no differences"))).ok();
     }
 
     for diff_entry in report.entries() {
         if cli.verbose || diff_entry.needs_attention() {
-            println!("  {diff_entry}");
+            ui::info(format!("  {diff_entry}")).ok();
         }
     }
-    println!();
+    ui::info("").ok();
 
     Ok(())
 }

--- a/src/cli/git_over/add.rs
+++ b/src/cli/git_over/add.rs
@@ -5,6 +5,7 @@ use dirs::home_dir;
 use crate::cli::common::resolve_inputs;
 use crate::exec::Context;
 use crate::overlays::Repository;
+use crate::ui;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -59,14 +60,15 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     let root = home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
     let _rel_path = repo_relative_path(&overlay, &root, &repo_root)?;
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {}",
         emojis::PACKAGE,
         style::white("Adding files from"),
         style::cyan(&short_path(&workdir.to_string_lossy())),
         style::white("to overlay"),
         style::cyan(&overlay.name),
-    );
+    ))
+    .ok();
 
     // Build execution context with the overlay's target as root
     let ctx = Context::builder()
@@ -82,13 +84,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     let resolved = resolve_inputs(&args.files)?;
 
     overlay.add_files(&ctx, &resolved).await.inspect_err(|e| {
-        eprintln!(
+        let _ = ui::warn(format!(
             "{} {} {}: {}",
             emojis::CROSSMARK,
             style::white_b("Failed to add to overlay"),
             style::cyan(&overlay.name),
             e,
-        );
+        ));
     })?;
 
     // Compute relative paths from the repo root for .git/info/exclude
@@ -107,12 +109,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         exclude_paths(&git_repo, &refs)?;
 
         if cli.verbose {
-            println!(
+            ui::info(format!(
                 "{} {} {}",
                 emojis::CHECKMARK,
                 style::white("Added to .git/info/exclude:"),
                 style::cyan(&exclude_entries.join(", ")),
-            );
+            ))
+            .ok();
         }
     }
 
@@ -127,7 +130,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         })
         .collect();
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {} ({})",
         emojis::SPARKLE,
         style::white_b("Added"),
@@ -135,7 +138,8 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         style::white_b("file(s) to overlay"),
         style::cyan(&overlay.name),
         added_display.join(", "),
-    );
+    ))
+    .ok();
 
     Ok(())
 }

--- a/src/cli/git_over/mount.rs
+++ b/src/cli/git_over/mount.rs
@@ -9,6 +9,7 @@ use noyalib::compat::serde_yaml as serde_yml;
 
 use crate::actions::git::config::{GitConfig, GitRepoConfig, RemoteConfig, WorktreeEntry};
 use crate::overlays::{self, Format, Repository};
+use crate::ui;
 use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
@@ -67,12 +68,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         over_repo.get(name)?
     } else if let Some(name) = get_overlay_config(&git_repo)? {
         let overlay = over_repo.get(&name)?;
-        println!(
+        ui::info(format!(
             "{} {} {}",
             emojis::PACKAGE,
             style::white("Using overlay from git config:"),
             style::cyan(&name),
-        );
+        ))
+        .ok();
         overlay
     } else {
         let overlays = over_repo.overlays()?;
@@ -99,14 +101,15 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         .to_str()
         .ok_or_else(|| anyhow!("repository path is not valid UTF-8"))?;
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {}",
         emojis::LINK,
         style::white("Mounting"),
         style::cyan(&short_path(&repo_root.to_string_lossy())),
         style::white("to overlay"),
         style::cyan(&overlay.name),
-    );
+    ))
+    .ok();
 
     // ── Inspect local repo properties ────────────────────────────────────
 
@@ -253,45 +256,47 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     let existing_entry = overlay.git.as_ref().and_then(|git| git.get(rel_path_str));
 
     if let Some(existing) = existing_entry {
-        println!(
+        ui::info(format!(
             "\n{} {} {}",
             emojis::PACKAGE,
             style::white_b("Overlay already has a git entry for"),
             style::cyan(rel_path_str),
-        );
-        println!("  url: {}", style::cyan(&existing.url));
+        ))
+        .ok();
+        ui::info(format!("  url: {}", style::cyan(&existing.url))).ok();
         if let Some(ref branch) = existing.branch {
-            println!("  branch: {}", style::cyan(branch));
+            ui::info(format!("  branch: {}", style::cyan(branch))).ok();
         }
         if let Some(ref remotes) = existing.remotes {
             for (name, cfg) in remotes {
-                println!("  remote {}: {}", style::cyan(name), cfg.url);
+                ui::info(format!("  remote {}: {}", style::cyan(name), cfg.url)).ok();
             }
         }
         if let Some(ref config) = existing.config {
             for (key, value) in &config.entries {
-                println!("  config {}: {}", style::cyan(key), value);
+                ui::info(format!("  config {}: {}", style::cyan(key), value)).ok();
             }
         }
         if existing.per_worktree_config {
-            println!("  per_worktree_config: {}", style::cyan("true"));
+            ui::info(format!("  per_worktree_config: {}", style::cyan("true"))).ok();
         }
         if let Some(ref wt_config) = existing.worktree_config {
             for (key, value) in &wt_config.entries {
-                println!("  worktree_config {}: {}", style::cyan(key), value);
+                ui::info(format!("  worktree_config {}: {}", style::cyan(key), value)).ok();
             }
         }
-        println!();
+        ui::info("").ok();
     }
 
     // ── Prompt user to select properties to export ───────────────────────
 
     if exportable.is_empty() {
-        println!(
+        ui::info(format!(
             "{} {}",
             emojis::CHECKMARK,
             style::white("No exportable properties found in local repo"),
-        );
+        ))
+        .ok();
     } else {
         let labels: Vec<&str> = exportable.iter().map(|p| p.label.as_str()).collect();
         let defaults: Vec<bool> = exportable
@@ -316,11 +321,12 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             .map_err(|e| anyhow!("selection cancelled: {}", e))?;
 
         if selections.is_empty() {
-            println!(
+            ui::info(format!(
                 "{} {}",
                 emojis::CHECKMARK,
                 style::white("No properties selected, skipping export"),
-            );
+            ))
+            .ok();
         } else {
             // Build the GitRepoConfig from selected properties
             let mut url = String::new();
@@ -417,26 +423,28 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
             })
             .await??;
 
-            println!(
+            ui::info(format!(
                 "{} {} {} {} {}",
                 emojis::SPARKLE,
                 style::white_b("Exported git config for"),
                 style::cyan(rel_path_str),
                 style::white_b("to overlay"),
                 style::cyan(&overlay.name),
-            );
+            ))
+            .ok();
         }
     }
 
     // ── Write overlay name to git config ─────────────────────────────────
 
     set_overlay_config(&git_repo, &overlay.name)?;
-    println!(
+    ui::info(format!(
         "{} {} {}",
         emojis::CHECKMARK,
         style::white("Set over.overlay ="),
         style::cyan(&overlay.name),
-    );
+    ))
+    .ok();
 
     Ok(())
 }

--- a/src/cli/git_over/status.rs
+++ b/src/cli/git_over/status.rs
@@ -5,6 +5,7 @@ use dirs::home_dir;
 use walkdir::WalkDir;
 
 use crate::overlays::{self, Repository};
+use crate::ui;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -32,26 +33,29 @@ pub async fn execute(cli: &CLI) -> Result<()> {
     let root = home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
     let rel_path = repo_relative_path(&overlay, &root, &repo_root)?;
 
-    println!(
+    ui::info(format!(
         "{} {} {}",
         emojis::PACKAGE,
         style::white_b("Repository:"),
         style::cyan(&short_path(&repo_root.to_string_lossy())),
-    );
+    ))
+    .ok();
     if is_worktree {
-        println!(
+        ui::info(format!(
             "  {} {}",
             style::white("Worktree:"),
             style::cyan(&short_path(&workdir.to_string_lossy())),
-        );
+        ))
+        .ok();
     } else if is_bare {
-        println!(
+        ui::info(format!(
             "  {} {}",
             style::white("Mode:"),
             style::cyan("worktree workspace (bare)"),
-        );
+        ))
+        .ok();
     }
-    println!(
+    ui::info(format!(
         "  {} {} {}",
         style::white("Overlay:"),
         style::cyan(&overlay.name),
@@ -59,13 +63,15 @@ pub async fn execute(cli: &CLI) -> Result<()> {
             "({})",
             short_path(&overlay.root.to_string_lossy())
         )),
-    );
-    println!(
+    ))
+    .ok();
+    ui::info(format!(
         "  {} {}",
         style::white("Relative path:"),
         style::cyan(rel_path.display()),
-    );
-    println!();
+    ))
+    .ok();
+    ui::info("").ok();
 
     // ── Overlay-managed files in worktree ────────────────────────────────
     // Walk the repo working tree, find symlinks pointing into the overlay root.
@@ -135,38 +141,41 @@ pub async fn execute(cli: &CLI) -> Result<()> {
     // ── Display results ──────────────────────────────────────────────────
 
     if managed_files.is_empty() && unapplied_files.is_empty() {
-        println!(
+        ui::info(format!(
             "  {} {}",
             emojis::CHECKMARK,
             style::white("No overlay-managed files found"),
-        );
+        ))
+        .ok();
         return Ok(());
     }
 
     if !managed_files.is_empty() {
-        println!(
+        ui::info(format!(
             "{} {} ({})",
             emojis::LINK,
             style::white_b("Managed files"),
             managed_files.len(),
-        );
+        ))
+        .ok();
         for file in &managed_files {
-            println!("  {} {}", emojis::GREEN_CIRCLE, style::cyan(file));
+            ui::info(format!("  {} {}", emojis::GREEN_CIRCLE, style::cyan(file))).ok();
         }
     }
 
     if !unapplied_files.is_empty() {
         if !managed_files.is_empty() {
-            println!();
+            ui::info("").ok();
         }
-        println!(
+        ui::info(format!(
             "{} {} ({})",
             emojis::PACKAGE,
             style::white_b("Overlay files not applied"),
             unapplied_files.len(),
-        );
+        ))
+        .ok();
         for file in &unapplied_files {
-            println!("  {} {}", style::yellow("?"), style::yellow(file));
+            ui::info(format!("  {} {}", style::yellow("?"), style::yellow(file))).ok();
         }
     }
 

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use clap::Args;
 use console::style;
 
@@ -5,7 +6,6 @@ use crate::cli::CLI;
 use crate::lint::{Severity, lint_repository};
 use crate::overlays::Repository;
 use crate::ui;
-use anyhow::Result;
 
 #[derive(Args, Debug)]
 pub struct Params {}

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -4,6 +4,7 @@ use console::style;
 use crate::cli::CLI;
 use crate::lint::{Severity, lint_repository};
 use crate::overlays::Repository;
+use crate::ui;
 use anyhow::Result;
 
 #[derive(Args, Debug)]
@@ -15,7 +16,7 @@ pub async fn execute(cli: &CLI, _args: &Params) -> Result<()> {
     let result = lint_repository(&repo);
 
     if result.diagnostics.is_empty() {
-        println!("{}", style("No issues found").green().bold());
+        ui::info(format!("{}", style("No issues found").green().bold())).ok();
         return Ok(());
     }
 
@@ -26,18 +27,23 @@ pub async fn execute(cli: &CLI, _args: &Params) -> Result<()> {
         };
         let overlay_label = style(format!("[{}]", diag.overlay)).cyan();
 
-        println!("{severity_label}{overlay_label}: {}", diag.message);
+        ui::info(format!("{severity_label}{overlay_label}: {}", diag.message)).ok();
 
         if let Some(file) = &diag.file {
             let location = format!("{}/{file}", diag.overlay);
-            println!("  {} {}", style("-->").dim(), style(location).dim());
+            ui::info(format!(
+                "  {} {}",
+                style("-->").dim(),
+                style(location).dim()
+            ))
+            .ok();
         }
 
         if let Some(hint) = &diag.hint {
-            println!("  {} {hint}", style("=").dim());
+            ui::info(format!("  {} {hint}", style("=").dim())).ok();
         }
 
-        println!();
+        ui::info("").ok();
     }
 
     // Summary
@@ -68,7 +74,7 @@ pub async fn execute(cli: &CLI, _args: &Params) -> Result<()> {
             .bold()
         ));
     }
-    println!("{} found", parts.join(", "));
+    ui::info(format!("{} found", parts.join(", "))).ok();
 
     if result.has_errors() {
         anyhow::bail!(

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use anyhow::Result;
 use clap::Args;
 use termtree::Tree;
 
 use crate::cli::CLI;
 use crate::overlays::Repository;
 use crate::ui;
-use anyhow::Result;
 
 #[derive(Args, Debug)]
 pub struct Params {

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -6,6 +6,7 @@ use termtree::Tree;
 
 use crate::cli::CLI;
 use crate::overlays::Repository;
+use crate::ui;
 use anyhow::Result;
 
 #[derive(Args, Debug)]
@@ -29,7 +30,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         print!("{tree}");
     } else {
         for overlay in &overlays {
-            println!("{}", overlay.name);
+            ui::info(&overlay.name).ok();
         }
     }
 

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -10,6 +10,7 @@ use dirs::home_dir;
 
 use crate::exec::Context;
 use crate::overlays::{BASENAME, DEFAULT_TARGET, Format, Repository};
+use crate::ui;
 use crate::ui::style::{self, DialogTheme};
 
 use super::CLI;
@@ -107,12 +108,13 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     if !args.dry_run {
         fs::create_dir_all(&overlay_root)?;
     }
-    println!(
+    ui::info(format!(
         "{} {} {}",
         style::white_b("Created overlay directory"),
         style::cyan(&path),
         style::white_b(&format!("({})", format)),
-    );
+    ))
+    .ok();
 
     // Write the overlay descriptor
     // Only include the target if it differs from the inherited value
@@ -124,8 +126,12 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     };
     let content = build_descriptor(descriptor_target, format, &git_entries);
     if args.dry_run {
-        println!("{}", style::white_b("Descriptor content (dry-run):"));
-        println!("{}", content);
+        ui::info(format!(
+            "{}",
+            style::white_b("Descriptor content (dry-run):")
+        ))
+        .ok();
+        ui::info(&content).ok();
     } else {
         fs::write(&descriptor, &content)?;
     }
@@ -146,7 +152,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         overlay.add_files(&ctx, &files_to_absorb).await?;
     }
 
-    println!(
+    ui::info(format!(
         "{} {} {} {}{}",
         style::white_b("Overlay"),
         style::cyan(&path),
@@ -165,7 +171,8 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
                 },
             )
         },
-    );
+    ))
+    .ok();
 
     Ok(())
 }

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use clap::Args;
 
 use crate::cli::CLI;
@@ -5,7 +6,6 @@ use crate::overlays::Repository;
 use crate::ui;
 use crate::ui::style;
 use crate::utils::short_path;
-use anyhow::Result;
 
 #[derive(Args, Debug)]
 pub struct Params {

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -2,6 +2,7 @@ use clap::Args;
 
 use crate::cli::CLI;
 use crate::overlays::Repository;
+use crate::ui;
 use crate::ui::style;
 use crate::utils::short_path;
 use anyhow::Result;
@@ -21,26 +22,30 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     let repo = Repository::new(home);
     let overlay = repo.get(&args.name)?;
 
-    println!("{}", style::white_b(&overlay.name));
-    println!("  root:   {}", short_path(&overlay.root.to_string_lossy()));
-    println!("  target: {}", overlay.target);
+    ui::info(format!("{}", style::white_b(&overlay.name))).ok();
+    ui::info(format!(
+        "  root:   {}",
+        short_path(&overlay.root.to_string_lossy())
+    ))
+    .ok();
+    ui::info(format!("  target: {}", overlay.target)).ok();
     if let Some(desc) = &overlay.description {
-        println!("  desc:   {}", desc);
+        ui::info(format!("  desc:   {}", desc)).ok();
     }
     if let Some(uses) = &overlay.uses {
-        println!("  uses:   {}", uses.join(", "));
+        ui::info(format!("  uses:   {}", uses.join(", "))).ok();
     }
     if let Some(link_dirs) = &overlay.link_dirs {
-        println!("  link_dirs: {}", link_dirs.join(", "));
+        ui::info(format!("  link_dirs: {}", link_dirs.join(", "))).ok();
     }
     if let Some(git) = &overlay.git {
-        println!("  git repositories:");
+        ui::info("  git repositories:").ok();
         for (path, cfg) in git {
-            println!("    {}: {}", path, cfg.url);
+            ui::info(format!("    {}: {}", path, cfg.url)).ok();
         }
     }
     if overlay.install.is_some() {
-        println!("  install: configured");
+        ui::info("  install: configured").ok();
     }
     Ok(())
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -9,6 +9,7 @@ use crate::desired::DesiredTree;
 use crate::exec::Context;
 use crate::overlays::{Overlay, Repository};
 use crate::status::Report;
+use crate::ui;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -43,7 +44,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     };
 
     if overlays.is_empty() {
-        println!("No overlays found.");
+        ui::info("No overlays found.").ok();
         return Ok(());
     }
 
@@ -75,22 +76,23 @@ fn print_overlay_status(
     let desired = DesiredTree::build(&ctx, overlay)?;
     let report = Report::build(&desired)?;
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {}",
         emojis::PACKAGE,
         style::white_b("Overlay"),
         style::cyan(&overlay.name),
         style::white_b("->"),
         style::cyan(&short_path(&target.to_string_lossy())),
-    );
-    println!("  {}", report.counts());
+    ))
+    .ok();
+    ui::info(format!("  {}", report.counts())).ok();
 
     for entry_status in report.entries() {
         if cli.verbose || entry_status.status.needs_attention() {
-            println!("  {entry_status}");
+            ui::info(format!("  {entry_status}")).ok();
         }
     }
-    println!();
+    ui::info("").ok();
 
     Ok(())
 }

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -9,6 +9,7 @@ use crate::desired::DesiredTree;
 use crate::exec::Context;
 use crate::overlays::{Overlay, Repository};
 use crate::sync::{self, SyncOptions, SyncOutcome};
+use crate::ui;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -86,7 +87,7 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     };
 
     if overlays.is_empty() {
-        println!("No overlays found.");
+        ui::info("No overlays found.").ok();
         return Ok(());
     }
 
@@ -128,38 +129,40 @@ async fn sync_overlay(
 
     if outcomes.is_empty() {
         if cli.verbose {
-            println!(
+            ui::info(format!(
                 "{} {} {} {}",
                 emojis::PACKAGE,
                 style::white_b("Overlay"),
                 style::cyan(&overlay.name),
                 style::white("has no checkout-materialized root entry"),
-            );
+            ))
+            .ok();
         }
         return Ok(false);
     }
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {}",
         emojis::PACKAGE,
         style::white_b("Overlay"),
         style::cyan(&overlay.name),
         style::white_b("->"),
         style::cyan(&short_path(&target.to_string_lossy())),
-    );
+    ))
+    .ok();
     // Unconditional summary (mirrors `status::Report::counts()`), so a
     // plain `over sync` still reports e.g. "1 up to date" without needing
     // `--verbose` — only the noisier per-checkout lines below are gated.
-    println!("  {}", summarize(&outcomes));
+    ui::info(format!("  {}", summarize(&outcomes))).ok();
 
     let mut needs_attention = false;
     for outcome in &outcomes {
         needs_attention |= outcome.needs_attention();
         if cli.verbose || !matches!(outcome, SyncOutcome::UpToDate { .. }) {
-            println!("  {outcome}");
+            ui::info(format!("  {outcome}")).ok();
         }
     }
-    println!();
+    ui::info("").ok();
 
     Ok(needs_attention)
 }

--- a/src/cli/unapply.rs
+++ b/src/cli/unapply.rs
@@ -9,6 +9,7 @@ use crate::cli::CLI;
 use crate::desired::DesiredTree;
 use crate::exec::Context;
 use crate::overlays::Repository;
+use crate::ui;
 use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 use crate::unapply::{Outcome, Report};
@@ -81,22 +82,23 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     let desired = DesiredTree::build_own(&ctx, &overlay)?;
     let report = Report::build(&desired)?;
 
-    println!(
+    ui::info(format!(
         "{} {} {} {} {}",
         emojis::PACKAGE,
         style::white_b("Overlay"),
         style::cyan(&overlay.name),
         style::white_b("->"),
         style::cyan(&short_path(&target.to_string_lossy())),
-    );
-    println!("  {}", report.counts());
+    ))
+    .ok();
+    ui::info(format!("  {}", report.counts())).ok();
 
     for entry_outcome in report.entries() {
         if cli.verbose || !matches!(entry_outcome.outcome, Outcome::AlreadyAbsent) {
-            println!("  {entry_outcome}");
+            ui::info(format!("  {entry_outcome}")).ok();
         }
     }
-    println!();
+    ui::info("").ok();
 
     report.execute(ctx).await?;
 

--- a/src/desired/entry.rs
+++ b/src/desired/entry.rs
@@ -6,10 +6,12 @@ use crate::actions::symlink::LinkType;
 /// What kind of filesystem node a [`DesiredEntry`] should be, independent of
 /// *how* it gets there (see [`MaterializationIntent`]).
 ///
-/// `File` is reserved for #61 (content-templated files): today's
-/// symlink-first apply (ADR-006, ADR-010) never writes real file content, so
-/// [`super::DesiredTree::build`] never produces it — only `Directory` and
-/// `Symlink` are reachable for now.
+/// `File` is produced by [`MaterializationIntent::PartialFile`] (#66):
+/// managed-block content written into an existing file. Rendered/templated
+/// whole-file content (#61) is a separate, still-unimplemented concern —
+/// symlink-first apply (ADR-006, ADR-010) otherwise never writes real file
+/// content, so today only `Directory`, `Symlink`, and the `PartialFile` case
+/// of `File` are reachable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntryKind {
     Directory,

--- a/src/desired/mod.rs
+++ b/src/desired/mod.rs
@@ -6,8 +6,9 @@
 //! apply` (#13) builds a [`crate::plan::Plan`] from a `DesiredTree` and
 //! executes it via a registered [`crate::materialize::Materializer`]
 //! (#108) — git repository checkouts remain a separate,
-//! `actions::git::clone_repositories` step, orthogonal to the plan, until
-//! #110 gives them a real materializer backend:
+//! `actions::git::clone_repositories` step, orthogonal to the plan, even
+//! though #110's `CheckoutMaterializer` classifies them like any other
+//! intent:
 //!
 //! ```text
 //! root configuration

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -33,7 +33,7 @@ use std::fmt;
 use std::fs;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 
 use crate::actions::partial::{self, BlockState};
 use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
@@ -230,7 +230,8 @@ fn classify_conflict(entry: &DesiredEntry, current: &ActualState) -> Result<Chan
         // diff just the block's content, not the whole file — the rest of
         // the target is never `over`'s concern.
         (MaterializationIntent::PartialFile { content, marker }, ActualState::File) => {
-            let current_text = fs::read_to_string(&entry.target)?;
+            let current_text = fs::read_to_string(&entry.target)
+                .with_context(|| format!("failed to read {}", entry.target.display()))?;
             let existing_block = match partial::find_block(&current_text, marker) {
                 BlockState::Found(x) => x.to_string(),
                 // Absent/malformed: nothing block-shaped to diff against —
@@ -256,8 +257,10 @@ fn classify_conflict(entry: &DesiredEntry, current: &ActualState) -> Result<Chan
 /// their content, falling back to a binary marker if either side isn't
 /// valid UTF-8 (mirrors git's own "binary files differ").
 fn content_diff_files(actual_path: &Path, desired_path: &Path) -> Result<ContentDiff> {
-    let old = fs::read(actual_path)?;
-    let new = fs::read(desired_path)?;
+    let old = fs::read(actual_path)
+        .with_context(|| format!("failed to read {}", actual_path.display()))?;
+    let new = fs::read(desired_path)
+        .with_context(|| format!("failed to read {}", desired_path.display()))?;
     Ok(match (String::from_utf8(old), String::from_utf8(new)) {
         (Ok(old), Ok(new)) => ContentDiff::from_texts(&old, &new),
         _ => ContentDiff::binary(),
@@ -393,6 +396,75 @@ mod tests {
         assert!(report.needs_attention());
     }
 
+    #[rstest]
+    #[cfg(unix)]
+    fn existing_file_conflict_reports_context_when_actual_is_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir
+            .child("file.txt")
+            .write_str("desired content\n")
+            .unwrap();
+        let actual = td.path().join("file.txt");
+        fs::write(&actual, "actual content\n").unwrap();
+        fs::set_permissions(&actual, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let result = Report::build(&desired);
+
+        fs::set_permissions(&actual, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to read"));
+    }
+
+    #[rstest]
+    #[cfg(unix)]
+    fn existing_file_conflict_reports_context_when_desired_is_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        let desired_file = overlay_dir.child("file.txt");
+        desired_file.write_str("desired content\n").unwrap();
+        fs::set_permissions(desired_file.path(), fs::Permissions::from_mode(0o000)).unwrap();
+        fs::write(td.path().join("file.txt"), "actual content\n").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let ctx = Context::builder()
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay.clone())
+            .build();
+
+        let desired = DesiredTree::build(&ctx, &overlay).unwrap();
+        let result = Report::build(&desired);
+
+        fs::set_permissions(desired_file.path(), fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to read"));
+    }
+
     #[test]
     fn drifted_partial_block_produces_block_level_diff() {
         let td = TempDir::new().unwrap();
@@ -424,6 +496,38 @@ mod tests {
             }
             other => panic!("expected Modified, got {other:?}"),
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn drifted_partial_block_reports_context_when_target_is_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(
+            &target,
+            "before\n# >>> over: m >>>\nhand-edited\n# <<< over: m <<<\nafter\n",
+        )
+        .unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o000)).unwrap();
+        let entry = DesiredEntry {
+            target: target.clone(),
+            provenance: crate::desired::Provenance::PartialSidecar {
+                overlay: "ov".to_string(),
+                config: std::path::PathBuf::from("/repo/ov/aliases.partial.toml"),
+            },
+            intent: MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "m".to_string(),
+            },
+        };
+        let result = classify_conflict(&entry, &ActualState::File);
+
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to read"));
     }
 
     #[test]

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -77,9 +77,9 @@ pub struct DiffEntry {
 
 impl DiffEntry {
     /// Whether this entry has anything worth showing — used by the CLI
-    /// to decide what to print without `--verbose`, same convention as
-    /// `status::Status::needs_attention`.
-    pub fn has_diff(&self) -> bool {
+    /// to decide what to print without `--verbose`, same name and
+    /// convention as `status::Status::needs_attention`.
+    pub fn needs_attention(&self) -> bool {
         !matches!(self.change, Change::Unchanged)
     }
 }
@@ -176,9 +176,11 @@ impl Report {
         self.entries.is_empty()
     }
 
-    /// Whether anything in this report has a diff worth showing.
-    pub fn has_changes(&self) -> bool {
-        self.entries.iter().any(DiffEntry::has_diff)
+    /// Whether anything in this report needs attention (has a diff worth
+    /// showing) — same name and convention as `status::Report` and
+    /// `unapply::Report`.
+    pub fn needs_attention(&self) -> bool {
+        self.entries.iter().any(DiffEntry::needs_attention)
     }
 }
 
@@ -311,7 +313,7 @@ mod tests {
 
         assert_eq!(report.entries().len(), 1);
         assert!(matches!(report.entries()[0].change, Change::Missing));
-        assert!(report.has_changes());
+        assert!(report.needs_attention());
     }
 
     #[tokio::test]
@@ -346,8 +348,8 @@ mod tests {
             .find(|e| e.entry.target == td.path().join("file.txt"))
             .unwrap();
         assert!(matches!(file_entry.change, Change::Unchanged));
-        assert!(!file_entry.has_diff());
-        assert!(!report.has_changes());
+        assert!(!file_entry.needs_attention());
+        assert!(!report.needs_attention());
     }
 
     #[rstest]
@@ -388,7 +390,7 @@ mod tests {
             }
             other => panic!("expected Modified, got {other:?}"),
         }
-        assert!(report.has_changes());
+        assert!(report.needs_attention());
     }
 
     #[test]
@@ -613,7 +615,7 @@ mod tests {
     fn empty_desired_tree_produces_empty_report() {
         let report = Report::build(&DesiredTree::default()).unwrap();
         assert!(report.is_empty());
-        assert!(!report.has_changes());
+        assert!(!report.needs_attention());
     }
 
     #[rstest]

--- a/src/exec/action.rs
+++ b/src/exec/action.rs
@@ -9,12 +9,3 @@ use super::context::Ctx;
 pub trait Action: Display {
     async fn execute(&self, ctx: Ctx) -> Result<()>;
 }
-
-// pub struct Progress {
-//     percent: u8,
-// }
-
-// #[async_trait]
-// pub trait WithProgress {
-//     fn listen(&self) -> Receiver<Progress>;
-// }

--- a/src/exec/context.rs
+++ b/src/exec/context.rs
@@ -305,6 +305,21 @@ impl Context {
     }
 }
 
+/// Shared handle to a [`Context`], cheap to clone (an `Arc` bump) and safe to
+/// pass across `.await` points.
+///
+/// Parameter-shape convention across the codebase (all three are
+/// intentional, not interchangeable by accident):
+/// - `ctx: Ctx` (owned) — trait methods (`Action::execute`,
+///   `Materializer::materialize`) and anything that must move the context
+///   into a spawned/boxed future or store it past the call. Cheap to
+///   produce at the call site via `ctx.clone()`.
+/// - `ctx: &Ctx` — thin, non-owning wrappers that may need to clone once to
+///   delegate into an owning callee (e.g. `Overlay::add_file` borrowing here
+///   and cloning once before calling `actions::fs::add_file`).
+/// - `ctx: &Context` — pure readers that only inspect fields (flags, `root`,
+///   …) and never need `Arc` semantics; `&Ctx` derefs to `&Context` at call
+///   sites, so this is the most permissive signature for such helpers.
 pub type Ctx = Arc<Context>;
 
 #[cfg(test)]

--- a/src/exec/context.rs
+++ b/src/exec/context.rs
@@ -328,6 +328,7 @@ mod tests {
     use assert_fs::TempDir;
     use assert_fs::prelude::*;
     use indicatif::{MultiProgress, ProgressBar};
+    use rstest::rstest;
 
     fn dummy_repo() -> Repository {
         #[cfg(unix)]
@@ -367,50 +368,50 @@ mod tests {
         assert_eq!(ctx.machine.arch, std::env::consts::ARCH);
     }
 
+    /// Every flag `Context::builder()` sets ends up exactly as requested,
+    /// independent of which other flags are also set — whether all five are
+    /// requested (mirrors the former `builder_sets_flags`) or only some
+    /// (mirrors the former `builder_partial_flags`); unset flags must stay
+    /// `false` rather than leaking a previous case's value.
+    #[rstest]
+    #[case(true, true, true, true, true)]
+    #[case(true, false, true, false, false)]
+    fn builder_sets_requested_flags(
+        #[case] dry_run: bool,
+        #[case] debug: bool,
+        #[case] verbose: bool,
+        #[case] force: bool,
+        #[case] no_prompt: bool,
+    ) {
+        let ctx = Context::builder()
+            .dry_run(dry_run)
+            .debug(debug)
+            .verbose(verbose)
+            .force(force)
+            .no_prompt(no_prompt)
+            .build();
+
+        assert_eq!(ctx.dry_run, dry_run);
+        assert_eq!(ctx.debug, debug);
+        assert_eq!(ctx.verbose, verbose);
+        assert_eq!(ctx.force, force);
+        assert_eq!(ctx.no_prompt, no_prompt);
+    }
+
     #[test]
-    fn builder_sets_flags() {
+    fn builder_sets_root_and_repository() {
         #[cfg(unix)]
         let root_path = PathBuf::from("/home/test");
         #[cfg(windows)]
         let root_path = PathBuf::from("C:\\home\\test");
 
         let ctx = Context::builder()
-            .dry_run(true)
-            .debug(true)
-            .verbose(true)
-            .force(true)
-            .no_prompt(true)
             .root(root_path.clone())
             .repository(dummy_repo())
             .build();
 
-        assert!(ctx.dry_run);
-        assert!(ctx.debug);
-        assert!(ctx.verbose);
-        assert!(ctx.force);
-        assert!(ctx.no_prompt);
         assert_eq!(ctx.root, root_path);
         assert_eq!(ctx.repository.root, dummy_repo().root);
-    }
-
-    #[test]
-    fn builder_partial_flags() {
-        #[cfg(unix)]
-        let root_path = PathBuf::from("/tmp");
-        #[cfg(windows)]
-        let root_path = PathBuf::from("C:\\tmp");
-
-        let ctx = Context::builder()
-            .dry_run(true)
-            .verbose(true)
-            .root(root_path)
-            .build();
-
-        assert!(ctx.dry_run);
-        assert!(!ctx.debug);
-        assert!(ctx.verbose);
-        assert!(!ctx.force);
-        assert!(!ctx.no_prompt);
     }
 
     #[test]

--- a/src/materialize/partial.rs
+++ b/src/materialize/partial.rs
@@ -10,7 +10,7 @@
 
 use std::fs;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 
 use crate::actions::partial::{BlockState, EnsurePartialBlock, find_block};
@@ -43,7 +43,8 @@ impl Materializer for PartialFileMaterializer {
         match actual::inspect(&entry.target)? {
             ActualState::Missing => Ok(Operation::Create),
             ActualState::File => {
-                let current = fs::read_to_string(&entry.target)?;
+                let current = fs::read_to_string(&entry.target)
+                    .with_context(|| format!("failed to read {}", entry.target.display()))?;
                 Ok(match find_block(&current, marker) {
                     // No block yet: inserting one is purely additive, same
                     // "nothing here yet" spirit as `Operation::Create`.
@@ -122,6 +123,26 @@ mod tests {
         target.write_str("unrelated content\n").unwrap();
         let e = entry(target.path().to_path_buf(), "alias x=y", "m");
         assert!(matches!(m.classify(&e).unwrap(), Operation::Create));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn classify_reports_context_when_target_is_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target.write_str("unrelated content\n").unwrap();
+        fs::set_permissions(target.path(), fs::Permissions::from_mode(0o000)).unwrap();
+
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        let result = m.classify(&e);
+
+        fs::set_permissions(target.path(), fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to read"));
     }
 
     #[test]

--- a/src/materialize/symlink.rs
+++ b/src/materialize/symlink.rs
@@ -14,8 +14,10 @@ use super::Materializer;
 /// symlinks (file- or directory-level), dispatched to the existing
 /// `actions::fs`/`actions::symlink` `Action` impls. Owns every
 /// [`MaterializationIntent`] except
-/// [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout),
-/// which #110 will give its own backend.
+/// [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout)
+/// (owned by `CheckoutMaterializer`, #110) and
+/// [`MaterializationIntent::PartialFile`](crate::desired::MaterializationIntent::PartialFile)
+/// (owned by `PartialFileMaterializer`, #66).
 ///
 /// This is a pure move of the logic that used to live directly in
 /// `plan::reconcile` (`classify`/`build_action`) — no behavior change.

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -272,14 +272,14 @@ impl Overlay {
                 }
             }
 
-            // Git checkouts stay outside the plan (no registered
-            // Materializer claims MaterializationIntent::Checkout yet;
-            // #110 owns adding a real checkout/worktree backend);
-            // everything else — the overlay's own directory, files, and
-            // `.link.*` sidecars — goes through a Plan built from this
-            // overlay's own DesiredTree (no `uses` recursion here: that's
-            // handled above, one overlay at a time, so each dependency
-            // keeps its own banner/cycle-check).
+            // Git checkouts stay outside the plan (cloning is presence-only
+            // and runs before the Plan even though #110's
+            // CheckoutMaterializer classifies MaterializationIntent::Checkout
+            // like any other intent); everything else — the overlay's own
+            // directory, files, and `.link.*` sidecars — goes through a Plan
+            // built from this overlay's own DesiredTree (no `uses`
+            // recursion here: that's handled above, one overlay at a time,
+            // so each dependency keeps its own banner/cycle-check).
             actions::git::clone_repositories(ctx.clone(), self, &target).await?;
 
             let ctx_with_target =

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -14,6 +14,7 @@ use crate::actions::install::InstallConfig;
 use crate::desired::DesiredTree;
 use crate::exec::{self, Ctx};
 use crate::plan::Plan;
+use crate::ui;
 use crate::ui::{emojis, style};
 
 use super::{DEFAULT_TARGET, Repository};
@@ -245,14 +246,15 @@ impl Overlay {
             stack.push(self.name.clone());
 
             let target = self.resolve_target(ctx)?;
-            println!(
+            ui::info(format!(
                 "{} {} {} {} {}",
                 emojis::PACKAGE,
                 style::white_b("Applying overlay"),
                 style::cyan(&self.name),
                 style::white_b("to"),
                 style::cyan(&target.to_string_lossy()),
-            );
+            ))
+            .ok();
             if let Some(uses) = &self.uses {
                 if ctx.no_uses {
                     tracing::debug!(overlay = %self.name, "skipping uses (--no-uses)");
@@ -287,14 +289,14 @@ impl Overlay {
             let desired = DesiredTree::build_own(&ctx_with_target, self)?;
             let plan = Plan::build(&desired)?;
             if ctx.verbose || ctx.dry_run {
-                println!("{plan}");
+                ui::info(format!("{plan}")).ok();
             }
             plan.execute(ctx_with_target).await?;
 
             stack.pop();
             visited.insert(self.name.clone());
 
-            println!(
+            ui::info(format!(
                 "{} {} {} {} {} {}",
                 emojis::SPARKLE,
                 style::white_b("Applied overlay"),
@@ -302,7 +304,8 @@ impl Overlay {
                 style::white_b("to"),
                 style::cyan(&target.to_string_lossy()),
                 style::white_b("with success"),
-            );
+            ))
+            .ok();
 
             Ok(())
         })

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -69,7 +69,7 @@ impl Repository {
         Ok(overlays)
     }
 
-    /// Get a repository by its name/relative path
+    /// Get an overlay by its name/relative path
     pub fn get(&self, name: &str) -> Result<Overlay> {
         let root = self.root.join(name);
         if !root.exists() {

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -5,7 +5,7 @@ use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
-use anyhow::{Context as AnyhowContext, Result};
+use anyhow::{Context as _, Result};
 
 use super::overlay::Overlay;
 use super::{BASENAME, Format, GLOB_PATTERN};

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -17,11 +17,11 @@ pub struct Repository {
     pub root: PathBuf,
 }
 
-// impl std::fmt::Display for Repository {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         std::fmt::Display::fmt(&self.root.display(), f)
-//     }
-// }
+impl std::fmt::Display for Repository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.root.display(), f)
+    }
+}
 
 impl Repository {
     pub fn new(root: PathBuf) -> Self {
@@ -110,6 +110,17 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn display_shows_the_root_path() {
+        #[cfg(unix)]
+        let root = PathBuf::from("/some/dotfiles");
+        #[cfg(windows)]
+        let root = PathBuf::from("C:\\some\\dotfiles");
+
+        let repo = Repository::new(root.clone());
+        assert_eq!(repo.to_string(), root.display().to_string());
+    }
 
     #[test]
     fn preferred_format_returns_toml_from_toml_config() {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -39,13 +39,11 @@
 //!
 //! ## What's deliberately *not* here
 //!
-//! - A real Git-checkout backend: [`MaterializationIntent::Checkout`]
-//!   entries have no registered [`crate::materialize::Materializer`] yet,
-//!   so they're classified as [`Operation::Deferred`] and never executed —
-//!   #110 registers a `CheckoutMaterializer` to change that, without this
-//!   module changing. `Overlay::apply` still clones git repositories
-//!   through the existing, separate `actions::git::clone_repositories`,
-//!   entirely orthogonal to this module.
+//! - Presence of the git repository itself: #110's `CheckoutMaterializer`
+//!   owns classifying [`MaterializationIntent::Checkout`] entries like every
+//!   other intent, but `Overlay::apply` still clones git repositories
+//!   through the existing, separate `actions::git::clone_repositories`
+//!   *before* building the `Plan`, entirely orthogonal to this module.
 //! - Materialization-rule migrations (symlink ↔ checkout, file-level ↔
 //!   directory-level symlink) and `defaults:`/`rules:` configuration —
 //!   #113. [`Operation`] is designed to grow variants for this without a

--- a/src/plan/reconcile.rs
+++ b/src/plan/reconcile.rs
@@ -33,9 +33,9 @@ pub struct Plan {
 impl Plan {
     /// Classify every entry in `desired` against current state, asking the
     /// registered [`Materializer`](crate::materialize::Materializer) that
-    /// owns each entry's intent. An intent no backend claims yet (today,
-    /// only [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout))
-    /// classifies as [`Operation::Deferred`].
+    /// owns each entry's intent. Since #110 every intent has a registered
+    /// backend, so [`Operation::Deferred`] is unreachable in practice — kept
+    /// as a defensive fallback if that ever stops being true.
     pub fn build(desired: &DesiredTree) -> Result<Self> {
         let registry = MaterializerRegistry::default();
         let mut steps = Vec::with_capacity(desired.len());
@@ -74,8 +74,8 @@ impl Plan {
     /// deterministic order (`DesiredTree` sorts entries by target path, so
     /// a directory's entry always precedes anything nested under it).
     /// `Noop`/`Deferred` steps are skipped — the former because there's
-    /// nothing to do, the latter because no backend claims that intent yet
-    /// (today, only [`MaterializationIntent::Checkout`](crate::desired::MaterializationIntent::Checkout) — #110).
+    /// nothing to do, the latter because it's unreachable in practice since
+    /// #110 (kept as a defensive fallback).
     pub async fn execute(&self, ctx: Ctx) -> Result<()> {
         let has_actionable = self
             .steps

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -29,10 +29,11 @@ pub enum Operation {
     /// Target exists and does not match the desired intent.
     Conflict { current: ActualState },
     /// No registered [`crate::materialize::Materializer`] claims this
-    /// entry's intent yet (today, only
-    /// [`MaterializationIntent::Checkout`] — #110 owns turning this into a
-    /// real checkout/worktree). Carried so a plan preview can still report
-    /// on it; [`super::Plan::execute`] never acts on it.
+    /// entry's intent. Unreachable in practice since #110 gave every intent
+    /// (including [`MaterializationIntent::Checkout`]) a real backend, but
+    /// kept as a defensive fallback so a plan preview still reports
+    /// something sensible instead of panicking; [`super::Plan::execute`]
+    /// never acts on it.
     Deferred,
 }
 

--- a/src/status/git.rs
+++ b/src/status/git.rs
@@ -4,10 +4,11 @@
 //! `repo.graph_ahead_behind()`) rather than reimplementing clean/dirty/
 //! ahead/behind/diverged detection.
 //!
-//! No [`crate::materialize::Materializer`] claims `Checkout` yet (#110 owns
-//! that), so this only ever *reads* whatever `actions::git::clone_repositories`
-//! (called directly by `Overlay::apply`, outside the `Plan`/`Materializer`
-//! model) already put on disk.
+//! `Checkout` has a registered [`crate::materialize::Materializer`]
+//! (`CheckoutMaterializer`, #110) like every other intent, but this module
+//! only ever *reads* whatever `actions::git::clone_repositories` (called
+//! directly by `Overlay::apply`, before the `Plan`/`Materializer` pipeline
+//! runs) already put on disk — content-level sync stays `over sync`'s job.
 
 use std::path::Path;
 

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -47,7 +47,7 @@ pub enum Status {
 }
 
 impl Status {
-    /// Whether this status needs attention — used by [`Report::has_issues`]
+    /// Whether this status needs attention — used by [`Report::needs_attention`]
     /// and by the CLI to decide what to show without `--verbose`.
     pub fn needs_attention(&self) -> bool {
         !matches!(self, Status::Applied)
@@ -225,7 +225,7 @@ impl Report {
     /// `Applied`). Informational only — `over status` never fails the
     /// process just because entries need attention, mirroring `git
     /// status`.
-    pub fn has_issues(&self) -> bool {
+    pub fn needs_attention(&self) -> bool {
         self.entries.iter().any(|e| e.status.needs_attention())
     }
 }
@@ -293,7 +293,7 @@ mod tests {
         assert_eq!(report.entries().len(), 1);
         assert_eq!(report.entries()[0].status, Status::Missing);
         assert_eq!(report.counts().missing, 1);
-        assert!(report.has_issues());
+        assert!(report.needs_attention());
     }
 
     #[tokio::test]
@@ -329,7 +329,7 @@ mod tests {
             .unwrap();
         assert_eq!(file_status.status, Status::Applied);
         assert_eq!(report.counts().missing, 0);
-        assert!(!report.has_issues());
+        assert!(!report.needs_attention());
     }
 
     #[rstest]
@@ -359,7 +359,7 @@ mod tests {
             .find(|e| e.entry.target == td.path().join("file.txt"))
             .unwrap();
         assert_eq!(file_status.status, Status::Conflict);
-        assert!(report.has_issues());
+        assert!(report.needs_attention());
     }
 
     #[test]
@@ -381,7 +381,7 @@ mod tests {
     fn empty_desired_tree_produces_empty_report() {
         let report = Report::build(&DesiredTree::default()).unwrap();
         assert!(report.is_empty());
-        assert!(!report.has_issues());
+        assert!(!report.needs_attention());
     }
 
     #[test]
@@ -496,7 +496,7 @@ mod tests {
                 diverged: 1,
             }
         );
-        assert!(report.has_issues());
+        assert!(report.needs_attention());
     }
 
     #[test]

--- a/src/ui/log.rs
+++ b/src/ui/log.rs
@@ -8,6 +8,15 @@ pub fn info(msg: impl AsRef<str>) -> Result<()> {
     Ok(())
 }
 
+/// Write a warning-level line to stderr — the `eprintln!` equivalent of
+/// [`info`], for user-facing warnings that aren't a full error chain (see
+/// [`display_error`] for that).
+pub fn warn(msg: impl AsRef<str>) -> Result<()> {
+    let term = Term::stderr();
+    term.write_line(msg.as_ref())?;
+    Ok(())
+}
+
 /// Initialize the tracing subscriber with the given verbosity level.
 ///
 /// - Default (no flags): only warnings and errors

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,4 +3,4 @@ pub mod style;
 
 pub mod log;
 
-pub use log::{display_error, info, init_tracing};
+pub use log::{display_error, info, init_tracing, warn};

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -1,9 +1,9 @@
 use std::fmt;
+use std::sync::LazyLock;
 
 use clap::builder::styling;
 use console::{Style, StyledObject, style};
 use dialoguer::theme::Theme;
-use std::sync::LazyLock;
 
 pub static TICK_CHARS_BRAILLE_4_6_DOWN: LazyLock<String> = LazyLock::new(|| String::from("⠶⢲⣰⣤⣆⡖"));
 pub static TICK_CHARS_BRAILLE_4_6_UP: LazyLock<String> = LazyLock::new(|| String::from("⠛⠹⠼⠶⠧⠏"));

--- a/src/unapply/mod.rs
+++ b/src/unapply/mod.rs
@@ -38,7 +38,7 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use tokio::task::spawn_blocking;
 
 use crate::actions::partial::{self, BlockState};
@@ -363,9 +363,11 @@ async fn remove_partial_block_if_unchanged(
             BlockState::Found(existing) if existing == expected => {
                 let stripped = partial::remove_block(&current, &marker);
                 if stripped.trim().is_empty() {
-                    fs::remove_file(&target)?;
+                    fs::remove_file(&target)
+                        .with_context(|| format!("failed to remove {}", target.display()))?;
                 } else {
-                    fs::write(&target, stripped)?;
+                    fs::write(&target, stripped)
+                        .with_context(|| format!("failed to write {}", target.display()))?;
                 }
                 Ok(())
             }
@@ -666,6 +668,65 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn remove_partial_block_if_unchanged_reports_context_when_removal_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Stripping the block leaves nothing behind, so the file itself
+        // must be removed — but its read-only parent directory rejects
+        // the removal, exercising the `.with_context` wrapping around
+        // `fs::remove_file`.
+        let td = TempDir::new().unwrap();
+        let dir = td.path().join("readonly");
+        fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("file.txt");
+        fs::write(&target, "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n").unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = remove_partial_block_if_unchanged(
+            target.clone(),
+            "m".to_string(),
+            "alias x=y".to_string(),
+        )
+        .await;
+
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to remove"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn remove_partial_block_if_unchanged_reports_context_when_write_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Stripping the block leaves surrounding content behind, so the
+        // file must be rewritten — but it's read-only, exercising the
+        // `.with_context` wrapping around `fs::write`.
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        fs::write(
+            &target,
+            "before\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\nafter\n",
+        )
+        .unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o444)).unwrap();
+
+        let result = remove_partial_block_if_unchanged(
+            target.clone(),
+            "m".to_string(),
+            "alias x=y".to_string(),
+        )
+        .await;
+
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("failed to write"));
     }
 
     #[tokio::test]

--- a/src/xdg/state.rs
+++ b/src/xdg/state.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 // us advisory `flock`/`LockFileEx` locking natively, so no extra dependency
 // (e.g. `fs4`) is needed here.
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::task::spawn_blocking;


### PR DESCRIPTION
A full-project consistency review (doc-to-doc, doc-to-code, code-to-code) surfaced 22 inconsistencies, all fixed here, one per commit:

- **Docs vs docs**: README's command table and AGENTS.md's module layout were missing `diff`/`sync`/`unapply`/`status`/`xdg` (added after #119-#123 but never back-documented); ADR-002's "no built-in diffing/sync" aside predated ADR-013/014 and read as contradicted by them.
- **Docs vs code**: `over status`'s usage synopsis was missing its `[NAME]`/`--root`/`--no-uses` arguments entirely; `over apply`'s description had the install/clone/symlink order backwards; several rustdoc comments across `plan`, `materialize`, `desired`, `overlays`, and `status` still described `MaterializationIntent::Checkout` as unimplemented pending #110, even though `CheckoutMaterializer` has long since shipped; `EntryKind`'s doc comment falsely claimed `File` was unreachable, contradicted by its own `PartialFile` variant a few lines down.
- **Code vs code**: `status`/`diff`/`unapply`'s sibling `Report` types named the same "surface this?" predicate three different ways (`has_issues`/`has_changes`/`has_diff`) — unified to `needs_attention`; a local `config` submodule in `actions/git` shadowed the external `config` crate; several `fs::read`/`fs::write` calls in materialize/diff/unapply paths were missing `.with_context()`, unlike their sibling config-loading code; `ui::info()` was defined but had exactly one real caller while ~90 `println!`/`eprintln!` call sites duplicated the same pattern — added `ui::warn()` and routed everything through both; a handful of import-ordering, `anyhow::Context` aliasing, and dead-code cleanups round it out.

One item (the `Ctx`/`&Ctx`/`&Context` parameter-shape finding) turned out, on closer inspection, to already be a deliberate, justified convention rather than drift — documented it in place instead of a risky mechanical rename.

No user-facing behavior changes; `mise run ci` is green.
