### PR TITLE
feat(overlays): root-declared overlays extend descriptor discovery

### DIFF
--- a/docs/adr/018-root-declared-overlays-extend-descriptor-discovery.md
+++ b/docs/adr/018-root-declared-overlays-extend-descriptor-discovery.md
@@ -1,0 +1,80 @@
+# ADR-018: Root-declared `overlays:` paths extend descriptor-glob discovery, amending ADR-002
+
+**Status:** accepted
+
+## Context
+
+`Repository::overlays()` (`src/overlays/repository.rs`) discovers overlays
+purely by globbing for `over.{yml,yaml,toml}` (`GLOB_PATTERN`) — a directory
+with no local descriptor is invisible, even though `Overlay::new`'s
+cascading config merge (ADR-002) already tolerates a missing descriptor at
+every *ancestor* level except the overlay's own directory
+(`.required(dir == root)`).
+
+#113 asks for a repository root that can declare overlays/workspaces
+directly, e.g. `overlays: [{ path: "hosts/*" }]`, so a directory doesn't
+need its own descriptor purely to exist as an overlay.
+
+## Decision
+
+Add `OverlayDeclaration { path: String }` (`src/overlays/discovery.rs`),
+read once from the repository root's own descriptor via a new
+`RootConfig { format, overlays }` struct (`src/overlays/repository.rs`) —
+the same one-shot, non-cascading read `preferred_format()` already used
+for `format`, now shared between both fields. `path` is a glob pattern or
+literal path, relative to the repository root.
+
+`resolve_declared_dirs` expands declarations into concrete directories
+using the `glob` crate, not `globset`: `globset` only tests an
+already-known path against a pattern (`GLOB_PATTERN`, `exclude`, `rules`
+all work this way — enumerate the tree with `WalkDir`, then filter), while
+a root declaration describes what to enumerate directly. This mirrors
+`cli::common::resolve_inputs`, the existing precedent for expanding a
+user-supplied glob against the real filesystem. A malformed glob, or one
+matching nothing, is silently skipped — consistent with how
+`MaterializationRule::matches` treats a bad `rules` glob: `over lint` is
+where diagnostics belong, not a hard error at discovery time. This issue
+does not add such a lint check; a future one can (see Consequences).
+
+`Repository::overlays()` unions descriptor-glob discovery with
+`declared_overlay_dirs()`, then dedups by resolved path before the
+existing "more specific overlay wins" parent-skip pass, which is otherwise
+unchanged. `lint::discover_overlay_dirs` (`src/lint/mod.rs`) does the same
+union so `over lint` isn't blind to root-declared overlays.
+
+`Overlay::new`'s `.required(dir == root)` becomes unconditional
+`.required(false)`: an overlay directory can now have zero descriptor
+anywhere in its own file, resolving entirely from ancestor config
+(including the repository root) plus hardcoded defaults (`target`'s
+`set_default`).
+
+Two scope decisions, made explicitly narrow for this issue:
+
+- **No nested declarations.** Only the repository root's own descriptor's
+  `overlays:` key is read. A directory matched by a root declaration
+  cannot itself declare further `overlays:` entries — avoids
+  recursion/cycle-safety concerns not requested by #113's core scenarios.
+- **Naming stays path-derived**, unchanged from today (ADR-002: identity
+  is the filesystem path, not a git ref) — a root-declared overlay's name
+  is still computed the same way in `Overlay::new`.
+
+## Consequences
+
+`Repository::get()`/`Overlay::new` now succeed for *any* existing
+directory under the repository root, even one with zero descriptor
+anywhere in its ancestor chain and not declared via `overlays:` at all —
+this was a deliberate, explicit part of #113/#127's scope, not limited to
+declared directories. Anyone relying on a missing descriptor as an
+implicit "this is not an overlay" guard (there was no such guard enforced
+elsewhere) will see previously-erroring paths now resolve successfully.
+
+`Repository::overlays()` and `lint::discover_overlay_dirs` still duplicate
+the descriptor-glob walk (pre-existing, not introduced here) — now each
+also duplicates the declared-dirs union call. Unifying the two discovery
+functions into one shared implementation is a reasonable follow-up, out of
+scope here.
+
+An empty-match root glob and a malformed root glob are both silent by
+design (see Decision) — no `over lint` check was added for either in this
+issue. A future issue can add one, mirroring `check_invalid_rules_globs`/
+`check_rules_paths_exist`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ by editing the old one. The history is the value.
 | [015](015-unapply-reuses-plan-classification-and-only-removes-safely-reversible-state.md) | `unapply` reuses `Plan`'s classification and only ever removes safely reversible state |
 | [016](016-partial-file-managed-blocks.md) | Partial files are managed blocks injected via a sidecar, not a stem-plus-sidecar pair |
 | [017](017-materialization-rules-generalize-link-dirs.md) | Materialization rules generalize `link_dirs` into path/subtree overrides, amending ADR-006 |
+| [018](018-root-declared-overlays-extend-descriptor-discovery.md) | Root-declared `overlays:` paths extend descriptor-glob discovery, amending ADR-002 |

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -126,7 +126,12 @@ fn discover_overlay_dirs(repo: &Repository) -> Vec<(PathBuf, String)> {
         .filter_map(|e| e.path().parent().map(|p| p.to_path_buf()))
         .collect();
 
+    // Union with root-declared `overlays:` directories (#113/#127), same
+    // as `Repository::overlays()` — otherwise `over lint` would be blind
+    // to overlays declared only via the root config.
+    dirs.extend(repo.declared_overlay_dirs());
     dirs.sort();
+    dirs.dedup();
 
     dirs.iter()
         .enumerate()
@@ -134,7 +139,13 @@ fn discover_overlay_dirs(repo: &Repository) -> Vec<(PathBuf, String)> {
         .filter_map(|(_, dir)| {
             dir.strip_prefix(&repo.root)
                 .ok()
-                .and_then(|rel| rel.to_str().map(|s| s.to_string()))
+                // Normalize to `/` so this name matches the one
+                // `Overlay::new` computes for the same directory
+                // (src/overlays/overlay.rs) — otherwise a nested overlay's
+                // key here (`\`-separated on Windows) would never equal
+                // the `/`-separated name another overlay's `uses` entry
+                // references, breaking cross-overlay checks on Windows.
+                .and_then(|rel| rel.to_str().map(|s| s.replace('\\', "/")))
                 .map(|name| (dir.clone(), name))
         })
         .collect()
@@ -242,6 +253,7 @@ const VALID_OVERLAY_KEYS: &[&str] = &[
     "git",
     "install",
     "link_dirs",
+    "overlays",
     "rules",
     "target",
     "uses",
@@ -665,6 +677,34 @@ mod tests {
 
         let result = lint_repository(&repo);
         assert!(result.diagnostics.is_empty());
+    }
+
+    #[rstest]
+    fn test_lint_discovers_root_declared_overlay_without_local_descriptor() {
+        let (td, repo) = setup_repo();
+        // `uses` cascades from the root descriptor (ADR-002) down to
+        // `hosts/laptop`, which has zero local descriptor of its own —
+        // only discoverable via the root declaration (#113/#127). If
+        // `over lint` were blind to it, this cycle/reference check would
+        // never run and no diagnostic would be produced.
+        td.child("over.toml")
+            .write_str(
+                "target = \"~\"\nuses = [\"nonexistent\"]\n\n[[overlays]]\npath = \"hosts/*\"",
+            )
+            .unwrap();
+        td.child("hosts/laptop").create_dir_all().unwrap();
+
+        let result = lint_repository(&repo);
+        assert!(result.has_errors());
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.overlay == "hosts/laptop"
+                    && d.message.contains("uses references non-existent overlay")),
+            "expected a diagnostic on hosts/laptop, got: {:?}",
+            result.diagnostics
+        );
     }
 
     #[rstest]

--- a/src/overlays/discovery.rs
+++ b/src/overlays/discovery.rs
@@ -1,0 +1,140 @@
+//! Root-level `overlays:` declarations (#113/#127): directories that
+//! belong to the repository's overlay set without their own local
+//! descriptor file, resolved once from the repository root's own
+//! `over.{toml,yaml,yml}` and unioned with descriptor-glob discovery
+//! (`GLOB_PATTERN`) in `Repository::overlays()` — see ADR-018.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// A single root-level overlay/workspace declaration. `path` is a glob
+/// pattern (e.g. `hosts/*`) or a literal path, relative to the repository
+/// root. Only the repository root's own descriptor's `overlays:` key is
+/// read — a directory matched this way cannot itself declare further
+/// `overlays:` entries (ADR-018: no recursive/nested expansion).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OverlayDeclaration {
+    pub path: String,
+}
+
+/// Expand root-declared paths/globs into concrete directories that exist
+/// on disk. Uses the filesystem-expanding `glob` crate rather than
+/// `globset` (which only tests an already-known path against a pattern,
+/// as used by `GLOB_PATTERN`/`exclude`/`rules`) because a declaration
+/// describes what to enumerate on disk, not what to test — mirrors
+/// `cli::common::resolve_inputs`. A malformed glob, or one matching
+/// nothing, is silently skipped (ADR-018): no error, no lint check in
+/// this issue.
+pub(super) fn resolve_declared_dirs(
+    repo_root: &Path,
+    declarations: &[OverlayDeclaration],
+) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    for decl in declarations {
+        let pattern = repo_root.join(&decl.path);
+        let Some(pattern_str) = pattern.to_str() else {
+            continue;
+        };
+        let Ok(paths) = glob::glob(pattern_str) else {
+            tracing::warn!("invalid overlays declaration pattern '{}'", decl.path);
+            continue;
+        };
+        // Only directories are overlays; a glob like `hosts/*` may also
+        // match plain files sitting alongside overlay directories.
+        dirs.extend(paths.filter_map(Result::ok).filter(|p| p.is_dir()));
+    }
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn a_literal_path_matching_an_existing_directory_resolves_to_it() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("shared")).unwrap();
+
+        let dirs = resolve_declared_dirs(
+            tmp.path(),
+            &[OverlayDeclaration {
+                path: "shared".to_string(),
+            }],
+        );
+
+        assert_eq!(dirs, vec![tmp.path().join("shared")]);
+    }
+
+    #[test]
+    fn a_glob_path_resolves_every_matching_directory() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("hosts/laptop")).unwrap();
+        fs::create_dir_all(tmp.path().join("hosts/desktop")).unwrap();
+
+        let mut dirs = resolve_declared_dirs(
+            tmp.path(),
+            &[OverlayDeclaration {
+                path: "hosts/*".to_string(),
+            }],
+        );
+        dirs.sort();
+
+        assert_eq!(
+            dirs,
+            vec![
+                tmp.path().join("hosts/desktop"),
+                tmp.path().join("hosts/laptop"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_path_matching_only_files_resolves_empty() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("hosts")).unwrap();
+        fs::write(tmp.path().join("hosts/README.md"), "not a dir").unwrap();
+
+        let dirs = resolve_declared_dirs(
+            tmp.path(),
+            &[OverlayDeclaration {
+                path: "hosts/*".to_string(),
+            }],
+        );
+
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn a_path_matching_nothing_on_disk_resolves_empty() {
+        let tmp = TempDir::new().unwrap();
+
+        let dirs = resolve_declared_dirs(
+            tmp.path(),
+            &[OverlayDeclaration {
+                path: "nonexistent/*".to_string(),
+            }],
+        );
+
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn a_malformed_glob_pattern_resolves_empty_without_erroring() {
+        let tmp = TempDir::new().unwrap();
+
+        // `glob::Pattern` rejects unmatched brackets.
+        let dirs = resolve_declared_dirs(
+            tmp.path(),
+            &[OverlayDeclaration {
+                path: "hosts/[".to_string(),
+            }],
+        );
+
+        assert!(dirs.is_empty());
+    }
+}

--- a/src/overlays/mod.rs
+++ b/src/overlays/mod.rs
@@ -13,10 +13,12 @@ pub(crate) const DEFAULT_TARGET: &str = "~";
 /// Overlay files extensions
 pub(crate) const EXTENSIONS: &[&str] = &["yml", "yaml", "toml"];
 
+pub mod discovery;
 pub mod overlay;
 pub mod repository;
 pub mod rules;
 
+pub use discovery::OverlayDeclaration;
 pub use overlay::Overlay;
 pub use repository::Repository;
 pub use rules::{Defaults, MaterializationKind, MaterializationRule};

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -113,6 +113,14 @@ impl fmt::Display for Overlay {
 }
 
 impl Overlay {
+    /// Build an overlay from its own directory, cascading config from
+    /// every ancestor up to and including the repository root (ADR-002).
+    /// The overlay's own descriptor is *not* required to exist (#127,
+    /// ADR-018): a directory declared only via the repository root's
+    /// `overlays:` key (or requested directly via `Repository::get`) with
+    /// zero local `over.*` anywhere in its ancestor chain still resolves,
+    /// entirely from inherited config plus hardcoded defaults (e.g.
+    /// `target`'s `set_default` below).
     pub fn new(repository: &Repository, root: &Path) -> Result<Self> {
         // Normalize to `/` so overlay names are portable identifiers that
         // don't leak the platform's native path separator (`\` on Windows).
@@ -131,7 +139,11 @@ impl Overlay {
                         .to_str()
                         .ok_or_else(|| anyhow::anyhow!("config path is not valid UTF-8"))?,
                 )
-                .required(dir == root),
+                // Never required (#127, ADR-018): every level of the
+                // cascade, including the overlay's own directory, is
+                // optional — a fully descriptor-less overlay still
+                // resolves via ancestor config + repository defaults.
+                .required(false),
             );
             if dir == repository.root {
                 break;
@@ -516,6 +528,23 @@ mod tests {
         assert!(overlay.is_link_dir(Path::new(".local/share/fonts")));
         assert!(!overlay.is_link_dir(Path::new(".config/other")));
         assert!(!overlay.is_link_dir(Path::new("random")));
+    }
+
+    #[test]
+    fn overlay_with_zero_local_descriptor_resolves_via_ancestor_config() {
+        let (td, repo) = repo_and_root();
+        // Repository root descriptor, providing the only `target` in the
+        // whole ancestor chain.
+        td.child("over.toml")
+            .write_str("target = \"~/inherited\"")
+            .unwrap();
+        // The overlay's own directory has no `over.*` file at all.
+        let overlay_dir = td.child("hosts/laptop");
+        overlay_dir.create_dir_all().unwrap();
+
+        let overlay = repo.get("hosts/laptop").unwrap();
+        assert_eq!(overlay.name, "hosts/laptop");
+        assert_eq!(overlay.target, "~/inherited");
     }
 
     #[rstest]

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -7,6 +7,7 @@ use walkdir::WalkDir;
 
 use anyhow::{Context as _, Result};
 
+use super::discovery::{OverlayDeclaration, resolve_declared_dirs};
 use super::overlay::Overlay;
 use super::{BASENAME, Format, GLOB_PATTERN};
 
@@ -48,7 +49,13 @@ impl Repository {
             .filter_map(|e| e.path().parent().map(|p| p.to_path_buf()))
             .collect();
 
+        // Union with root-declared `overlays:` directories (#113/#127) —
+        // dedup by resolved path since a directory can be found by both
+        // mechanisms (e.g. a root-declared dir that also has its own
+        // descriptor).
+        dirs.extend(self.declared_overlay_dirs());
         dirs.sort();
+        dirs.dedup();
 
         let mut overlays = Vec::new();
         for (idx, dir) in dirs.iter().enumerate() {
@@ -89,18 +96,43 @@ impl Repository {
     /// Reads `format` from the repository root `over.{toml,yaml,yml}`.
     /// Returns `None` when no root config exists or the field is absent.
     pub fn preferred_format(&self) -> Option<Format> {
-        #[derive(Deserialize)]
-        struct RootPrefs {
-            format: Option<Format>,
-        }
-        let basename = self.root.join(BASENAME);
-        let cfg = Config::builder()
-            .add_source(File::with_name(basename.to_str()?).required(false))
-            .build()
-            .ok()?;
-        let prefs: RootPrefs = cfg.try_deserialize().ok()?;
-        prefs.format
+        self.root_config().format
     }
+
+    /// Directories declared via the repository root's `overlays:` key
+    /// (#113/#127), resolved to concrete filesystem paths. Public so
+    /// `over lint`'s own discovery (`lint::discover_overlay_dirs`) can
+    /// union the same set instead of re-deriving it.
+    pub fn declared_overlay_dirs(&self) -> Vec<PathBuf> {
+        let declarations = self.root_config().overlays.unwrap_or_default();
+        resolve_declared_dirs(&self.root, &declarations)
+    }
+
+    /// One-shot, non-cascading read of the repository root's own
+    /// descriptor. Unlike `Overlay::new`'s ancestor-chain cascade
+    /// (ADR-002), this reads *only* `self.root`'s file: `format` and
+    /// `overlays` are root-scoped fields with no meaning cascaded
+    /// per-overlay (ADR-018).
+    fn root_config(&self) -> RootConfig {
+        let basename = self.root.join(BASENAME);
+        let Some(path) = basename.to_str() else {
+            return RootConfig::default();
+        };
+        Config::builder()
+            .add_source(File::with_name(path).required(false))
+            .build()
+            .ok()
+            .and_then(|cfg| cfg.try_deserialize().ok())
+            .unwrap_or_default()
+    }
+}
+
+/// The repository root's own descriptor fields, read once and not
+/// cascaded to overlays (ADR-018) — see [`Repository::root_config`].
+#[derive(Debug, Deserialize, Default)]
+struct RootConfig {
+    format: Option<Format>,
+    overlays: Option<Vec<OverlayDeclaration>>,
 }
 
 #[cfg(test)]
@@ -215,5 +247,69 @@ mod tests {
         let overlays = repo.overlays().unwrap();
         assert_eq!(overlays.len(), 1);
         assert_eq!(overlays[0].name, "parent/child");
+    }
+
+    #[test]
+    fn overlays_discovers_root_declared_directory_without_local_descriptor() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "target = \"~\"\n\n[[overlays]]\npath = \"hosts/*\"",
+        )
+        .unwrap();
+        // No `over.*` at all in `hosts/laptop` — must still be discovered
+        // and resolve `target` from the repository root config.
+        fs::create_dir_all(tmp.path().join("hosts/laptop")).unwrap();
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let overlays = repo.overlays().unwrap();
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].name, "hosts/laptop");
+        assert_eq!(overlays[0].target, "~");
+    }
+
+    #[test]
+    fn overlays_merges_declared_and_descriptor_discovery_without_duplicates() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "target = \"~\"\n\n[[overlays]]\npath = \"shared\"",
+        )
+        .unwrap();
+        // Also has its own local descriptor — matched by both mechanisms.
+        let shared = tmp.path().join("shared");
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(shared.join("over.toml"), "target = \"~/shared\"").unwrap();
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let overlays = repo.overlays().unwrap();
+        assert_eq!(overlays.len(), 1, "should not produce a duplicate entry");
+        assert_eq!(overlays[0].name, "shared");
+        assert_eq!(overlays[0].target, "~/shared");
+    }
+
+    #[test]
+    fn overlays_root_declaration_glob_matching_nothing_is_silently_empty() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "target = \"~\"\n\n[[overlays]]\npath = \"nonexistent/*\"",
+        )
+        .unwrap();
+        // A legitimate sibling overlay so this test isn't tripped up by
+        // the pre-existing (unrelated to #127) edge case where the
+        // repository root itself, when it has its own `over.toml` and no
+        // descendant overlay at all, is discovered as an overlay with an
+        // empty name — the root is always a path-prefix of every other
+        // discovered dir and gets skipped by the "more specific overlay
+        // wins" rule below as soon as one exists.
+        let other = tmp.path().join("other");
+        fs::create_dir_all(&other).unwrap();
+        fs::write(other.join("over.toml"), "target = \"~\"").unwrap();
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let overlays = repo.overlays().unwrap();
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].name, "other");
     }
 }


### PR DESCRIPTION
Let the repository root declare `overlays:` (paths/globs) so a directory becomes a discovered overlay without needing its own `over.{toml,yaml,yml}` — the second of #113's sub-issues, building on #126/#131.

## What changed

- A repository root `over.toml` can declare `overlays: [{ path = "hosts/*" }]`; each matched directory is unioned with today's descriptor-glob discovery (`over.{toml,yaml,yml}`), deduplicated by resolved path.
- `Overlay::new` no longer requires a local descriptor at the overlay's own directory: a directory declared only via the root's `overlays:` key — or requested directly with zero descriptor anywhere in its ancestor chain — now resolves entirely from inherited config plus repository defaults (e.g. `target`).
- `over lint`'s own discovery does the same union, so root-declared overlays aren't invisible to lint checks.
- New ADR-018 documents the decision (amending ADR-002): expansion uses the `glob` crate (filesystem enumeration) rather than `globset` (path testing); a root-declared glob matching nothing is silently empty; nested `overlays:` declarations (a directory matched via `overlays:` declaring further `overlays:` of its own) are not supported.

Closes #127
