### PR TITLE
feat(overlays): add default_overlay selection for apply/unapply/status/diff/sync

### DIFF
--- a/docs/adr/019-default-overlay-selection-extends-templating-to-overlay-choice.md
+++ b/docs/adr/019-default-overlay-selection-extends-templating-to-overlay-choice.md
@@ -1,0 +1,90 @@
+# ADR-019: `default_overlay` extends templating to overlay selection, amending ADR-010
+
+**Status:** accepted
+
+## Context
+
+#113 asks for a repository root that can designate one overlay as the
+default target for commands accepting an optional `NAME` argument, e.g.:
+
+```toml
+default_overlay = "hosts/{{ machine.hostname }}"
+```
+
+Two existing decisions shape how this can be implemented:
+
+- ADR-010 says templating "stays scoped to those two path fields" — an
+  overlay's `target` and a `.link.toml` sidecar's `target`
+  (`exec::templates::render_string` against `exec::Context`). A
+  `default_overlay` value isn't a path at all; it's an overlay *name*
+  used to look one up via `Repository::get`.
+- `apply`/`unapply` (`src/cli/apply.rs`, `src/cli/unapply.rs`) already
+  have a `NAME` omitted → interactive `FuzzySelect` prompt fallback.
+  `status`/`diff`/`sync` (`src/cli/status.rs`, `diff.rs`, `sync.rs`)
+  instead treat an omitted `NAME` as "every overlay" — a different
+  contract from apply/unapply's, and one that a configured
+  `default_overlay` necessarily changes: reporting/syncing "just the
+  default" is the whole point of configuring one, but this narrows what
+  used to be a fan-out over every overlay.
+
+## Decision
+
+`default_overlay: Option<String>` is added to `RootConfig`
+(`src/overlays/repository.rs`), read through the existing one-shot,
+non-cascading `root_config()` helper — the same mechanism `format` and
+`overlays` already use (ADR-018). It is root-scoped only, never cascaded
+per-overlay, since "which overlay is the default" has no meaning at any
+other level of the descriptor chain.
+
+`Repository::default_overlay(&self, ctx: &exec::Context) -> Result<Option<Overlay>>`
+renders the raw string via `exec::templates::render_string` against the
+same `exec::Context` `Overlay::resolve_target` already uses — extending
+ADR-010's templating scope to this third field. Unlike `target`, the
+rendered string isn't used as a path: it's passed straight to
+`Repository::get`, so validation (does this overlay exist?) is folded
+into the same call. Absence is silent (`Ok(None)`, matching
+`preferred_format()`'s contract); a configured-but-broken value (bad
+template syntax, or a name that doesn't resolve to a real overlay) is a
+hard `Err`, never a silent fallback to another selection method — this
+mirrors how a bad `uses` entry already fails loudly rather than being
+skipped.
+
+CLI wiring keeps explicit CLI selection strictly first, per #113's ask:
+
+- `apply`/`unapply`: a new shared `cli::common::select_overlay` helper
+  (deduplicating the previously copy-pasted `Some(name) => repo.get /
+  None => FuzzySelect` block) tries `Repository::default_overlay` between
+  the explicit-name check and the interactive prompt.
+- `status`/`diff`/`sync`: an omitted `NAME` now resolves to
+  `Repository::default_overlay`'s result when one is configured,
+  otherwise falls back unchanged to today's "every overlay"
+  (`Repository::overlays()`). A new `-a`/`--all` flag (conflicting with
+  the positional `NAME`) is the explicit opt-out, always producing
+  "every overlay" regardless of a configured default.
+
+In all five commands, an explicit `NAME` short-circuits before
+`default_overlay` is even resolved — a misconfigured default never
+breaks an invocation that didn't need it.
+
+## Consequences
+
+Templating's blast radius (ADR-010's stated benefit: "at worst a path
+resolves wrong") now also covers overlay *selection*, not only path
+resolution — a broken `default_overlay` template can send commands to
+the wrong overlay or fail outright, not just place files somewhere
+unexpected. The scope is still narrow (one field, resolved once per
+invocation, always validated against `Repository::get` before use).
+
+`status`/`diff`/`sync` gain a real, user-visible behavior change: once
+`default_overlay` is configured, a bare `over status` (etc.) reports on
+one overlay instead of every overlay it did before. This is opt-in
+(nothing changes until a user adds `default_overlay` to their config) but
+is still a breaking change in effect for anyone who configures it
+expecting today's fan-out to keep working — `--all` is the escape hatch,
+and this is called out in `docs/configuration.md` and each command's
+usage doc.
+
+`over add` is deliberately not wired to `default_overlay` — its
+`NAME`-omitted prompt selects a *target to add files into*, a related but
+distinct concept from choosing which existing overlay a command acts on,
+and #128 doesn't ask for it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ by editing the old one. The history is the value.
 | [016](016-partial-file-managed-blocks.md) | Partial files are managed blocks injected via a sidecar, not a stem-plus-sidecar pair |
 | [017](017-materialization-rules-generalize-link-dirs.md) | Materialization rules generalize `link_dirs` into path/subtree overrides, amending ADR-006 |
 | [018](018-root-declared-overlays-extend-descriptor-discovery.md) | Root-declared `overlays:` paths extend descriptor-glob discovery, amending ADR-002 |
+| [019](019-default-overlay-selection-extends-templating-to-overlay-choice.md) | `default_overlay` extends templating to overlay selection, amending ADR-010 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,33 @@ This preference only governs what `over new` **writes**. Reading an overlay
 tolerates any of `.toml`/`.yaml`/`.yml` regardless of this setting — see
 [ADR-003](adr/003-overlay-descriptors-tolerate-any-format-on-read.md).
 
+### Default Overlay Selection
+
+The `default_overlay` field names the overlay commands should act on when
+no `NAME` argument is given. It's rendered as a template against the same
+context used for an overlay's own `target` field (`{{ machine.* }}`, etc.),
+so it can resolve to a different overlay per machine:
+
+```toml
+default_overlay = "hosts/{{ machine.hostname }}"
+```
+
+Selection priority (highest to lowest) for `over apply`/`over unapply`:
+
+1. An explicit `NAME` CLI argument.
+2. The resolved `default_overlay`.
+3. The existing interactive fuzzy-select prompt.
+
+For `over status`/`over diff`/`over sync`, omitting `NAME` normally reports
+on every overlay; once `default_overlay` is configured, it narrows an
+omitted `NAME` to just that overlay instead. Pass `-a`/`--all` to force
+"every overlay" regardless of a configured default.
+
+A `default_overlay` naming an overlay that doesn't exist, or that fails to
+render, is a hard error — never a silent fallback to another selection
+method. See
+[ADR-019](adr/019-default-overlay-selection-extends-templating-to-overlay-choice.md).
+
 ## Materialization Rules
 
 By default, every file in an overlay is symlinked individually and every

--- a/docs/usage/apply.md
+++ b/docs/usage/apply.md
@@ -8,7 +8,7 @@ root.
 Usage: over apply [OPTIONS] [NAME]
 
 Arguments:
-  [NAME]  Name of the overlay to apply
+  [NAME]  Name of the overlay to apply (uses default_overlay if configured)
 
 Options:
   -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
@@ -23,6 +23,9 @@ Options:
   -h, --help         Print help
 ```
 
+- When `NAME` is omitted, the repository's configured `default_overlay` (if
+  any) is used instead of prompting interactively — see
+  [Default Overlay Selection](../configuration.md#default-overlay-selection).
 - `--no-uses` applies only the named overlay, skipping every overlay it
   `uses`.
 - `--install` additionally runs the `install` section (see

--- a/docs/usage/diff.md
+++ b/docs/usage/diff.md
@@ -8,16 +8,22 @@ anything.
 Usage: over diff [OPTIONS] [NAME]
 
 Arguments:
-  [NAME]  Name of the overlay to check (all overlays if omitted)
+  [NAME]  Name of the overlay to check (default_overlay if configured, all overlays otherwise)
 
 Options:
   -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
   -r, --root <ROOT>  The target root directory (~)
   -d, --debug        Toggle debug traces
       --no-uses      Do not process uses
+  -a, --all          Diff every overlay, ignoring any configured default_overlay
   -v, --verbose      Toggle verbose output
   -h, --help         Print help
 ```
+
+When `NAME` is omitted, a configured `default_overlay` (see
+[Default Overlay Selection](../configuration.md#default-overlay-selection))
+narrows the report to just that overlay; pass `--all` to report on every
+overlay regardless.
 
 `diff` reuses the same `DesiredTree`/`Plan` reconciliation model as
 [`over status`](status.md), but goes one step further: instead of just

--- a/docs/usage/status.md
+++ b/docs/usage/status.md
@@ -6,16 +6,22 @@ Get the current repository/directory overlays status.
 Usage: over status [OPTIONS] [NAME]
 
 Arguments:
-  [NAME]  Name of the overlay to check (all overlays if omitted)
+  [NAME]  Name of the overlay to check (default_overlay if configured, all overlays otherwise)
 
 Options:
   -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
   -r, --root <ROOT>  The target root directory (~)
   -d, --debug        Toggle debug traces
       --no-uses      Do not process uses
+  -a, --all          Check every overlay, ignoring any configured default_overlay
   -v, --verbose      Toggle verbose output
   -h, --help         Print help
 ```
+
+When `NAME` is omitted, a configured `default_overlay` (see
+[Default Overlay Selection](../configuration.md#default-overlay-selection))
+narrows the report to just that overlay; pass `--all` to report on every
+overlay regardless.
 
 Each entry is classified into one of 8 statuses (referenced by `over diff`
 and `over unapply` too):

--- a/docs/usage/sync.md
+++ b/docs/usage/sync.md
@@ -8,21 +8,27 @@ the checkout back upstream.
 Usage: over sync [OPTIONS] [NAME]
 
 Arguments:
-  [NAME]  Name of the overlay to sync (all overlays if omitted)
+  [NAME]  Name of the overlay to sync (default_overlay if configured, all overlays otherwise)
 
 Options:
   -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
   -r, --root <ROOT>  The target root directory (~)
   -d, --debug        Toggle debug traces
       --no-uses      Do not process uses
-      --pull-only    Only pull upstream changes into the checkout
+  -a, --all          Sync every overlay, ignoring any configured default_overlay
   -v, --verbose      Toggle verbose output
+      --pull-only    Only pull upstream changes into the checkout
       --push-only    Only push local commits to the overlay source
       --continue     Re-attempt a sync after resolving conflicts manually
       --abort        Abort an in-progress merge left by a conflicted sync
   -n, --dry-run      Report what would happen without syncing
   -h, --help         Print help
 ```
+
+When `NAME` is omitted, a configured `default_overlay` (see
+[Default Overlay Selection](../configuration.md#default-overlay-selection))
+narrows the sync to just that overlay; pass `--all` to sync every overlay
+regardless.
 
 ## Scope: the overlay's root git entry only
 

--- a/docs/usage/unapply.md
+++ b/docs/usage/unapply.md
@@ -9,7 +9,7 @@ apply` afterwards fully restores everything.
 Usage: over unapply [OPTIONS] [NAME]
 
 Arguments:
-  [NAME]  Name of the overlay to unapply
+  [NAME]  Name of the overlay to unapply (uses default_overlay if configured)
 
 Options:
   -H, --home <HOME>  Configuration and overlays root [env: OVER_HOME]
@@ -19,6 +19,10 @@ Options:
   -v, --verbose      Toggle verbose output
   -h, --help         Print help
 ```
+
+When `NAME` is omitted, the repository's configured `default_overlay` (if
+any) is used instead of prompting interactively — see
+[Default Overlay Selection](../configuration.md#default-overlay-selection).
 
 ## What it does
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -2,19 +2,18 @@ use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
 use clap::Args;
-use dialoguer::FuzzySelect;
 use dirs::home_dir;
 
 use crate::actions;
 use crate::cli::CLI;
+use crate::cli::common::select_overlay;
 use crate::exec::Context;
 use crate::overlays::Repository;
 use crate::ui;
-use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 #[derive(Args, Debug)]
 pub struct Params {
-    #[clap(help = "Name of the overlay to apply")]
+    #[clap(help = "Name of the overlay to apply (uses default_overlay if configured)")]
     name: Option<String>,
 
     #[clap(short, long, help = "The target root directory (~)")]
@@ -42,29 +41,16 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
     }
 
     let home = cli.resolve_home()?;
-    let repo = Repository::new(home.clone());
+    let repo = Repository::new(home);
     if cli.debug {
         tracing::debug!(?repo, "repository");
     }
-    let overlay = match &args.name {
-        Some(name) => repo.get(name)?,
-        None => {
-            let overlays = repo.overlays()?;
-            if overlays.is_empty() {
-                return Err(anyhow!("no overlays found in repository"));
-            }
-            let selection = FuzzySelect::with_theme(&DialogTheme::default())
-                .with_prompt("Choose the overlay to apply")
-                .default(0)
-                .items(&overlays[..])
-                .interact()
-                .map_err(|e| anyhow!("overlay selection cancelled: {}", e))?;
-            overlays[selection].clone()
-        }
-    };
-    if cli.debug {
-        tracing::debug!(?overlay, "resolved overlay");
-    }
+
+    let root = args
+        .root
+        .clone()
+        .or_else(home_dir)
+        .ok_or_else(|| anyhow!("could not determine home directory"))?;
 
     let ctx = Context::builder()
         .dry_run(args.dry_run)
@@ -73,15 +59,21 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         .force(args.force)
         .no_prompt(args.no_prompt)
         .no_uses(args.no_uses)
-        .root(
-            args.root
-                .clone()
-                .or_else(home_dir)
-                .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?,
-        )
+        .root(root)
         .repository(repo)
-        .overlay(overlay.clone())
         .build();
+
+    let overlay = select_overlay(
+        &ctx.repository,
+        &ctx,
+        args.name.as_deref(),
+        "Choose the overlay to apply",
+    )?;
+    if cli.debug {
+        tracing::debug!(?overlay, "resolved overlay");
+    }
+
+    let ctx = ctx.with_overlay(overlay.clone());
 
     if args.install {
         actions::install::install(&ctx, &overlay).await?;

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -2,7 +2,12 @@ use std::env::current_dir;
 use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
+use dialoguer::FuzzySelect;
 use dirs::home_dir;
+
+use crate::exec;
+use crate::overlays::{Overlay, Repository};
+use crate::ui::style::DialogTheme;
 
 /// Check whether a string contains glob metacharacters.
 pub fn is_glob_pattern(s: &str) -> bool {
@@ -65,6 +70,36 @@ pub fn resolve_inputs(inputs: &[String]) -> Result<Vec<PathBuf>> {
     }
 
     Ok(resolved)
+}
+
+/// Resolve which overlay a single-`NAME`-argument command (`apply`,
+/// `unapply`) should act on: an explicit CLI name always wins; if
+/// omitted, the repository's templated `default_overlay` is tried next
+/// (#128); only if neither applies does this fall back to the existing
+/// interactive `FuzzySelect` prompt.
+pub fn select_overlay(
+    repo: &Repository,
+    ctx: &exec::Context,
+    name: Option<&str>,
+    prompt: &str,
+) -> Result<Overlay> {
+    if let Some(name) = name {
+        return repo.get(name);
+    }
+    if let Some(overlay) = repo.default_overlay(ctx)? {
+        return Ok(overlay);
+    }
+    let overlays = repo.overlays()?;
+    if overlays.is_empty() {
+        return Err(anyhow!("no overlays found in repository"));
+    }
+    let selection = FuzzySelect::with_theme(&DialogTheme::default())
+        .with_prompt(prompt)
+        .default(0)
+        .items(&overlays[..])
+        .interact()
+        .map_err(|e| anyhow!("overlay selection cancelled: {}", e))?;
+    Ok(overlays[selection].clone())
 }
 
 #[cfg(test)]
@@ -154,6 +189,70 @@ mod tests {
         let td = TempDir::new().unwrap();
         let pattern = format!("{}/*.nonexistent", td.path().display());
         let result = resolve_inputs(&[pattern]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn select_overlay_explicit_name_wins_over_default() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"default-one\"",
+        )
+        .unwrap();
+        for name in ["default-one", "explicit-one"] {
+            let ov = tmp.path().join(name);
+            std::fs::create_dir_all(&ov).unwrap();
+            std::fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        let overlay =
+            select_overlay(&repo, &ctx, Some("explicit-one"), "Choose an overlay").unwrap();
+        assert_eq!(overlay.name, "explicit-one");
+    }
+
+    #[test]
+    fn select_overlay_uses_default_when_name_omitted() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"myoverlay\"",
+        )
+        .unwrap();
+        let ov = tmp.path().join("myoverlay");
+        std::fs::create_dir_all(&ov).unwrap();
+        std::fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        let overlay = select_overlay(&repo, &ctx, None, "Choose an overlay").unwrap();
+        assert_eq!(overlay.name, "myoverlay");
+    }
+
+    #[test]
+    fn select_overlay_no_default_and_empty_repo_errors() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        let result = select_overlay(&repo, &ctx, None, "Choose an overlay");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn select_overlay_misconfigured_default_errors_without_prompting() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"does-not-exist\"",
+        )
+        .unwrap();
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        // Must error, not silently fall through to an interactive prompt
+        // that would hang the test suite waiting on stdin.
+        let result = select_overlay(&repo, &ctx, None, "Choose an overlay");
         assert!(result.is_err());
     }
 }

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -15,7 +15,9 @@ use crate::utils::short_path;
 
 #[derive(Args, Debug)]
 pub struct Params {
-    #[clap(help = "Name of the overlay to check (all overlays if omitted)")]
+    #[clap(
+        help = "Name of the overlay to check (default_overlay if configured, all overlays otherwise)"
+    )]
     name: Option<String>,
 
     #[clap(short, long, help = "The target root directory (~)")]
@@ -23,6 +25,14 @@ pub struct Params {
 
     #[clap(long, help = "Do not process uses")]
     no_uses: bool,
+
+    #[clap(
+        long,
+        short,
+        conflicts_with = "name",
+        help = "Diff every overlay, ignoring any configured default_overlay"
+    )]
+    all: bool,
 }
 
 pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
@@ -38,9 +48,19 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         .or_else(home_dir)
         .ok_or_else(|| anyhow!("could not determine home directory"))?;
 
-    let overlays = match &args.name {
-        Some(name) => vec![repo.get(name)?],
-        None => repo.overlays()?,
+    let overlays = match (&args.name, args.all) {
+        (Some(name), _) => vec![repo.get(name)?],
+        (None, true) => repo.overlays()?,
+        (None, false) => {
+            let ctx = Context::builder()
+                .root(root.clone())
+                .repository(repo.clone())
+                .build();
+            match repo.default_overlay(&ctx)? {
+                Some(overlay) => vec![overlay],
+                None => repo.overlays()?,
+            }
+        }
     };
 
     if overlays.is_empty() {
@@ -118,6 +138,7 @@ mod tests {
             name: name.map(String::from),
             root: Some(root),
             no_uses: false,
+            all: false,
         }
     }
 
@@ -205,5 +226,63 @@ mod tests {
         let cli = make_cli(tmp.path().to_path_buf());
         let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
         assert!(result.is_ok());
+    }
+
+    /// An omitted `NAME` narrows to just the configured `default_overlay`
+    /// instead of reporting on every overlay (#128).
+    #[tokio::test]
+    async fn diff_default_overlay_narrows_omitted_name() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("over.toml"), "default_overlay = \"alpha\"").unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["alpha", "beta"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    /// `--all` recovers today's "every overlay" behavior even when a
+    /// `default_overlay` is configured (#128).
+    #[tokio::test]
+    async fn diff_all_flag_overrides_configured_default() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("over.toml"), "default_overlay = \"alpha\"").unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["alpha", "beta"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let mut p = params(None, root.path().to_path_buf());
+        p.all = true;
+        let result = execute(&cli, &p).await;
+        assert!(result.is_ok());
+    }
+
+    /// A `default_overlay` naming a nonexistent overlay is a hard error,
+    /// not a silent fallback to "all overlays" (#128).
+    #[tokio::test]
+    async fn diff_misconfigured_default_overlay_errors() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"does-not-exist\"",
+        )
+        .unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_err());
     }
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -15,7 +15,9 @@ use crate::utils::short_path;
 
 #[derive(Args, Debug)]
 pub struct Params {
-    #[clap(help = "Name of the overlay to check (all overlays if omitted)")]
+    #[clap(
+        help = "Name of the overlay to check (default_overlay if configured, all overlays otherwise)"
+    )]
     name: Option<String>,
 
     #[clap(short, long, help = "The target root directory (~)")]
@@ -23,6 +25,14 @@ pub struct Params {
 
     #[clap(long, help = "Do not process uses")]
     no_uses: bool,
+
+    #[clap(
+        long,
+        short,
+        conflicts_with = "name",
+        help = "Check every overlay, ignoring any configured default_overlay"
+    )]
+    all: bool,
 }
 
 pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
@@ -38,9 +48,19 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         .or_else(home_dir)
         .ok_or_else(|| anyhow!("could not determine home directory"))?;
 
-    let overlays = match &args.name {
-        Some(name) => vec![repo.get(name)?],
-        None => repo.overlays()?,
+    let overlays = match (&args.name, args.all) {
+        (Some(name), _) => vec![repo.get(name)?],
+        (None, true) => repo.overlays()?,
+        (None, false) => {
+            let ctx = Context::builder()
+                .root(root.clone())
+                .repository(repo.clone())
+                .build();
+            match repo.default_overlay(&ctx)? {
+                Some(overlay) => vec![overlay],
+                None => repo.overlays()?,
+            }
+        }
     };
 
     if overlays.is_empty() {
@@ -115,6 +135,7 @@ mod tests {
             name: name.map(String::from),
             root: Some(root),
             no_uses: false,
+            all: false,
         }
     }
 
@@ -202,5 +223,63 @@ mod tests {
         let cli = make_cli(tmp.path().to_path_buf());
         let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
         assert!(result.is_ok());
+    }
+
+    /// An omitted `NAME` narrows to just the configured `default_overlay`
+    /// instead of reporting on every overlay (#128).
+    #[tokio::test]
+    async fn status_default_overlay_narrows_omitted_name() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("over.toml"), "default_overlay = \"alpha\"").unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["alpha", "beta"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    /// `--all` recovers today's "every overlay" behavior even when a
+    /// `default_overlay` is configured (#128).
+    #[tokio::test]
+    async fn status_all_flag_overrides_configured_default() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("over.toml"), "default_overlay = \"alpha\"").unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["alpha", "beta"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let mut p = params(None, root.path().to_path_buf());
+        p.all = true;
+        let result = execute(&cli, &p).await;
+        assert!(result.is_ok());
+    }
+
+    /// A `default_overlay` naming a nonexistent overlay is a hard error,
+    /// not a silent fallback to "all overlays" (#128).
+    #[tokio::test]
+    async fn status_misconfigured_default_overlay_errors() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"does-not-exist\"",
+        )
+        .unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_err());
     }
 }

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -15,7 +15,9 @@ use crate::utils::short_path;
 
 #[derive(Args, Debug)]
 pub struct Params {
-    #[clap(help = "Name of the overlay to sync (all overlays if omitted)")]
+    #[clap(
+        help = "Name of the overlay to sync (default_overlay if configured, all overlays otherwise)"
+    )]
     name: Option<String>,
 
     #[clap(short, long, help = "The target root directory (~)")]
@@ -23,6 +25,14 @@ pub struct Params {
 
     #[clap(long, help = "Do not process uses")]
     no_uses: bool,
+
+    #[clap(
+        long,
+        short,
+        conflicts_with = "name",
+        help = "Sync every overlay, ignoring any configured default_overlay"
+    )]
+    all: bool,
 
     #[clap(
         long,
@@ -81,9 +91,19 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         .or_else(home_dir)
         .ok_or_else(|| anyhow!("could not determine home directory"))?;
 
-    let overlays = match &args.name {
-        Some(name) => vec![repo.get(name)?],
-        None => repo.overlays()?,
+    let overlays = match (&args.name, args.all) {
+        (Some(name), _) => vec![repo.get(name)?],
+        (None, true) => repo.overlays()?,
+        (None, false) => {
+            let ctx = Context::builder()
+                .root(root.clone())
+                .repository(repo.clone())
+                .build();
+            match repo.default_overlay(&ctx)? {
+                Some(overlay) => vec![overlay],
+                None => repo.overlays()?,
+            }
+        }
     };
 
     if overlays.is_empty() {
@@ -217,6 +237,7 @@ mod tests {
             name: name.map(String::from),
             root: Some(root),
             no_uses: false,
+            all: false,
             pull_only: false,
             push_only: false,
             continue_: false,
@@ -309,6 +330,64 @@ mod tests {
             &params(Some("does-not-exist"), root.path().to_path_buf()),
         )
         .await;
+        assert!(result.is_err());
+    }
+
+    /// An omitted `NAME` narrows to just the configured `default_overlay`
+    /// instead of syncing every overlay (#128).
+    #[tokio::test]
+    async fn sync_default_overlay_narrows_omitted_name() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("over.toml"), "default_overlay = \"plain\"").unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["plain", "other"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
+        assert!(result.is_ok());
+    }
+
+    /// `--all` recovers today's "every overlay" behavior even when a
+    /// `default_overlay` is configured (#128).
+    #[tokio::test]
+    async fn sync_all_flag_overrides_configured_default() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("over.toml"), "default_overlay = \"plain\"").unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+        for name in ["plain", "other"] {
+            let ov = tmp.path().join(name);
+            fs::create_dir_all(&ov).unwrap();
+            fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+        }
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let mut p = params(None, root.path().to_path_buf());
+        p.all = true;
+        let result = execute(&cli, &p).await;
+        assert!(result.is_ok());
+    }
+
+    /// A `default_overlay` naming a nonexistent overlay is a hard error,
+    /// not a silent fallback to "all overlays" (#128).
+    #[tokio::test]
+    async fn sync_misconfigured_default_overlay_errors() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"does-not-exist\"",
+        )
+        .unwrap();
+        let root = tmp.child("root");
+        root.create_dir_all().unwrap();
+
+        let cli = make_cli(tmp.path().to_path_buf());
+        let result = execute(&cli, &params(None, root.path().to_path_buf())).await;
         assert!(result.is_err());
     }
 

--- a/src/cli/unapply.rs
+++ b/src/cli/unapply.rs
@@ -2,22 +2,21 @@ use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
 use clap::Args;
-use dialoguer::FuzzySelect;
 use dirs::home_dir;
 
 use crate::cli::CLI;
+use crate::cli::common::select_overlay;
 use crate::desired::DesiredTree;
 use crate::exec::Context;
 use crate::overlays::Repository;
 use crate::ui;
-use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
 use crate::unapply::{Outcome, Report};
 use crate::utils::short_path;
 
 #[derive(Args, Debug)]
 pub struct Params {
-    #[clap(help = "Name of the overlay to unapply")]
+    #[clap(help = "Name of the overlay to unapply (uses default_overlay if configured)")]
     name: Option<String>,
 
     #[clap(short, long, help = "The target root directory (~)")]
@@ -38,26 +37,6 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
 
     let home = cli.resolve_home()?;
     let repo = Repository::new(home);
-    let overlay = match &args.name {
-        Some(name) => repo.get(name)?,
-        None => {
-            let overlays = repo.overlays()?;
-            if overlays.is_empty() {
-                return Err(anyhow!("no overlays found in repository"));
-            }
-            let selection = FuzzySelect::with_theme(&DialogTheme::default())
-                .with_prompt("Choose the overlay to unapply")
-                .default(0)
-                .items(&overlays[..])
-                .interact()
-                .map_err(|e| anyhow!("overlay selection cancelled: {}", e))?;
-            overlays[selection].clone()
-        }
-    };
-    if cli.debug {
-        tracing::debug!(?overlay, "resolved overlay");
-    }
-
     let root = args
         .root
         .clone()
@@ -70,8 +49,19 @@ pub async fn execute(cli: &CLI, args: &Params) -> Result<()> {
         .verbose(cli.verbose)
         .root(root)
         .repository(repo)
-        .overlay(overlay.clone())
         .build();
+
+    let overlay = select_overlay(
+        &ctx.repository,
+        &ctx,
+        args.name.as_deref(),
+        "Choose the overlay to unapply",
+    )?;
+    if cli.debug {
+        tracing::debug!(?overlay, "resolved overlay");
+    }
+
+    let ctx = ctx.with_overlay(overlay.clone());
     let target = overlay.resolve_target(&ctx)?;
     let ctx = ctx.with_resolved_overlay(overlay.name.clone(), target.to_string_lossy().to_string());
 

--- a/src/overlays/repository.rs
+++ b/src/overlays/repository.rs
@@ -10,6 +10,7 @@ use anyhow::{Context as _, Result};
 use super::discovery::{OverlayDeclaration, resolve_declared_dirs};
 use super::overlay::Overlay;
 use super::{BASENAME, Format, GLOB_PATTERN};
+use crate::exec;
 
 /// Manage all overlays
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -108,6 +109,30 @@ impl Repository {
         resolve_declared_dirs(&self.root, &declarations)
     }
 
+    /// Resolve the repository root's configured `default_overlay`, if any
+    /// (#113/#128), rendering it as a template against `ctx` — the same
+    /// `exec::Context` used for `target` (see `Overlay::resolve_target`),
+    /// so `{{ machine.hostname }}` etc. can select a machine-specific
+    /// overlay — then validating the rendered name actually exists.
+    ///
+    /// `Ok(None)` means no `default_overlay` is configured: silent,
+    /// matching `preferred_format()`'s absent-means-opt-out contract.
+    /// `Err` means it *is* configured but broken (bad template, or names
+    /// an overlay that doesn't exist): a misconfigured default must never
+    /// silently fall through to another selection method (never silence
+    /// errors, AGENTS.md).
+    pub fn default_overlay(&self, ctx: &exec::Context) -> Result<Option<Overlay>> {
+        let Some(raw) = self.root_config().default_overlay else {
+            return Ok(None);
+        };
+        let name = exec::templates::render_string(&raw, ctx)
+            .with_context(|| format!("failed to render default_overlay template '{raw}'"))?;
+        let overlay = self
+            .get(&name)
+            .with_context(|| format!("configured default_overlay '{name}' not found"))?;
+        Ok(Some(overlay))
+    }
+
     /// One-shot, non-cascading read of the repository root's own
     /// descriptor. Unlike `Overlay::new`'s ancestor-chain cascade
     /// (ADR-002), this reads *only* `self.root`'s file: `format` and
@@ -133,6 +158,7 @@ impl Repository {
 struct RootConfig {
     format: Option<Format>,
     overlays: Option<Vec<OverlayDeclaration>>,
+    default_overlay: Option<String>,
 }
 
 #[cfg(test)]
@@ -286,6 +312,87 @@ mod tests {
         assert_eq!(overlays.len(), 1, "should not produce a duplicate entry");
         assert_eq!(overlays[0].name, "shared");
         assert_eq!(overlays[0].target, "~/shared");
+    }
+
+    #[test]
+    fn default_overlay_returns_none_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        assert!(repo.default_overlay(&ctx).unwrap().is_none());
+    }
+
+    #[test]
+    fn default_overlay_resolves_static_name() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"myoverlay\"",
+        )
+        .unwrap();
+        let ov = tmp.path().join("myoverlay");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        let overlay = repo.default_overlay(&ctx).unwrap().unwrap();
+        assert_eq!(overlay.name, "myoverlay");
+    }
+
+    #[test]
+    fn default_overlay_renders_machine_template() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"hosts/{{ machine.hostname }}\"",
+        )
+        .unwrap();
+        let ov = tmp.path().join("hosts/laptop");
+        fs::create_dir_all(&ov).unwrap();
+        fs::write(ov.join("over.toml"), "target = \"~\"").unwrap();
+
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let machine = exec::MachineInfo {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            hostname: "laptop".to_string(),
+            username: "tester".to_string(),
+            distro: None,
+            distro_id: None,
+        };
+        let ctx = exec::Context::builder()
+            .repository(repo.clone())
+            .machine(machine)
+            .build();
+        let overlay = repo.default_overlay(&ctx).unwrap().unwrap();
+        assert_eq!(overlay.name, "hosts/laptop");
+    }
+
+    #[test]
+    fn default_overlay_errors_when_named_overlay_missing() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"does-not-exist\"",
+        )
+        .unwrap();
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        assert!(repo.default_overlay(&ctx).is_err());
+    }
+
+    #[test]
+    fn default_overlay_errors_on_invalid_template_syntax() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("over.toml"),
+            "default_overlay = \"{{ invalid\"",
+        )
+        .unwrap();
+        let repo = Repository::new(tmp.path().to_path_buf());
+        let ctx = exec::Context::builder().repository(repo.clone()).build();
+        assert!(repo.default_overlay(&ctx).is_err());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::{error::Error, fs};
 
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use tempfile::TempDir;
 
@@ -105,6 +106,61 @@ fn apply_without_name_empty_repo_fails() -> TestResult {
     cmd.assert()
         .failure()
         .stderr(contains("no overlays found in repository"));
+    Ok(())
+}
+
+/// A configured `default_overlay` (#128) is used without prompting when
+/// `NAME` is omitted.
+#[test]
+fn apply_without_name_uses_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(contains("dev"));
+    Ok(())
+}
+
+/// An explicit `NAME` always overrides a configured `default_overlay`
+/// (#128).
+#[test]
+fn apply_explicit_name_overrides_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "other", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(contains("other"));
+    Ok(())
+}
+
+/// A `default_overlay` naming a nonexistent overlay is a hard error, not
+/// a silent fallback to the interactive prompt (#128).
+#[test]
+fn apply_without_name_misconfigured_default_overlay_fails() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(
+        repo.path().join("over.toml"),
+        b"default_overlay = \"does-not-exist\"",
+    )?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["apply", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(contains("default_overlay"));
     Ok(())
 }
 
@@ -414,6 +470,52 @@ fn status_empty_repository_reports_no_overlays() -> TestResult {
     Ok(())
 }
 
+/// A configured `default_overlay` (#128) narrows an omitted `NAME` to
+/// just that overlay instead of reporting on every overlay.
+#[test]
+fn status_without_name_narrows_to_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["status", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"))
+        .stdout(contains("other").not());
+    Ok(())
+}
+
+/// `--all` recovers "every overlay" even with a `default_overlay`
+/// configured (#128).
+#[test]
+fn status_all_flag_overrides_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["status", "--all", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"))
+        .stdout(contains("other"));
+    Ok(())
+}
+
 // ── diff integration tests ───────────────────────────────────────────────
 
 #[test]
@@ -522,6 +624,52 @@ fn diff_empty_repository_reports_no_overlays() -> TestResult {
     Ok(())
 }
 
+/// A configured `default_overlay` (#128) narrows an omitted `NAME` to
+/// just that overlay instead of reporting on every overlay.
+#[test]
+fn diff_without_name_narrows_to_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["diff", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"))
+        .stdout(contains("other").not());
+    Ok(())
+}
+
+/// `--all` recovers "every overlay" even with a `default_overlay`
+/// configured (#128).
+#[test]
+fn diff_all_flag_overrides_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["diff", "--all", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"))
+        .stdout(contains("other"));
+    Ok(())
+}
+
 // ── sync integration tests ────────────────────────────────────────────────
 
 fn git(dir: &Path, args: &[&str]) {
@@ -588,6 +736,54 @@ fn sync_empty_repository_reports_no_overlays() -> TestResult {
         .assert()
         .success()
         .stdout(contains("No overlays found"));
+    Ok(())
+}
+
+/// A configured `default_overlay` (#128) narrows an omitted `NAME` to
+/// just that overlay instead of syncing every overlay. `--verbose` makes
+/// a git-entry-less overlay still print its name, so the assertion can
+/// tell which overlay(s) were actually visited.
+#[test]
+fn sync_without_name_narrows_to_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["sync", "--verbose", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"))
+        .stdout(contains("other").not());
+    Ok(())
+}
+
+/// `--all` recovers "every overlay" even with a `default_overlay`
+/// configured (#128).
+#[test]
+fn sync_all_flag_overrides_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let other = repo.path().join("other");
+    fs::create_dir_all(&other)?;
+    fs::write(other.join("over.toml"), b"target = \"~\"")?;
+    let root = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["sync", "--all", "--verbose", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"))
+        .stdout(contains("other"));
     Ok(())
 }
 
@@ -756,6 +952,24 @@ fn unapply_unknown_overlay_fails() -> TestResult {
         .args(["unapply", "does-not-exist"])
         .assert()
         .failure();
+    Ok(())
+}
+
+/// A configured `default_overlay` (#128) is used without prompting when
+/// `NAME` is omitted.
+#[test]
+fn unapply_without_name_uses_configured_default_overlay() -> TestResult {
+    let repo = setup_overlay_repo();
+    fs::write(repo.path().join("over.toml"), b"default_overlay = \"dev\"")?;
+    let root = TempDir::new()?;
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(repo.path())
+        .args(["unapply", "--root"])
+        .arg(root.path())
+        .assert()
+        .success()
+        .stdout(contains("dev"));
     Ok(())
 }
 


### PR DESCRIPTION
Closes #128

Adds a `default_overlay` field to the repository root config, letting a single overlay be designated as the target for commands that accept an optional `NAME` argument. It's templated with the same context used for an overlay's `target` field, so it can resolve per-machine:

```toml
default_overlay = "hosts/{{ machine.hostname }}"
```

**Behavior:**
- `over apply` / `over unapply`: when `NAME` is omitted, the configured default is used instead of the interactive fuzzy-select prompt.
- `over status` / `over diff` / `over sync`: an omitted `NAME` now narrows to just the default overlay instead of every overlay. A new `-a`/`--all` flag recovers the previous "every overlay" behavior regardless of a configured default.
- An explicit `NAME` argument always overrides the configured default.
- A `default_overlay` naming a nonexistent overlay, or with a broken template, is a hard error — never a silent fallback.

Nothing changes for repositories that don't configure `default_overlay`.

See [ADR-019](docs/adr/019-default-overlay-selection-extends-templating-to-overlay-choice.md) for the design rationale.
