### PR TITLE
feat(overlays): materialization rules with defaults and path/subtree overrides

### DIFF
--- a/docs/adr/017-materialization-rules-generalize-link-dirs.md
+++ b/docs/adr/017-materialization-rules-generalize-link-dirs.md
@@ -1,0 +1,79 @@
+# ADR-017: Materialization rules generalize `link_dirs` into path/subtree overrides, amending ADR-006
+
+**Status:** accepted
+
+## Context
+
+ADR-006 established symlink-first apply with two escape hatches:
+`link_dirs` (a directory symlinked as a unit instead of walked file-by-file)
+and `.link.*` sidecars (arbitrary extra links). `link_dirs` is a single flat
+list of glob patterns, always resolving to the same directory-level symlink
+outcome, with no way to declare a repository-wide default independent of any
+particular pattern, and no way to override that default for a specific
+subtree without also going back to enumerating `link_dirs` globs.
+
+#113 asks for a general `defaults`/`rules` model: a default materialization
+for an overlay, plus more specific path/subtree overrides, resolved
+hierarchically. `checkout` materialization (`overlay.git`) and rule-driven
+migration between materializations are both out of scope here — see #129 for
+migration and #130 for legacy detection.
+
+## Decision
+
+Add `defaults: { materialization }` and `rules: [{ path, materialization }]`
+to the overlay descriptor schema (`src/overlays/rules.rs`:
+`MaterializationKind`, `Defaults`, `MaterializationRule`). `materialization`
+is one of `symlink` (recurse and symlink files individually — today's
+implicit default) or `symlink-directory` (symlink the directory as a single
+unit). `checkout` is deliberately not a valid value: that intent stays
+driven by `overlay.git`, unrelated to this resolution.
+
+Resolution (`rules::resolve`), for a directory at a given relative path:
+
+1. the most specific matching `rules` entry (a literal path always outranks
+   a glob; longer patterns are considered more specific within the same
+   tier — see `MaterializationRule::specificity`);
+2. `defaults.materialization`;
+3. the hardcoded fallback, `symlink`.
+
+Both fields are inherited through the *same* cascading descriptor chain
+ADR-002 already established (root `over.toml` down to the overlay's own
+directory) — no separate root-only configuration mechanism was introduced.
+A repository root `over.toml` setting `defaults.materialization` becomes the
+baseline for every overlay; any overlay along the chain can override it
+entirely (config-rs replaces a scalar/list value wholesale at the nearest
+level that defines it — the same "closest wins entirely, not merged
+element-wise" semantics `exclude`, `link_dirs`, `git`, and `uses` already
+have).
+
+`link_dirs` is kept, unchanged in the config file, but reimplemented as
+sugar: `Overlay::effective_rules` (`rules::effective_rules`) translates each
+`link_dirs` glob into an equivalent `MaterializationRule` with
+`materialization: symlink-directory`, placed *before* explicit `rules`
+entries so an explicit rule wins a specificity tie against a legacy
+`link_dirs` pattern for the same path. `Overlay::is_link_dir` — the two
+existing call sites (`desired::tree::walk_overlay_tree`,
+`actions::fs::add_dir`) — now delegates to `rules::resolve`, so both
+mechanisms flow through one resolution path.
+
+## Consequences
+
+A single new mechanism replaces what would otherwise be two independent
+special cases (`link_dirs`, and any future default-materialization field).
+`over lint` gains matching checks for `rules` (invalid globs, empty list,
+duplicate paths, paths matching nothing on disk), mirroring the existing
+`link_dirs` checks.
+
+Because `rules`/`defaults` — like every other overlay field — are replaced
+wholesale by the nearest config level that defines them rather than merged
+element-wise across levels, an overlay that defines its own `rules` list
+loses the repository root's `rules` entries entirely unless it repeats them.
+This is consistent with the rest of the schema, but is a real limitation
+worth documenting for anyone expecting per-level list merging.
+
+Specificity ranking (`MaterializationRule::specificity`) is a heuristic —
+literal-beats-glob, then longer-pattern-wins — not a full partial order over
+arbitrary glob pairs. It resolves the case #113 asks for (a specific path
+overriding a broader glob) but can still surprise for two overlapping globs
+of unrelated shapes; `over lint`'s duplicate-path check only catches exact
+string duplicates, not general shadowing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ by editing the old one. The history is the value.
 | [014](014-bidirectional-checkout-synchronization.md) | Bidirectional checkout synchronization is `over sync`, scoped to an overlay's root git entry |
 | [015](015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md) | `unapply` reuses `Plan`'s classification and only ever removes safely reversible state |
 | [016](016-partial-file-managed-blocks.md) | Partial files are managed blocks injected via a sidecar, not a stem-plus-sidecar pair |
+| [017](017-materialization-rules-generalize-link-dirs.md) | Materialization rules generalize `link_dirs` into path/subtree overrides, amending ADR-006 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,48 @@ This preference only governs what `over new` **writes**. Reading an overlay
 tolerates any of `.toml`/`.yaml`/`.yml` regardless of this setting — see
 [ADR-003](adr/003-overlay-descriptors-tolerate-any-format-on-read.md).
 
+## Materialization Rules
+
+By default, every file in an overlay is symlinked individually and every
+directory is recursed into. Two fields, available both in the repository
+root config and in any overlay's own descriptor (they inherit through the
+same cascading chain as every other field — see
+[ADR-002](adr/002-overlay-is-a-directory-not-a-repository.md)), let you
+override this per overlay or per subtree:
+
+```toml
+[defaults]
+materialization = "symlink"          # symlink | symlink-directory
+
+[[rules]]
+path = "some/directory"               # glob or literal, relative to the overlay root
+materialization = "symlink-directory"
+```
+
+- `defaults.materialization` sets the materialization applied to every
+  directory with no more specific `rules` match. `symlink` (the default)
+  recurses into the directory and symlinks each file individually.
+  `symlink-directory` symlinks the directory as a single unit — its
+  contents are not separately enumerated or tracked.
+- `rules` is a list of path/subtree overrides. `path` is a glob pattern (or
+  a literal path) relative to the overlay root. When more than one rule
+  matches the same path, the most specific one wins: a literal path always
+  outranks a glob, and among glob patterns the longer one wins.
+- A repository root `over.toml` setting `defaults`/`rules` becomes the
+  baseline for every overlay; any overlay along the cascading chain can
+  override either field entirely for its own tree (the nearest
+  descriptor that defines the field wins, same as `exclude`/`link_dirs`/
+  `git`/`uses`).
+- A file added to a source subtree still governed by a `symlink`
+  (file-level) rule is automatically picked up the next time `over`
+  inspects the overlay — there is no separate step to "add" it to the
+  rule.
+
+`link_dirs` (a list of glob patterns symlinked as a whole directory instead
+of walked file-by-file) still works and is equivalent to a `rules` entry
+with `materialization = "symlink-directory"` — both resolve through the
+same mechanism. See [ADR-017](adr/017-materialization-rules-generalize-link-dirs.md).
+
 ## Partial Files
 
 A `<name>.partial.{toml,yaml,yml}` sidecar file, placed anywhere in an

--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -286,8 +286,10 @@ pub async fn add_file(ctx: Ctx, overlay: &Overlay, file: &PathBuf) -> Result<()>
     Ok(())
 }
 
-/// Add a directory to an overlay, either as a whole directory symlink (if it matches
-/// `link_dirs`) or by recursing into it and adding each file individually.
+/// Add a directory to an overlay, either as a whole directory symlink (if it
+/// resolves to `SymlinkDirectory` via `rules`/`defaults`/`link_dirs` — see
+/// `Overlay::is_link_dir`, #113/#126) or by recursing into it and adding
+/// each file individually.
 pub async fn add_dir(ctx: Ctx, overlay: &Overlay, dir: &Path) -> Result<()> {
     let src = if dir.is_relative() {
         current_dir()?.join(dir)

--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -38,6 +38,19 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     if let Some(link_dirs) = &overlay.link_dirs {
         ui::info(format!("  link_dirs: {}", link_dirs.join(", "))).ok();
     }
+    if let Some(defaults) = &overlay.defaults {
+        ui::info(format!(
+            "  defaults: materialization = {}",
+            defaults.materialization
+        ))
+        .ok();
+    }
+    if let Some(rules) = &overlay.rules {
+        ui::info("  rules:").ok();
+        for rule in rules {
+            ui::info(format!("    {}: {}", rule.path, rule.materialization)).ok();
+        }
+    }
     if let Some(git) = &overlay.git {
         ui::info("  git repositories:").ok();
         for (path, cfg) in git {

--- a/src/desired/mod.rs
+++ b/src/desired/mod.rs
@@ -25,8 +25,8 @@
 //! ```
 //!
 //! [`DesiredTree::build`] walks an [`Overlay`](crate::overlays::Overlay) and
-//! everything it transitively `uses`, translating today's *implicit*
-//! symlink-first rules (`link_dirs`, `exclude`, `.link.*` sidecars,
+//! everything it transitively `uses`, translating symlink-first rules
+//! (`defaults`/`rules`, `link_dirs`, `exclude`, `.link.*` sidecars,
 //! `.partial.*` sidecars (#66), `git`) into an explicit list of
 //! [`DesiredEntry`] values. It never touches the filesystem beyond
 //! read-only inspection already required by that resolution (e.g.
@@ -34,9 +34,11 @@
 //!
 //! ## What's deliberately *not* here
 //!
-//! - Overlay discovery without an `over.yml` marker, and a `defaults:`/
-//!   `rules:` configuration syntax with path/subtree overrides — that's
-//!   #113, layered on top of this model later.
+//! - Overlay discovery without an `over.yml` marker — that's #127, layered
+//!   on top of this model later. (A `defaults:`/`rules:` configuration
+//!   syntax with path/subtree overrides *is* here — #126, resolved via
+//!   `Overlay::materialization_for`/`crate::overlays::rules` before this
+//!   module ever walks the overlay tree.)
 //! - Rendered file content (`DesiredEntry` has no `content` field) — #61.
 //! - Permission metadata (`DesiredEntry` has no `permissions` field) — #65.
 //! - Comparing against actual filesystem state and materializing anything —

--- a/src/desired/tree.rs
+++ b/src/desired/tree.rs
@@ -235,7 +235,10 @@ fn walk_overlay_tree(
 
         let entry_target = target.join(rel_path);
 
-        // A directory matching `link_dirs` is one materialization unit — its
+        // A directory resolved to `SymlinkDirectory` — via a `rules`
+        // entry, `defaults.materialization`, or a legacy `link_dirs` match,
+        // all resolved through the same mechanism (#113/#126,
+        // `Overlay::is_link_dir`) — is one materialization unit; its
         // children are not separately enumerated.
         if path.is_dir() && overlay.is_link_dir(rel_path) {
             entries.push(DesiredEntry {
@@ -561,6 +564,121 @@ mod tests {
                 .iter()
                 .any(|e| e.target == root.join("mydir/inner.txt"))
         );
+    }
+
+    /// #126: an explicit `rules` entry produces the same
+    /// `SymlinkDirectory` shape as `link_dirs`, through the same
+    /// resolution path.
+    #[rstest]
+    fn a_materialization_rule_produces_a_symlink_directory_entry() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str(
+                "target = \"~\"\n[[rules]]\npath = \"mydir\"\nmaterialization = \"symlink-directory\"",
+            )
+            .unwrap();
+        overlay_dir.child("mydir").create_dir_all().unwrap();
+        overlay_dir
+            .child("mydir/inner.txt")
+            .write_str("content")
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let root = td.path().to_path_buf();
+        let dir_entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == root.join("mydir"))
+            .expect("mydir entry present");
+        assert!(matches!(
+            dir_entry.intent,
+            MaterializationIntent::SymlinkDirectory { .. }
+        ));
+        assert!(
+            !tree
+                .entries()
+                .iter()
+                .any(|e| e.target == root.join("mydir/inner.txt"))
+        );
+    }
+
+    /// #113: `defaults.materialization` applies repository-/overlay-wide,
+    /// to every directory with no more specific `rules` override.
+    #[rstest]
+    fn defaults_materialization_applies_to_every_directory_without_a_rule() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"\n[defaults]\nmaterialization = \"symlink-directory\"")
+            .unwrap();
+        overlay_dir.child("sub").create_dir_all().unwrap();
+        overlay_dir
+            .child("sub/inner.txt")
+            .write_str("content")
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let root = td.path().to_path_buf();
+        let sub_entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == root.join("sub"))
+            .expect("sub entry present");
+        assert!(matches!(
+            sub_entry.intent,
+            MaterializationIntent::SymlinkDirectory { .. }
+        ));
+    }
+
+    /// #113: a file added to a source subtree governed by a file-level
+    /// rule appears in the next `DesiredTree` build with no rule change —
+    /// `walk_overlay_tree` re-walks the filesystem every call, so this is
+    /// a regression test, not new behavior.
+    #[rstest]
+    fn a_newly_added_file_is_picked_up_without_any_rule_change() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let root = td.path().to_path_buf();
+
+        let before = DesiredTree::build(&c, &overlay).unwrap();
+        assert!(
+            !before
+                .entries()
+                .iter()
+                .any(|e| e.target == root.join("new.txt"))
+        );
+
+        overlay_dir.child("new.txt").write_str("content").unwrap();
+
+        let after = DesiredTree::build(&c, &overlay).unwrap();
+        let entry = after
+            .entries()
+            .iter()
+            .find(|e| e.target == root.join("new.txt"))
+            .expect("newly added file should appear in the next build");
+        assert!(matches!(
+            entry.intent,
+            MaterializationIntent::SymlinkFile { .. }
+        ));
     }
 
     #[rstest]

--- a/src/lint/checks.rs
+++ b/src/lint/checks.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use globset::GlobBuilder;
+use walkdir::WalkDir;
 
 use crate::actions::partial::discover_partials;
 use crate::actions::symlink::{LinkType, discover_symlinks};
@@ -17,6 +18,10 @@ pub fn check_overlay(overlay: &Overlay) -> Vec<Diagnostic> {
     diagnostics.extend(check_invalid_exclude_globs(overlay));
     diagnostics.extend(check_empty_link_dirs(overlay));
     diagnostics.extend(check_invalid_link_dirs_globs(overlay));
+    diagnostics.extend(check_empty_rules(overlay));
+    diagnostics.extend(check_invalid_rules_globs(overlay));
+    diagnostics.extend(check_duplicate_rule_paths(overlay));
+    diagnostics.extend(check_rules_paths_exist(overlay));
     diagnostics.extend(check_git(overlay));
     diagnostics.extend(check_symlinks(overlay));
     diagnostics.extend(check_partials(overlay));
@@ -127,6 +132,107 @@ fn check_invalid_link_dirs_globs(overlay: &Overlay) -> Vec<Diagnostic> {
                     format!("invalid glob pattern in `link_dirs`: \"{pattern}\""),
                 )
                 .with_hint(format!("{err}")),
+            );
+        }
+    }
+    diagnostics
+}
+
+// ── materialization rules checks (#113/#126) ────────────────────────────
+
+fn check_empty_rules(overlay: &Overlay) -> Vec<Diagnostic> {
+    if matches!(&overlay.rules, Some(list) if list.is_empty()) {
+        vec![
+            Diagnostic::warning(&overlay.name, "empty `rules` list is redundant")
+                .with_hint("remove the `rules` field or add path overrides"),
+        ]
+    } else {
+        Vec::new()
+    }
+}
+
+fn check_invalid_rules_globs(overlay: &Overlay) -> Vec<Diagnostic> {
+    let Some(rules) = &overlay.rules else {
+        return Vec::new();
+    };
+
+    let mut diagnostics = Vec::new();
+    for rule in rules {
+        if let Err(err) = GlobBuilder::new(&rule.path).literal_separator(true).build() {
+            diagnostics.push(
+                Diagnostic::error(
+                    &overlay.name,
+                    format!("invalid glob pattern in `rules`: \"{}\"", rule.path),
+                )
+                .with_hint(format!("{err}")),
+            );
+        }
+    }
+    diagnostics
+}
+
+/// A rule whose `path` exactly duplicates an earlier one always shadows
+/// it (`rules::resolve` breaks specificity ties by keeping the last
+/// match), so the earlier entry can never take effect.
+fn check_duplicate_rule_paths(overlay: &Overlay) -> Vec<Diagnostic> {
+    let Some(rules) = &overlay.rules else {
+        return Vec::new();
+    };
+
+    let mut diagnostics = Vec::new();
+    let mut seen = HashSet::new();
+    for rule in rules {
+        if !seen.insert(&rule.path) {
+            diagnostics.push(
+                Diagnostic::warning(
+                    &overlay.name,
+                    format!(
+                        "duplicate rule path \"{}\"; only the last entry ever applies",
+                        rule.path
+                    ),
+                )
+                .with_hint("remove the redundant rule"),
+            );
+        }
+    }
+    diagnostics
+}
+
+/// A rule whose glob never matches anything under the overlay is either a
+/// typo or leftover from a rename — flag it rather than silently doing
+/// nothing.
+fn check_rules_paths_exist(overlay: &Overlay) -> Vec<Diagnostic> {
+    let Some(rules) = &overlay.rules else {
+        return Vec::new();
+    };
+
+    let mut diagnostics = Vec::new();
+    for rule in rules {
+        let Ok(glob) = GlobBuilder::new(&rule.path).literal_separator(true).build() else {
+            // Already reported by `check_invalid_rules_globs`.
+            continue;
+        };
+        let matcher = glob.compile_matcher();
+        let exists = WalkDir::new(&overlay.root)
+            .min_depth(1)
+            .into_iter()
+            .filter_map(Result::ok)
+            .any(|e| {
+                e.path()
+                    .strip_prefix(&overlay.root)
+                    .ok()
+                    .is_some_and(|rel| matcher.is_match(rel))
+            });
+        if !exists {
+            diagnostics.push(
+                Diagnostic::warning(
+                    &overlay.name,
+                    format!(
+                        "rule path \"{}\" does not match any file or directory in the overlay",
+                        rule.path
+                    ),
+                )
+                .with_hint("remove the rule or fix the path"),
             );
         }
     }
@@ -436,6 +542,88 @@ mod tests {
     fn test_valid_glob_in_link_dirs() {
         let overlay = setup_overlay("target = \"~\"\nlink_dirs = [\".config/*\"]");
         let diags = check_invalid_link_dirs_globs(&overlay);
+        assert!(diags.is_empty());
+    }
+
+    // ── materialization rules checks (#113/#126) ─────────────────────────
+
+    #[rstest]
+    fn test_empty_rules() {
+        let overlay = setup_overlay("target = \"~\"\nrules = []");
+        let diags = check_empty_rules(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+    }
+
+    #[rstest]
+    fn test_invalid_glob_in_rules() {
+        let overlay = setup_overlay(
+            "target = \"~\"\n[[rules]]\npath = \"[invalid\"\nmaterialization = \"symlink\"",
+        );
+        let diags = check_invalid_rules_globs(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert!(diags[0].message.contains("invalid glob"));
+    }
+
+    #[rstest]
+    fn test_valid_glob_in_rules() {
+        let overlay = setup_overlay(
+            "target = \"~\"\n[[rules]]\npath = \".config/*\"\nmaterialization = \"symlink-directory\"",
+        );
+        let diags = check_invalid_rules_globs(&overlay);
+        assert!(diags.is_empty());
+    }
+
+    #[rstest]
+    fn test_duplicate_rule_paths() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[[rules]]
+path = "dup"
+materialization = "symlink"
+
+[[rules]]
+path = "dup"
+materialization = "symlink-directory"
+"#,
+        );
+        let diags = check_duplicate_rule_paths(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert!(diags[0].message.contains("duplicate rule path"));
+    }
+
+    #[rstest]
+    fn test_rule_path_does_not_exist() {
+        let overlay = setup_overlay(
+            "target = \"~\"\n[[rules]]\npath = \"missing\"\nmaterialization = \"symlink-directory\"",
+        );
+        let diags = check_rules_paths_exist(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert!(diags[0].message.contains("does not match any file"));
+    }
+
+    #[rstest]
+    fn test_rule_path_existence_check_skips_invalid_globs() {
+        // An invalid glob is already reported by `check_invalid_rules_globs`
+        // — `check_rules_paths_exist` must skip it rather than double-report.
+        let overlay = setup_overlay(
+            "target = \"~\"\n[[rules]]\npath = \"[invalid\"\nmaterialization = \"symlink-directory\"",
+        );
+        let diags = check_rules_paths_exist(&overlay);
+        assert!(diags.is_empty());
+    }
+
+    #[rstest]
+    fn test_rule_path_exists_no_diagnostic() {
+        let overlay = setup_overlay(
+            "target = \"~\"\n[[rules]]\npath = \"present\"\nmaterialization = \"symlink-directory\"",
+        );
+        std::fs::create_dir_all(overlay.root.join("present")).unwrap();
+        let diags = check_rules_paths_exist(&overlay);
         assert!(diags.is_empty());
     }
 

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -235,12 +235,14 @@ fn check_cycles(overlays: &HashMap<String, &Overlay>) -> Vec<Diagnostic> {
 /// Valid user-facing top-level keys in an overlay descriptor.
 /// Internal keys (`name`, `root`) set by code are excluded.
 const VALID_OVERLAY_KEYS: &[&str] = &[
+    "defaults",
     "description",
     "exclude",
     "format",
     "git",
     "install",
     "link_dirs",
+    "rules",
     "target",
     "uses",
 ];

--- a/src/overlays/mod.rs
+++ b/src/overlays/mod.rs
@@ -15,9 +15,11 @@ pub(crate) const EXTENSIONS: &[&str] = &["yml", "yaml", "toml"];
 
 pub mod overlay;
 pub mod repository;
+pub mod rules;
 
 pub use overlay::Overlay;
 pub use repository::Repository;
+pub use rules::{Defaults, MaterializationKind, MaterializationRule};
 
 /// Overlay files search pattern
 pub static GLOB_PATTERN: LazyLock<String> =

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -17,6 +17,7 @@ use crate::plan::Plan;
 use crate::ui;
 use crate::ui::{emojis, style};
 
+use super::rules::{self, Defaults, MaterializationKind, MaterializationRule};
 use super::{DEFAULT_TARGET, Repository};
 
 fn default_none() -> Option<Vec<String>> {
@@ -84,8 +85,24 @@ pub struct Overlay {
 
     pub install: Option<InstallConfig>,
 
+    /// Repository-/overlay-level default materialization applied to every
+    /// directory with no matching `rules` entry (#113/#126). Absent
+    /// entirely falls back to [`MaterializationKind::Symlink`] (today's
+    /// implicit default) — see [`rules::resolve`].
+    pub defaults: Option<Defaults>,
+
+    /// Path/subtree materialization overrides (#113/#126); most specific
+    /// match wins — see [`rules::resolve`]. `link_dirs` below is
+    /// equivalent to a `rules` entry with `materialization:
+    /// symlink-directory` and is resolved through the same mechanism
+    /// (ADR-017).
+    pub rules: Option<Vec<MaterializationRule>>,
+
     /// Glob patterns for directories that should be symlinked as a unit
-    /// rather than recursed into when adding.
+    /// rather than recursed into when adding. Kept for backward
+    /// compatibility: internally equivalent to a `rules` entry with
+    /// `materialization: symlink-directory` (ADR-017) — prefer `rules`
+    /// for new configs; both resolve through [`rules::resolve`].
     pub link_dirs: Option<Vec<String>>,
 }
 
@@ -162,21 +179,19 @@ impl Overlay {
         })
     }
 
-    /// Check if a relative path matches any `link_dirs` glob pattern,
-    /// meaning it should be symlinked as a whole directory rather than recursed into.
+    /// Resolve the effective materialization for a directory at
+    /// `rel_path`: the most specific matching `rules` entry, else
+    /// `defaults.materialization`, else `Symlink` — see [`rules::resolve`].
+    pub fn materialization_for(&self, rel_path: &Path) -> MaterializationKind {
+        rules::resolve(self, rel_path)
+    }
+
+    /// Whether a relative path should be symlinked as a whole directory
+    /// unit rather than recursed into. Broadened beyond a literal
+    /// `link_dirs` glob match to also honor `rules`/`defaults`
+    /// (#113/#126) — see [`Self::materialization_for`].
     pub fn is_link_dir(&self, rel_path: &Path) -> bool {
-        let patterns = match &self.link_dirs {
-            Some(p) if !p.is_empty() => p,
-            _ => return false,
-        };
-        for pattern in patterns {
-            if let Ok(glob) = GlobBuilder::new(pattern).literal_separator(true).build()
-                && glob.compile_matcher().is_match(rel_path)
-            {
-                return true;
-            }
-        }
-        false
+        self.materialization_for(rel_path) == MaterializationKind::SymlinkDirectory
     }
 
     /// Check if a relative path matches any `exclude` glob pattern.

--- a/src/overlays/rules.rs
+++ b/src/overlays/rules.rs
@@ -1,0 +1,273 @@
+//! Materialization rules: a default materialization plus path/subtree
+//! overrides, resolved into a [`MaterializationKind`] for each directory
+//! encountered while walking an overlay's tree (#126, part of #113).
+//!
+//! This module only decides *whether* a directory should be recursed into
+//! (and its files symlinked individually) or symlinked as a single unit —
+//! it has no notion of `source`/`link_type`/`Checkout`, which live on
+//! [`crate::desired::MaterializationIntent`] once [`crate::desired::tree`]
+//! has resolved concrete filesystem paths. `checkout` is deliberately not a
+//! valid `materialization` value here: that intent stays driven by
+//! `overlay.git` (see ADR-017). Assigning an arbitrary subtree to a
+//! checkout, or migrating an already-symlinked path to one, is rule-change
+//! *migration* territory, tracked separately (#129).
+
+use std::fmt;
+use std::path::Path;
+
+use globset::GlobBuilder;
+use serde::{Deserialize, Serialize};
+
+use super::overlay::Overlay;
+
+/// How a directory-shaped entry should be materialized once a `rules`/
+/// `defaults` entry has been resolved for it (or none matched).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum MaterializationKind {
+    /// Recurse into the directory and symlink each file individually —
+    /// today's implicit default.
+    #[default]
+    Symlink,
+    /// Symlink the directory as a single unit; its contents are not
+    /// separately enumerated (equivalent to a `link_dirs` match).
+    SymlinkDirectory,
+}
+
+impl fmt::Display for MaterializationKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MaterializationKind::Symlink => write!(f, "symlink"),
+            MaterializationKind::SymlinkDirectory => write!(f, "symlink-directory"),
+        }
+    }
+}
+
+/// Repository- or overlay-level default materialization, applied when no
+/// `rules` entry matches a given path. Inherited through the same
+/// cascading descriptor chain as every other overlay field (ADR-002): a
+/// root `over.toml` sets a repository-wide baseline, and any ancestor
+/// down to the overlay's own directory can override it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct Defaults {
+    #[serde(default)]
+    pub materialization: MaterializationKind,
+}
+
+/// A single path/subtree materialization override.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaterializationRule {
+    /// Glob pattern (or literal path), relative to the overlay root.
+    pub path: String,
+    pub materialization: MaterializationKind,
+}
+
+impl MaterializationRule {
+    /// Whether `rel_path` matches this rule's `path` glob. A malformed
+    /// glob never matches — `over lint` is where invalid patterns are
+    /// reported, not a panic/error here (mirrors `Overlay::is_excluded`).
+    fn matches(&self, rel_path: &Path) -> bool {
+        GlobBuilder::new(&self.path)
+            .literal_separator(true)
+            .build()
+            .ok()
+            .is_some_and(|glob| glob.compile_matcher().is_match(rel_path))
+    }
+
+    /// Rough specificity ranking used to break ties when more than one
+    /// rule matches the same path: a literal pattern (no glob
+    /// metacharacters) always outranks a wildcard one, and within the
+    /// same tier a longer pattern is considered more specific. Not a
+    /// perfect partial order for every possible pair of globs, but enough
+    /// to resolve the common "a specific path overrides a broader glob"
+    /// case #113 asks for.
+    fn specificity(&self) -> (bool, usize) {
+        let is_literal = !self.path.contains(['*', '?', '[', '{']);
+        (is_literal, self.path.len())
+    }
+}
+
+/// `overlay.rules` plus one equivalent [`MaterializationRule`] per
+/// `link_dirs` glob (translated to `SymlinkDirectory`), so both resolve
+/// through [`resolve`] — one code path, no behavior change for existing
+/// `link_dirs` configs (ADR-017).
+///
+/// `link_dirs`-derived entries are listed first so an explicit `rules`
+/// entry wins ties against a legacy `link_dirs` pattern for the same path
+/// (`Iterator::max_by_key`, which [`resolve`] uses, returns the *last*
+/// maximum on ties).
+pub(super) fn effective_rules(overlay: &Overlay) -> Vec<MaterializationRule> {
+    let mut rules: Vec<MaterializationRule> = overlay
+        .link_dirs
+        .iter()
+        .flatten()
+        .map(|pattern| MaterializationRule {
+            path: pattern.clone(),
+            materialization: MaterializationKind::SymlinkDirectory,
+        })
+        .collect();
+    rules.extend(overlay.rules.iter().flatten().cloned());
+    rules
+}
+
+/// Resolve the effective [`MaterializationKind`] for a directory at
+/// `rel_path` within `overlay`, in precedence order:
+///
+/// 1. the most specific matching `rules` entry (explicit config, or a
+///    `link_dirs` pattern translated into an equivalent rule);
+/// 2. `defaults.materialization`;
+/// 3. the hardcoded fallback (`Symlink` — today's implicit default).
+///
+/// Only meaningful for directories: files are always symlinked
+/// individually regardless of `rules`/`defaults` — there is no
+/// "file-level checkout" or "whole-file directory" distinction to make
+/// here.
+pub(super) fn resolve(overlay: &Overlay, rel_path: &Path) -> MaterializationKind {
+    let rules = effective_rules(overlay);
+    let best = rules
+        .iter()
+        .filter(|rule| rule.matches(rel_path))
+        .max_by_key(|rule| rule.specificity());
+    match best {
+        Some(rule) => rule.materialization,
+        None => overlay
+            .defaults
+            .map(|d| d.materialization)
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overlays::Repository;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use rstest::rstest;
+
+    fn setup_overlay(toml_content: &str) -> Overlay {
+        let td = TempDir::new().unwrap();
+        let repo = Repository::new(td.path().to_path_buf());
+        let ov = td.child("ov");
+        ov.create_dir_all().unwrap();
+        ov.child("over.toml").write_str(toml_content).unwrap();
+        let overlay = repo.get("ov").unwrap();
+        // Keep `td` alive for the overlay's lifetime (test-only leak).
+        Box::leak(Box::new(td));
+        overlay
+    }
+
+    #[rstest]
+    #[case(MaterializationKind::Symlink, "symlink")]
+    #[case(MaterializationKind::SymlinkDirectory, "symlink-directory")]
+    fn display_matches_the_kebab_case_config_value(
+        #[case] kind: MaterializationKind,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(kind.to_string(), expected);
+    }
+
+    #[rstest]
+    fn no_defaults_no_rules_falls_back_to_symlink() {
+        let overlay = setup_overlay("target = \"~\"");
+        assert_eq!(
+            resolve(&overlay, Path::new("anything")),
+            MaterializationKind::Symlink
+        );
+    }
+
+    #[rstest]
+    fn defaults_materialization_applies_to_every_unmatched_path() {
+        let overlay =
+            setup_overlay("target = \"~\"\n[defaults]\nmaterialization = \"symlink-directory\"");
+        assert_eq!(
+            resolve(&overlay, Path::new("any/dir")),
+            MaterializationKind::SymlinkDirectory
+        );
+    }
+
+    #[rstest]
+    fn a_rule_overrides_the_default_for_its_own_subtree_only() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[defaults]
+materialization = "symlink"
+
+[[rules]]
+path = "special"
+materialization = "symlink-directory"
+"#,
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("special")),
+            MaterializationKind::SymlinkDirectory
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("other")),
+            MaterializationKind::Symlink
+        );
+    }
+
+    #[rstest]
+    fn a_literal_rule_wins_over_an_overlapping_glob_rule() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[[rules]]
+path = "some/*"
+materialization = "symlink"
+
+[[rules]]
+path = "some/dir"
+materialization = "symlink-directory"
+"#,
+        );
+        // Both rules match "some/dir"; the literal, more specific one wins
+        // regardless of declaration order.
+        assert_eq!(
+            resolve(&overlay, Path::new("some/dir")),
+            MaterializationKind::SymlinkDirectory
+        );
+        // The glob-only rule still applies to paths the literal one
+        // doesn't cover.
+        assert_eq!(
+            resolve(&overlay, Path::new("some/other")),
+            MaterializationKind::Symlink
+        );
+    }
+
+    #[rstest]
+    fn link_dirs_resolves_through_the_same_mechanism_as_an_explicit_rule() {
+        let overlay = setup_overlay("target = \"~\"\nlink_dirs = [\".config/nvim\"]");
+        assert_eq!(
+            resolve(&overlay, Path::new(".config/nvim")),
+            MaterializationKind::SymlinkDirectory
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new(".config/other")),
+            MaterializationKind::Symlink
+        );
+    }
+
+    #[rstest]
+    fn an_explicit_rule_wins_a_tie_against_a_link_dirs_pattern() {
+        // Same exact path via both mechanisms, disagreeing on the result:
+        // the explicit `rules` entry (added after `link_dirs`-derived
+        // entries in `effective_rules`) must win.
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+link_dirs = ["dual"]
+
+[[rules]]
+path = "dual"
+materialization = "symlink"
+"#,
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("dual")),
+            MaterializationKind::Symlink
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1412,6 +1412,37 @@ link_dirs = [".config/nvim"]
     Ok(())
 }
 
+/// #126: `over show` displays resolved `defaults`/`rules` when configured.
+#[test]
+fn show_overlay_with_materialization_rules() -> TestResult {
+    let tmp = TempDir::new()?;
+    let ov = tmp.path().join("rules_overlay");
+    fs::create_dir_all(&ov)?;
+    fs::write(
+        ov.join("over.toml"),
+        br#"target = "~"
+[defaults]
+materialization = "symlink-directory"
+
+[[rules]]
+path = "special"
+materialization = "symlink"
+"#,
+    )?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(tmp.path())
+        .args(["show", "rules_overlay"])
+        .assert()
+        .success()
+        .stdout(contains("rules_overlay"))
+        .stdout(contains("defaults: materialization = symlink-directory"))
+        .stdout(contains("rules:"))
+        .stdout(contains("special: symlink"));
+    Ok(())
+}
+
 #[test]
 fn show_overlay_with_install_config() -> TestResult {
     let tmp = TempDir::new()?;


### PR DESCRIPTION
Adds a `defaults`/`rules` configuration model for materialization, resolved hierarchically before `DesiredTree` construction — the first of #113's five sub-issues.

## What changed

- A repository root `over.toml` can set a baseline `defaults.materialization` (`symlink` or `symlink-directory`); any overlay along the existing cascading descriptor chain can override it, or add `rules` entries scoping the override to a specific path/subtree (most specific match wins).
- `link_dirs` keeps working exactly as before, now implemented as sugar for an equivalent `symlink-directory` rule, so both mechanisms resolve through the same code path.
- `over lint` validates `rules` the same way it already validates `exclude`/`link_dirs` (invalid globs, empty list, duplicate/shadowed paths, paths matching nothing on disk).
- `over show` displays the resolved `defaults`/`rules` when present.
- New ADR-017 documents the decision (amending ADR-006), and `docs/configuration.md` gains a "Materialization Rules" section.

## Scope

`checkout` materialization and migrating between materializations are explicitly out of scope here — see #129/#130.

Closes #126
