### PR TITLE
feat(plan): reconcile materialization rule changes as explicit migrations

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -37,6 +37,7 @@ use anyhow::{Context as _, Result};
 
 use crate::actions::partial::{self, BlockState};
 use crate::desired::{DesiredEntry, DesiredTree, MaterializationIntent};
+use crate::plan::actual;
 use crate::plan::{ActualState, Operation, Plan};
 use crate::status::{self, Status};
 use crate::ui::{emojis, style};
@@ -196,6 +197,13 @@ fn classify_fs(entry: &DesiredEntry, operation: &Operation) -> Result<Change> {
             _ => Change::Unchanged,
         }),
         Operation::Conflict { current } => classify_conflict(entry, current),
+        // A pending rule-change migration (#129, blocked or not): a
+        // fundamentally different kind of entity occupies the target than
+        // what's currently desired — exactly what `Unexpected` already
+        // means, no meaningful line diff to show either way.
+        Operation::Migrate { .. } => Ok(Change::Unexpected {
+            actual: actual::inspect(&entry.target)?,
+        }),
         Operation::Deferred => unreachable!(
             "only Checkout entries ever classify as Deferred, and those are \
              routed to classify_checkout before reaching classify_fs"
@@ -713,6 +721,34 @@ mod tests {
         };
         let change = classify_fs(&entry, &Operation::Noop).unwrap();
         assert!(matches!(change, Change::Broken));
+    }
+
+    #[test]
+    fn migrate_operation_is_unexpected_with_current_actual_state() {
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        let entry = DesiredEntry {
+            target: target.clone(),
+            provenance: crate::desired::Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: std::path::PathBuf::from("/repo/ov"),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: std::path::PathBuf::from("/repo/ov"),
+                link_type: LinkType::Soft,
+            },
+        };
+        let operation = Operation::Migrate {
+            from: MaterializationIntent::Checkout,
+            to: entry.intent.clone(),
+            blocked: None,
+        };
+        let change = classify_fs(&entry, &operation).unwrap();
+        match change {
+            Change::Unexpected { actual } => assert_eq!(actual, ActualState::Directory),
+            other => panic!("expected Unexpected, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/materialize/checkout.rs
+++ b/src/materialize/checkout.rs
@@ -16,12 +16,17 @@
 //! This materializer's `materialize` is therefore a correctness fallback
 //! (any other caller of `Plan::execute`, e.g. tests), not the primary path.
 
+use std::path::Path;
+
 use anyhow::Result;
 use async_trait::async_trait;
+use tokio::task::spawn_blocking;
 
 use crate::actions;
+use crate::actions::symlink::LinkType;
 use crate::desired::{DesiredEntry, MaterializationIntent, Provenance};
 use crate::exec::{Action, Ctx};
+use crate::plan::actual::{self, ActualState};
 use crate::plan::{Operation, PlanStep};
 use crate::status::{self, Status};
 
@@ -30,6 +35,28 @@ use super::Materializer;
 /// Owns [`MaterializationIntent::Checkout`]. See the module doc for the
 /// scope split with `over sync`.
 pub struct CheckoutMaterializer;
+
+/// Best-effort reconstruction of what a stale symlink used to materialize
+/// (#129), for [`Operation::Migrate`]'s `from` field — used only for
+/// `Display`/diagnostics, never for execution (removing a symlink doesn't
+/// need to know which kind it was). A directory-level symlink's target is
+/// itself a directory; anything else (a file, or a dangling link whose
+/// target no longer exists) is assumed file-level. Rule-driven symlinks
+/// are always soft (#126: `walk_overlay_tree` never resolves a `rules`/
+/// `defaults`/`link_dirs` match to a hard link).
+fn reconstruct_symlink_intent(points_to: &Path) -> MaterializationIntent {
+    if points_to.is_dir() {
+        MaterializationIntent::SymlinkDirectory {
+            source: points_to.to_path_buf(),
+            link_type: LinkType::Soft,
+        }
+    } else {
+        MaterializationIntent::SymlinkFile {
+            source: points_to.to_path_buf(),
+            link_type: LinkType::Soft,
+        }
+    }
+}
 
 #[async_trait(?Send)]
 impl Materializer for CheckoutMaterializer {
@@ -41,6 +68,22 @@ impl Materializer for CheckoutMaterializer {
     /// clean/dirty/ahead/behind/conflict detection — the same read-only
     /// inspection `over status`/`over diff` already rely on.
     fn classify(&self, entry: &DesiredEntry) -> Result<Operation> {
+        // A stale symlink here (left by a `SymlinkFile`/`SymlinkDirectory`
+        // rule that used to resolve this path, #126) would otherwise make
+        // `status::git::inspect`'s `Repository::open` fail below ->
+        // `Status::Broken` -> collapse to `Noop`, silently stuck forever
+        // (the exact bug #129 fixes). Check `ActualState` first so a
+        // `symlink -> checkout` rule-change migration is detected instead.
+        // Always safe: removing a symlink never touches overlay source
+        // content, unlike a git checkout's own uncommitted work.
+        if let ActualState::Symlink { points_to } = actual::inspect(&entry.target)? {
+            return Ok(Operation::Migrate {
+                from: reconstruct_symlink_intent(&points_to),
+                to: MaterializationIntent::Checkout,
+                blocked: None,
+            });
+        }
+
         Ok(match status::git::inspect(entry)? {
             Status::Missing => Operation::Create,
             // Applied/Modified/Ahead/Behind/Diverged/Broken/Conflict all
@@ -57,9 +100,11 @@ impl Materializer for CheckoutMaterializer {
         })
     }
 
-    /// Only ever invoked for `Operation::Create` (`Plan::execute` skips
-    /// `Noop`/`Deferred`) — i.e. only when the repository doesn't exist
-    /// yet. Delegates to the same, unchanged `EnsureGitRepository` action
+    /// Invoked for `Operation::Create` (repository doesn't exist yet) and
+    /// for an unblocked `Operation::Migrate` (#129: a stale symlink sits
+    /// where a checkout is now desired) — the latter first removes the
+    /// symlink, then falls through to the same clone logic. Delegates to
+    /// the same, unchanged `EnsureGitRepository` action
     /// `actions::git::clone_repositories` already runs per entry.
     async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()> {
         let Provenance::Git {
@@ -71,6 +116,17 @@ impl Materializer for CheckoutMaterializer {
                  (see desired::tree::collect_own_entries)"
             );
         };
+
+        // `blocked: Some(_)` never occurs for a `symlink -> checkout`
+        // migration (removing a symlink is always safe, `classify` never
+        // constructs one) — `blocked: None` is spelled out explicitly
+        // anyway so this stays correct if that ever changes, rather than
+        // silently cloning over whatever's still there.
+        if matches!(step.operation, Operation::Migrate { blocked: None, .. }) && !ctx.dry_run {
+            let target = step.entry.target.clone();
+            spawn_blocking(move || actions::fs::remove_target(&target)).await??;
+        }
+
         actions::git::EnsureGitRepository::new(
             step.entry.target.clone(),
             (**config).clone(),
@@ -188,6 +244,99 @@ mod tests {
         dir.create_dir_all().unwrap();
         let e = entry(dir.path().to_path_buf(), git_config(""));
         assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    fn classify_stale_symlink_file_is_migrate_to_checkout() {
+        // A `SymlinkFile` rule used to resolve this path; the rule changed
+        // to `overlay.git` (#129) — the stale symlink must be detected as
+        // a migration, never silently stuck as `Noop`.
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let source = td.child("source.txt");
+        source.write_str("hello").unwrap();
+        let target = td.path().join("target");
+        symlink::symlink_file(source.path(), &target).unwrap();
+
+        let e = entry(target, git_config(""));
+        match m.classify(&e).unwrap() {
+            Operation::Migrate { from, to, blocked } => {
+                assert!(matches!(from, MaterializationIntent::SymlinkFile { .. }));
+                assert!(matches!(to, MaterializationIntent::Checkout));
+                assert!(blocked.is_none());
+            }
+            other => panic!("expected Migrate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_stale_symlink_directory_is_migrate_to_checkout() {
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let source = td.child("source_dir");
+        source.create_dir_all().unwrap();
+        let target = td.path().join("target");
+        symlink::symlink_dir(source.path(), &target).unwrap();
+
+        let e = entry(target, git_config(""));
+        match m.classify(&e).unwrap() {
+            Operation::Migrate { from, to, blocked } => {
+                assert!(matches!(
+                    from,
+                    MaterializationIntent::SymlinkDirectory { .. }
+                ));
+                assert!(matches!(to, MaterializationIntent::Checkout));
+                assert!(blocked.is_none());
+            }
+            other => panic!("expected Migrate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materialize_migrate_removes_symlink_then_clones() {
+        use crate::exec::Context;
+        use crate::overlays::Repository;
+
+        let source_td = TempDir::new().unwrap();
+        init_committed_repo(source_td.path());
+
+        let dest_td = TempDir::new().unwrap();
+        // Stale symlink left by a prior `SymlinkDirectory` rule at the
+        // same path the checkout is now desired at.
+        let stale_source = dest_td.child("stale_source");
+        stale_source.create_dir_all().unwrap();
+        let target = dest_td.path().join("checkout");
+        symlink::symlink_dir(stale_source.path(), &target).unwrap();
+
+        let m = CheckoutMaterializer;
+        let e = entry(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+        );
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Migrate {
+                from: MaterializationIntent::SymlinkDirectory {
+                    source: stale_source.path().to_path_buf(),
+                    link_type: crate::actions::symlink::LinkType::Soft,
+                },
+                to: MaterializationIntent::Checkout,
+                blocked: None,
+            },
+        };
+
+        let repo = Repository::new(dest_td.path().to_path_buf());
+        let ctx = Context::builder()
+            .root(dest_td.path().to_path_buf())
+            .repository(repo)
+            .build()
+            .with_multiprogress(indicatif::MultiProgress::new());
+
+        m.materialize(ctx, &step).await.unwrap();
+
+        assert!(!target.is_symlink(), "stale symlink should be gone");
+        assert!(target.join(".git").exists());
+        assert!(target.join("README.md").exists());
     }
 
     #[tokio::test]

--- a/src/materialize/symlink.rs
+++ b/src/materialize/symlink.rs
@@ -1,12 +1,18 @@
-use anyhow::Result;
-use async_trait::async_trait;
+use std::fs;
+use std::path::Path;
 
-use crate::actions::fs::EnsureDirLink;
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use tokio::task::spawn_blocking;
+
+use crate::actions::fs::{EnsureDirLink, remove_target};
+use crate::actions::symlink::LinkType;
 use crate::actions::{EnsureDir, EnsureLink, EnsureSymlink};
 use crate::desired::{DesiredEntry, MaterializationIntent, Provenance};
 use crate::exec::{Action, Ctx};
 use crate::plan::actual::{self, ActualState};
 use crate::plan::{Operation, PlanStep};
+use crate::status::{self, Status};
 
 use super::Materializer;
 
@@ -37,14 +43,51 @@ impl Materializer for SymlinkMaterializer {
         match &entry.intent {
             MaterializationIntent::Directory => {
                 let actual = actual::inspect(&entry.target)?;
-                Ok(match actual {
-                    ActualState::Missing => Operation::Create,
-                    ActualState::Directory => Operation::Noop,
-                    other => Operation::Conflict { current: other },
-                })
+                match actual {
+                    ActualState::Missing => Ok(Operation::Create),
+                    // Deliberately *not* checked for a checkout-migration
+                    // here (unlike the `SymlinkDirectory` arm below):
+                    // `collect_own_entries` unconditionally emits a
+                    // `Directory` entry for every overlay's own target root
+                    // (`src/desired/tree.rs`), regardless of whether
+                    // `overlay.git` *also* declares that same root path
+                    // (`git = "<url>"`, the common root-checkout shorthand)
+                    // — so this entry's target legitimately has a `.git`
+                    // any time a root-level checkout is configured, forever,
+                    // not just when a rule changed. Treating that as a
+                    // pending migration would delete the checkout on every
+                    // single `apply`. Coordinating the two independent
+                    // `DesiredEntry` sources for the same target is a
+                    // pre-existing, separate gap (not #129's to fix — see
+                    // the module's `SymlinkDirectory` arm doc, which isn't
+                    // exposed to this ambiguity since the root's own base
+                    // entry is always plain `Directory`, never
+                    // `SymlinkDirectory`).
+                    ActualState::Directory => Ok(Operation::Noop),
+                    // A directory-level symlink used to sit here (#126); a
+                    // rule change now recurses this path instead (#129).
+                    // Only migrate when it's provably the *same* overlay
+                    // source this `Directory` entry would itself walk —
+                    // never a foreign symlink pointing elsewhere.
+                    ActualState::Symlink { ref points_to } => match &entry.provenance {
+                        Provenance::Overlay { source, .. } if points_to == source => {
+                            Ok(Operation::Migrate {
+                                from: MaterializationIntent::SymlinkDirectory {
+                                    source: points_to.clone(),
+                                    link_type: LinkType::Soft,
+                                },
+                                to: MaterializationIntent::Directory,
+                                blocked: None,
+                            })
+                        }
+                        _ => Ok(Operation::Conflict {
+                            current: actual.clone(),
+                        }),
+                    },
+                    other => Ok(Operation::Conflict { current: other }),
+                }
             }
-            MaterializationIntent::SymlinkFile { source, .. }
-            | MaterializationIntent::SymlinkDirectory { source, .. } => {
+            MaterializationIntent::SymlinkFile { source, .. } => {
                 let actual = actual::inspect(&entry.target)?;
                 Ok(match actual {
                     ActualState::Missing => Operation::Create,
@@ -54,6 +97,38 @@ impl Materializer for SymlinkMaterializer {
                     other => Operation::Conflict { current: other },
                 })
             }
+            MaterializationIntent::SymlinkDirectory { source, .. } => {
+                let actual = actual::inspect(&entry.target)?;
+                match actual {
+                    ActualState::Missing => Ok(Operation::Create),
+                    ActualState::Symlink { ref points_to } if points_to == source => {
+                        Ok(Operation::Noop)
+                    }
+                    // A real directory sits where a directory-level symlink
+                    // is now desired (#129): either it's actually a git
+                    // checkout that should migrate (rule/`overlay.git`
+                    // change), or it's a directory this same overlay
+                    // previously walked file-by-file and can safely
+                    // collapse (every leaf is exactly the symlink the
+                    // overlay would create), or it's a genuine conflict.
+                    ActualState::Directory => {
+                        if let Some(op) = checkout_migration(entry)? {
+                            return Ok(op);
+                        }
+                        if directory_is_symlink_mirror(&entry.target, source)? {
+                            return Ok(Operation::Migrate {
+                                from: MaterializationIntent::Directory,
+                                to: entry.intent.clone(),
+                                blocked: None,
+                            });
+                        }
+                        Ok(Operation::Conflict {
+                            current: ActualState::Directory,
+                        })
+                    }
+                    other => Ok(Operation::Conflict { current: other }),
+                }
+            }
             MaterializationIntent::Checkout | MaterializationIntent::PartialFile { .. } => {
                 unreachable!("MaterializerRegistry only calls classify() after handles() passed")
             }
@@ -61,9 +136,132 @@ impl Materializer for SymlinkMaterializer {
     }
 
     async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()> {
-        let action = build_action(ctx.clone(), &step.entry);
-        action.execute(ctx).await
+        match &step.operation {
+            Operation::Migrate {
+                from,
+                blocked: None,
+                ..
+            } => materialize_migration(ctx, &step.entry, from).await,
+            // Defensive: `Plan::execute`'s `is_actionable` never calls
+            // `materialize` for a blocked migration — but never silently
+            // fall through to the plain `build_action` path below either,
+            // which could force-discard whatever's blocking it (e.g. a
+            // dirty checkout) if this were ever invoked directly. Treat it
+            // exactly like `Noop`.
+            Operation::Migrate {
+                blocked: Some(reason),
+                ..
+            } => {
+                tracing::warn!(
+                    target = %step.entry.target.display(),
+                    reason = %reason,
+                    "materialize called for a blocked migration; skipping",
+                );
+                Ok(())
+            }
+            _ => {
+                let action = build_action(ctx.clone(), &step.entry);
+                action.execute(ctx).await
+            }
+        }
     }
+}
+
+/// `entry.target` already exists as a real directory. If it's actually a
+/// git checkout, return the [`Operation::Migrate`] reconciling it to
+/// `entry.intent` (#129) — safe (`blocked: None`) when fully in sync with
+/// its upstream, blocked otherwise (never silently discarded, never routed
+/// through force/no_prompt/absorb-diff — the exact safety gate
+/// `CheckoutMaterializer::classify` already relies on for the reverse
+/// direction, reused here via `status::git::inspect_checkout` rather than
+/// re-derived). `None` when `entry.target` isn't a checkout at all — the
+/// fast `.git`-presence check skips the `git2` call entirely for the
+/// overwhelmingly common case, leaving the caller to decide its own
+/// default.
+fn checkout_migration(entry: &DesiredEntry) -> Result<Option<Operation>> {
+    if !entry.target.join(".git").exists() {
+        return Ok(None);
+    }
+    Ok(match status::git::inspect_checkout(&entry.target)? {
+        // `.git` exists but isn't a valid repo — not actually a checkout.
+        Status::Broken => None,
+        Status::Applied => Some(Operation::Migrate {
+            from: MaterializationIntent::Checkout,
+            to: entry.intent.clone(),
+            blocked: None,
+        }),
+        unsafe_status => Some(Operation::Migrate {
+            from: MaterializationIntent::Checkout,
+            to: entry.intent.clone(),
+            blocked: Some(status::describe(&unsafe_status)),
+        }),
+    })
+}
+
+/// Recursively confirm every entry under `target` is exactly the symlink
+/// the overlay would itself create for it under `source` — a directory
+/// "fully owned" by the overlay, nothing foreign, nothing real. Lets a
+/// `recurse -> directory-level symlink` rule change (#129) collapse the
+/// directory safely instead of falling back to `Operation::Conflict`;
+/// removing it loses nothing the overlay didn't already provide.
+fn directory_is_symlink_mirror(target: &Path, source: &Path) -> Result<bool> {
+    for dir_entry in fs::read_dir(target)? {
+        let dir_entry = dir_entry?;
+        let path = dir_entry.path();
+        let file_type = dir_entry.file_type()?;
+        let expected = source.join(dir_entry.file_name());
+        if file_type.is_symlink() {
+            if fs::read_link(&path)? != expected {
+                return Ok(false);
+            }
+        } else if file_type.is_dir() {
+            if !directory_is_symlink_mirror(&path, &expected)? {
+                return Ok(false);
+            }
+        } else {
+            // A real file (or anything else): not reconstructible from the
+            // overlay alone.
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Perform an unblocked `Operation::Migrate` (#129): remove whatever
+/// currently occupies `entry.target` (re-verifying a checkout's safety
+/// right before deleting — classify → execute isn't atomic, and a checkout
+/// must never be discarded even if it turned dirty in between), then
+/// materialize `entry.intent` fresh via the same tested `Action`s
+/// `build_action` already dispatches to. The target is empty/gone by the
+/// time that action runs, so it always takes the plain `Create` path —
+/// never the force/no_prompt/absorb-diff conflict machinery, which is
+/// exactly what a rule-driven migration must avoid triggering.
+async fn materialize_migration(
+    ctx: Ctx,
+    entry: &DesiredEntry,
+    from: &MaterializationIntent,
+) -> Result<()> {
+    if ctx.dry_run {
+        return Ok(());
+    }
+
+    if matches!(from, MaterializationIntent::Checkout) {
+        match status::git::inspect_checkout(&entry.target)? {
+            Status::Applied => {}
+            other => {
+                return Err(anyhow!(
+                    "refusing to migrate '{}': checkout {} since it was classified — rerun to re-evaluate",
+                    entry.target.display(),
+                    status::describe(&other),
+                ));
+            }
+        }
+    }
+
+    let target = entry.target.clone();
+    spawn_blocking(move || remove_target(&target)).await??;
+
+    build_action(ctx.clone(), entry).execute(ctx).await
 }
 
 /// Translate an entry into the existing, tested `Action` that materializes
@@ -120,6 +318,9 @@ mod tests {
     use super::*;
     use crate::actions::symlink::LinkType;
     use crate::exec::Context;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use git2::Signature;
     use std::path::PathBuf;
 
     fn entry(intent: MaterializationIntent) -> DesiredEntry {
@@ -131,6 +332,29 @@ mod tests {
             },
             intent,
         }
+    }
+
+    /// `git2::Repository::init` + one commit, mirroring
+    /// `materialize::checkout::tests::init_committed_repo` — a clean
+    /// checkout by default (no upstream configured, so `ahead_behind`
+    /// reports `None` -> `Status::Applied`).
+    fn init_committed_repo(path: &std::path::Path) {
+        let repo = git2::Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
     }
 
     #[test]
@@ -211,6 +435,294 @@ mod tests {
         let ctx = Context::builder().build();
         let action = build_action(ctx, &entry);
         assert!(format!("{action}").contains("create directory:"));
+    }
+
+    #[test]
+    fn directory_intent_coexisting_with_a_checkout_is_noop_not_migrate() {
+        // `collect_own_entries` unconditionally emits a `Directory` entry
+        // for every overlay's own target root, regardless of whether
+        // `overlay.git` *also* declares that same root as a checkout
+        // (`git = "<url>"`) — a legitimate, permanent coexistence, not a
+        // rule change. Misclassifying this as `Migrate` would delete the
+        // checkout on every single `apply` (a real regression #129 must
+        // not reintroduce).
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: td.path().to_path_buf(),
+            ..entry(MaterializationIntent::Directory)
+        };
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    fn classify_clean_checkout_is_migrate_to_symlink_directory() {
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: td.path().to_path_buf(),
+            ..entry(MaterializationIntent::SymlinkDirectory {
+                source: PathBuf::from("/repo/ov"),
+                link_type: LinkType::Soft,
+            })
+        };
+        match m.classify(&e).unwrap() {
+            Operation::Migrate { from, to, blocked } => {
+                assert!(matches!(from, MaterializationIntent::Checkout));
+                assert!(matches!(to, MaterializationIntent::SymlinkDirectory { .. }));
+                assert!(blocked.is_none());
+            }
+            other => panic!("expected Migrate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_dirty_checkout_is_migrate_blocked_not_conflict() {
+        // A dirty checkout must never classify as `Operation::Conflict`
+        // (force/no_prompt/absorb-diff would discard it) nor as a bare
+        // `Noop`/`Migrate{blocked: None}` (silently invisible) — it must be
+        // reported as a blocked migration.
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        fs::write(td.path().join("README.md"), "changed").unwrap();
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: td.path().to_path_buf(),
+            ..entry(MaterializationIntent::SymlinkDirectory {
+                source: PathBuf::from("/repo/ov"),
+                link_type: LinkType::Soft,
+            })
+        };
+        match m.classify(&e).unwrap() {
+            Operation::Migrate {
+                from,
+                blocked: Some(reason),
+                ..
+            } => {
+                assert!(matches!(from, MaterializationIntent::Checkout));
+                assert!(reason.contains("uncommitted"));
+            }
+            other => panic!("expected blocked Migrate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_directory_symlink_matching_source_is_migrate_to_directory() {
+        let td = TempDir::new().unwrap();
+        let source = td.child("source_dir");
+        source.create_dir_all().unwrap();
+        let target = td.path().join("target_dir");
+        symlink::symlink_dir(source.path(), &target).unwrap();
+
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: target.clone(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: source.path().to_path_buf(),
+            },
+            intent: MaterializationIntent::Directory,
+        };
+        match m.classify(&e).unwrap() {
+            Operation::Migrate { from, to, blocked } => {
+                assert!(matches!(
+                    from,
+                    MaterializationIntent::SymlinkDirectory { .. }
+                ));
+                assert!(matches!(to, MaterializationIntent::Directory));
+                assert!(blocked.is_none());
+            }
+            other => panic!("expected Migrate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_foreign_symlink_is_still_conflict() {
+        // A symlink at the target that does *not* point at this same
+        // entry's overlay source must never be treated as a migration —
+        // only reconstructible, overlay-owned state is safe to collapse.
+        let td = TempDir::new().unwrap();
+        let foreign = td.child("foreign_dir");
+        foreign.create_dir_all().unwrap();
+        let target = td.path().join("target_dir");
+        symlink::symlink_dir(foreign.path(), &target).unwrap();
+
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target,
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: PathBuf::from("/repo/ov/somewhere-else"),
+            },
+            intent: MaterializationIntent::Directory,
+        };
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_symlink_mirror_directory_is_migrate_to_symlink_directory() {
+        let td = TempDir::new().unwrap();
+        let source = td.child("source_dir");
+        source.create_dir_all().unwrap();
+        source.child("a.txt").write_str("a").unwrap();
+        source.child("sub").create_dir_all().unwrap();
+        source.child("sub/b.txt").write_str("b").unwrap();
+
+        // A directory previously walked file-by-file: every leaf is a
+        // symlink pointing under `source`, nothing foreign.
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(target.join("sub")).unwrap();
+        symlink::symlink_file(source.path().join("a.txt"), target.join("a.txt")).unwrap();
+        symlink::symlink_file(source.path().join("sub/b.txt"), target.join("sub/b.txt")).unwrap();
+
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: target.clone(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: source.path().to_path_buf(),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: source.path().to_path_buf(),
+                link_type: LinkType::Soft,
+            },
+        };
+        match m.classify(&e).unwrap() {
+            Operation::Migrate { from, to, blocked } => {
+                assert!(matches!(from, MaterializationIntent::Directory));
+                assert!(matches!(to, MaterializationIntent::SymlinkDirectory { .. }));
+                assert!(blocked.is_none());
+            }
+            other => panic!("expected Migrate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_directory_with_foreign_file_is_still_conflict() {
+        // A real (non-symlink) file inside the directory means it isn't a
+        // pure mirror of the overlay source — never safe to auto-collapse.
+        let td = TempDir::new().unwrap();
+        let source = td.child("source_dir");
+        source.create_dir_all().unwrap();
+
+        let target = td.path().join("target_dir");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("foreign.txt"), "not from the overlay").unwrap();
+
+        let m = SymlinkMaterializer;
+        let e = DesiredEntry {
+            target: target.clone(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: source.path().to_path_buf(),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: source.path().to_path_buf(),
+                link_type: LinkType::Soft,
+            },
+        };
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn materialize_migrate_checkout_to_symlink_replaces_directory() {
+        let td = TempDir::new().unwrap();
+        let checkout_dir = td.child("checkout");
+        checkout_dir.create_dir_all().unwrap();
+        init_committed_repo(checkout_dir.path());
+
+        let source = td.child("elsewhere");
+        source.create_dir_all().unwrap();
+
+        let m = SymlinkMaterializer;
+        let target = checkout_dir.path().to_path_buf();
+        let e = DesiredEntry {
+            target: target.clone(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: source.path().to_path_buf(),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: source.path().to_path_buf(),
+                link_type: LinkType::Soft,
+            },
+        };
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Migrate {
+                from: MaterializationIntent::Checkout,
+                to: MaterializationIntent::SymlinkDirectory {
+                    source: source.path().to_path_buf(),
+                    link_type: LinkType::Soft,
+                },
+                blocked: None,
+            },
+        };
+        let ctx = Context::builder().build();
+        m.materialize(ctx, &step).await.unwrap();
+
+        assert!(
+            target.is_symlink(),
+            "checkout should be gone, replaced by a symlink"
+        );
+        assert_eq!(fs::read_link(&target).unwrap(), source.path());
+    }
+
+    #[tokio::test]
+    async fn materialize_migrate_blocked_never_invoked_is_defensive_noop() {
+        // Even if something ever called `materialize` directly for a
+        // blocked migration (bypassing `Plan::execute`'s `is_actionable`
+        // filter), and even with `--force`, the dirty checkout must remain
+        // untouched — never silently discarded.
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        fs::write(td.path().join("README.md"), "changed").unwrap();
+
+        let m = SymlinkMaterializer;
+        let target = td.path().to_path_buf();
+        let source = PathBuf::from("/repo/ov/somewhere");
+        let e = DesiredEntry {
+            target: target.clone(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: source.clone(),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: source.clone(),
+                link_type: LinkType::Soft,
+            },
+        };
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Migrate {
+                from: MaterializationIntent::Checkout,
+                to: MaterializationIntent::SymlinkDirectory {
+                    source,
+                    link_type: LinkType::Soft,
+                },
+                blocked: Some("has uncommitted changes".to_string()),
+            },
+        };
+        let ctx = Context::builder().force(true).build();
+        m.materialize(ctx, &step).await.unwrap();
+
+        assert!(
+            target.join(".git").exists(),
+            "checkout must remain a git repo"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("README.md")).unwrap(),
+            "changed",
+            "uncommitted change must remain"
+        );
     }
 
     #[test]

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -44,10 +44,12 @@
 //!   other intent, but `Overlay::apply` still clones git repositories
 //!   through the existing, separate `actions::git::clone_repositories`
 //!   *before* building the `Plan`, entirely orthogonal to this module.
-//! - Materialization-rule migrations (symlink ↔ checkout, file-level ↔
-//!   directory-level symlink) and `defaults:`/`rules:` configuration —
-//!   #113. [`Operation`] is designed to grow variants for this without a
-//!   `Plan`/`PlanStep` shape change.
+//! - `defaults:`/`rules:` configuration itself — #126, `crate::overlays::rules`.
+//!   [`Operation::Migrate`] (#129) reconciles what those rules resolve
+//!   *changing* between runs (symlink ↔ checkout, file-level ↔
+//!   directory-level symlink) without a `Plan`/`PlanStep` shape change, per
+//!   ADR-012's headroom — added as a new `Operation` variant, classified by
+//!   the same `Materializer`s that already own each intent.
 //! - `status`/`diff`/`unapply` commands themselves — #12/#109/#64. This
 //!   module only makes `Plan` reusable for them.
 

--- a/src/plan/reconcile.rs
+++ b/src/plan/reconcile.rs
@@ -11,6 +11,17 @@ use crate::ui::style;
 
 use super::step::{Operation, PlanStep};
 
+/// Whether a step needs [`Materializer::materialize`](crate::materialize::Materializer::materialize)
+/// called for it: `Create`/`Conflict` always did; an unblocked `Migrate`
+/// does too (#129) — a blocked one doesn't, exactly like `Noop`/`Deferred`.
+fn is_actionable(operation: &Operation) -> bool {
+    match operation {
+        Operation::Create | Operation::Conflict { .. } => true,
+        Operation::Migrate { blocked, .. } => blocked.is_none(),
+        Operation::Noop | Operation::Deferred => false,
+    }
+}
+
 static SPINNER_STYLE: LazyLock<ProgressStyle> = LazyLock::new(|| {
     ProgressStyle::with_template("{spinner:.cyan} {wide_msg}")
         .expect("static progress template must be valid")
@@ -70,17 +81,17 @@ impl Plan {
             .any(|s| matches!(s.operation, Operation::Conflict { .. }))
     }
 
-    /// Execute every actionable step (`Create`/`Conflict`) in the plan's
-    /// deterministic order (`DesiredTree` sorts entries by target path, so
-    /// a directory's entry always precedes anything nested under it).
-    /// `Noop`/`Deferred` steps are skipped — the former because there's
-    /// nothing to do, the latter because it's unreachable in practice since
-    /// #110 (kept as a defensive fallback).
+    /// Execute every actionable step (`Create`/`Conflict`/an unblocked
+    /// `Migrate`) in the plan's deterministic order (`DesiredTree` sorts
+    /// entries by target path, so a directory's entry always precedes
+    /// anything nested under it). `Noop`/`Deferred` steps are skipped — the
+    /// former because there's nothing to do, the latter because it's
+    /// unreachable in practice since #110 (kept as a defensive fallback). A
+    /// blocked `Migrate` (`blocked: Some(_)`) is skipped too — it's
+    /// understood, but not safe to perform yet (#129), and must never be
+    /// forced through.
     pub async fn execute(&self, ctx: Ctx) -> Result<()> {
-        let has_actionable = self
-            .steps
-            .iter()
-            .any(|s| matches!(s.operation, Operation::Create | Operation::Conflict { .. }));
+        let has_actionable = self.steps.iter().any(|s| is_actionable(&s.operation));
         if !has_actionable {
             return Ok(());
         }
@@ -91,7 +102,7 @@ impl Plan {
             .with_message("");
 
         for step in &self.steps {
-            if matches!(step.operation, Operation::Noop | Operation::Deferred) {
+            if !is_actionable(&step.operation) {
                 continue;
             }
 
@@ -136,6 +147,24 @@ impl fmt::Display for Plan {
             .iter()
             .filter(|s| matches!(s.operation, Operation::Conflict { .. }))
             .count();
+        let migrate = self
+            .steps
+            .iter()
+            .filter(|s| matches!(s.operation, Operation::Migrate { blocked: None, .. }))
+            .count();
+        let blocked = self
+            .steps
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.operation,
+                    Operation::Migrate {
+                        blocked: Some(_),
+                        ..
+                    }
+                )
+            })
+            .count();
         let deferred = self
             .steps
             .iter()
@@ -144,11 +173,14 @@ impl fmt::Display for Plan {
 
         writeln!(
             f,
-            "{} {} to create, {} unchanged, {} conflict(s), {} deferred",
+            "{} {} to create, {} unchanged, {} conflict(s), {} to migrate, \
+             {} migration(s) blocked, {} deferred",
             style::white_b("Plan:"),
             create,
             noop,
             conflicts,
+            migrate,
+            blocked,
             deferred,
         )?;
         for step in self
@@ -165,6 +197,8 @@ impl fmt::Display for Plan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actions::symlink::LinkType;
+    use crate::desired::{DesiredEntry, MaterializationIntent, Provenance};
     use crate::exec::Context;
     use crate::overlays::{Overlay, Repository};
     use assert_fs::TempDir;
@@ -402,6 +436,62 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn unblocked_migrate_is_actionable() {
+        let op = Operation::Migrate {
+            from: MaterializationIntent::Checkout,
+            to: MaterializationIntent::Directory,
+            blocked: None,
+        };
+        assert!(is_actionable(&op));
+    }
+
+    #[test]
+    fn blocked_migrate_is_not_actionable() {
+        let op = Operation::Migrate {
+            from: MaterializationIntent::Checkout,
+            to: MaterializationIntent::Directory,
+            blocked: Some("has uncommitted changes".to_string()),
+        };
+        assert!(!is_actionable(&op));
+    }
+
+    #[tokio::test]
+    async fn blocked_migrate_step_is_skipped_by_execute() {
+        let (td, repo) = repo_and_root();
+        let c = ctx(td.path().to_path_buf(), repo, None);
+        let target = td.path().join("some_target");
+        let entry = DesiredEntry {
+            target: target.clone(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: PathBuf::from("/src"),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: PathBuf::from("/src"),
+                link_type: LinkType::Soft,
+            },
+        };
+        let plan = Plan {
+            steps: vec![PlanStep {
+                entry,
+                operation: Operation::Migrate {
+                    from: MaterializationIntent::Checkout,
+                    to: MaterializationIntent::SymlinkDirectory {
+                        source: PathBuf::from("/src"),
+                        link_type: LinkType::Soft,
+                    },
+                    blocked: Some("has uncommitted changes".to_string()),
+                },
+            }],
+        };
+        // No materializer would even be looked up for this step since it's
+        // skipped — if it weren't, this would fail trying to remove/link a
+        // nonexistent `/src`.
+        plan.execute(c).await.unwrap();
+        assert!(!target.exists());
+    }
+
     #[tokio::test]
     async fn sidecar_hard_link_is_dispatched_to_ensure_symlink() {
         let (td, repo) = repo_and_root();
@@ -431,5 +521,316 @@ mod tests {
         // Hard links are real files, not symlinks.
         assert!(!target.is_symlink());
         assert_eq!(fs::read_to_string(&target).unwrap(), "hard");
+    }
+
+    // ── #129: end-to-end rule-change migrations ─────────────────────────
+    //
+    // These use a `.link.toml` sidecar (not `link_dirs`/`rules`) for the
+    // symlink side of each scenario specifically so `conf` doesn't *also*
+    // exist as a real directory in the overlay's own source tree —
+    // `overlay.git` and `walk_overlay_tree` are two independent,
+    // uncoordinated `DesiredEntry` sources (a pre-existing gap, not #129's
+    // to fix), and having both resolve the same target would produce two
+    // competing entries instead of the single one these tests need.
+
+    fn init_committed_repo(path: &std::path::Path) {
+        let repo = git2::Repository::init(path).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Test").unwrap();
+        cfg.set_str("user.email", "test@test.com").unwrap();
+        drop(cfg);
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        fs::write(path.join("README.md"), "# Test").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn root_level_checkout_coexists_with_its_own_base_directory_entry() {
+        // `git = "<url>"` (the `ROOT_PATH` shorthand) makes the overlay's
+        // entire target root a checkout — `collect_own_entries` still
+        // unconditionally emits a plain `Directory` entry for that exact
+        // same root too (every overlay needs a place to live). A second
+        // `apply` (or a `--force` one, as here) must never treat the
+        // already-cloned checkout as a pending `Directory` migration and
+        // delete it — a real regression #129 introduced and fixed before
+        // landing.
+        //
+        // `target`/`root` must be a *separate* directory from the
+        // repository/overlay descriptor tree here (unlike most other tests
+        // in this file, which reuse the same `td` for both): the clone
+        // target is the root itself, and `libgit2` refuses to clone into a
+        // non-empty directory — which the repository root always is, since
+        // it holds the overlay's own `ov/` descriptor.
+        let (home, repo) = repo_and_root();
+        let overlay_dir = home.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        let source_repo = home.child("source_repo");
+        source_repo.create_dir_all().unwrap();
+        init_committed_repo(source_repo.path());
+        let repo_url = source_repo.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("over.toml")
+            .write_str(&format!("target = \"~\"\ngit = \"{repo_url}\""))
+            .unwrap();
+        let root = TempDir::new().unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(
+            root.path().to_path_buf(),
+            repo.clone(),
+            Some(overlay.clone()),
+        );
+        let clone_ctx = c
+            .clone()
+            .with_multiprogress(indicatif::MultiProgress::new());
+        // Mirrors `Overlay::apply_inner`: `clone_repositories` runs before
+        // `Plan::build`/`execute` (ADR-014) — by the time the plan sees the
+        // `Checkout` entry, the repository already exists and classifies
+        // as `Noop`, exactly like a real `apply`.
+        crate::actions::git::clone_repositories(clone_ctx.clone(), &overlay, root.path())
+            .await
+            .unwrap();
+        assert!(root.path().join(".git").exists());
+
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(clone_ctx.clone())
+            .await
+            .unwrap();
+        assert!(root.path().join(".git").exists(), "checkout must survive");
+
+        // Re-apply (mirroring `over apply --force` run twice): the plan
+        // must find nothing to migrate, and the checkout must survive.
+        let desired2 = DesiredTree::build(&c, &overlay).unwrap();
+        let plan2 = Plan::build(&desired2).unwrap();
+        assert!(
+            plan2
+                .steps()
+                .iter()
+                .all(|s| matches!(s.operation, Operation::Noop)),
+            "second plan should find nothing to do, got: {plan2}"
+        );
+        plan2.execute(clone_ctx).await.unwrap();
+        assert!(root.path().join(".git").exists(), "checkout must survive");
+    }
+
+    #[tokio::test]
+    async fn rule_change_from_symlink_to_checkout_migrates_and_clones() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+
+        // Phase 1: a `.link.toml` sidecar symlinks `conf` to some other
+        // real directory — apply creates the symlink.
+        let elsewhere = td.child("elsewhere");
+        elsewhere.create_dir_all().unwrap();
+        let elsewhere_toml = elsewhere.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("conf.link.toml")
+            .write_str(&format!("target = \"{elsewhere_toml}\""))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(c.clone())
+            .await
+            .unwrap();
+        let conf_target = td.path().join("conf");
+        assert!(conf_target.is_symlink(), "sidecar should create a symlink");
+
+        // Phase 2: drop the sidecar, add `conf` to `overlay.git` instead.
+        fs::remove_file(overlay_dir.path().join("conf.link.toml")).unwrap();
+        let source_repo = td.child("source_repo");
+        source_repo.create_dir_all().unwrap();
+        init_committed_repo(source_repo.path());
+        let repo_url = source_repo.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("over.toml")
+            .write_str(&format!("target = \"~\"\n[git]\nconf = \"{repo_url}\""))
+            .unwrap();
+
+        let overlay2 = repo.get("ov").unwrap();
+        let desired2 = DesiredTree::build(&c, &overlay2).unwrap();
+        let plan2 = Plan::build(&desired2).unwrap();
+        let step = plan2
+            .steps()
+            .iter()
+            .find(|s| s.entry.target == conf_target)
+            .unwrap();
+        match &step.operation {
+            Operation::Migrate {
+                to, blocked: None, ..
+            } => assert!(matches!(to, MaterializationIntent::Checkout)),
+            other => panic!("expected a safe Migrate to Checkout, got {other:?}"),
+        }
+
+        let clone_ctx = c
+            .clone()
+            .with_multiprogress(indicatif::MultiProgress::new());
+        plan2.execute(clone_ctx).await.unwrap();
+        assert!(!conf_target.is_symlink(), "stale symlink should be gone");
+        assert!(conf_target.join(".git").exists(), "checkout now exists");
+        assert!(conf_target.join("README.md").exists());
+    }
+
+    #[tokio::test]
+    async fn clean_checkout_migrates_back_to_symlink_when_git_entry_removed() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+
+        // Phase 1: `conf` is a git checkout.
+        let source_repo = td.child("source_repo");
+        source_repo.create_dir_all().unwrap();
+        init_committed_repo(source_repo.path());
+        let repo_url = source_repo.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("over.toml")
+            .write_str(&format!("target = \"~\"\n[git]\nconf = \"{repo_url}\""))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let clone_ctx = c
+            .clone()
+            .with_multiprogress(indicatif::MultiProgress::new());
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(clone_ctx)
+            .await
+            .unwrap();
+        let conf_target = td.path().join("conf");
+        assert!(conf_target.join(".git").exists());
+
+        // Phase 2: `overlay.git` is dropped, a `.link.toml` sidecar takes
+        // over the same path instead.
+        let elsewhere = td.child("elsewhere");
+        elsewhere.create_dir_all().unwrap();
+        let elsewhere_toml = elsewhere.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir
+            .child("conf.link.toml")
+            .write_str(&format!("target = \"{elsewhere_toml}\""))
+            .unwrap();
+
+        let overlay2 = repo.get("ov").unwrap();
+        let desired2 = DesiredTree::build(&c, &overlay2).unwrap();
+        let plan2 = Plan::build(&desired2).unwrap();
+        let step = plan2
+            .steps()
+            .iter()
+            .find(|s| s.entry.target == conf_target)
+            .unwrap();
+        match &step.operation {
+            Operation::Migrate {
+                from,
+                blocked: None,
+                ..
+            } => assert!(matches!(from, MaterializationIntent::Checkout)),
+            other => panic!("expected a safe Migrate from Checkout, got {other:?}"),
+        }
+
+        plan2.execute(c.clone()).await.unwrap();
+        assert!(
+            !conf_target.join(".git").exists(),
+            "checkout should be gone"
+        );
+        assert!(conf_target.is_symlink(), "now a symlink instead");
+        assert_eq!(fs::read_link(&conf_target).unwrap(), elsewhere.path());
+    }
+
+    #[tokio::test]
+    async fn dirty_checkout_blocks_migration_back_to_symlink() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+
+        let source_repo = td.child("source_repo");
+        source_repo.create_dir_all().unwrap();
+        init_committed_repo(source_repo.path());
+        let repo_url = source_repo.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("over.toml")
+            .write_str(&format!("target = \"~\"\n[git]\nconf = \"{repo_url}\""))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone(), Some(overlay.clone()));
+        let clone_ctx = c
+            .clone()
+            .with_multiprogress(indicatif::MultiProgress::new());
+        let desired = DesiredTree::build(&c, &overlay).unwrap();
+        Plan::build(&desired)
+            .unwrap()
+            .execute(clone_ctx)
+            .await
+            .unwrap();
+        let conf_target = td.path().join("conf");
+
+        // Make an uncommitted change inside the checkout.
+        fs::write(conf_target.join("README.md"), "local edit").unwrap();
+
+        let elsewhere = td.child("elsewhere");
+        elsewhere.create_dir_all().unwrap();
+        let elsewhere_toml = elsewhere.path().to_string_lossy().replace('\\', "\\\\");
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        overlay_dir
+            .child("conf.link.toml")
+            .write_str(&format!("target = \"{elsewhere_toml}\""))
+            .unwrap();
+
+        let overlay2 = repo.get("ov").unwrap();
+        let desired2 = DesiredTree::build(&c, &overlay2).unwrap();
+        let plan2 = Plan::build(&desired2).unwrap();
+        let step = plan2
+            .steps()
+            .iter()
+            .find(|s| s.entry.target == conf_target)
+            .unwrap();
+        match &step.operation {
+            Operation::Migrate {
+                blocked: Some(reason),
+                ..
+            } => assert!(reason.contains("uncommitted")),
+            other => panic!("expected a blocked Migrate, got {other:?}"),
+        }
+
+        // Even with `--force`, the dirty checkout must stay untouched.
+        let force_ctx = Context::builder()
+            .force(true)
+            .root(td.path().to_path_buf())
+            .repository(repo.clone())
+            .overlay(overlay2.clone())
+            .build();
+        plan2.execute(force_ctx).await.unwrap();
+        assert!(conf_target.join(".git").exists(), "checkout must remain");
+        assert_eq!(
+            fs::read_to_string(conf_target.join("README.md")).unwrap(),
+            "local edit",
+            "uncommitted change must remain"
+        );
     }
 }

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -9,13 +9,6 @@ use super::actual::ActualState;
 /// What a single [`PlanStep`] needs to do to reconcile actual state with
 /// [`DesiredEntry`] intent.
 ///
-/// Deliberately a small, closed set today. One extension point this issue
-/// is asked to leave open, without implementing it yet:
-///
-/// - #113 will add rule-change transitions (symlink ↔ checkout, file-level
-///   ↔ directory-level symlink) as new variants here (e.g. a future
-///   `Migrate`) rather than requiring a different `Plan`/[`PlanStep`] shape.
-///
 /// #108 already replaced [`super::Plan::execute`]'s direct dispatch on
 /// [`MaterializationIntent`] with a lookup into a registered
 /// [`crate::materialize::Materializer`] per intent — `Operation` itself
@@ -28,6 +21,22 @@ pub enum Operation {
     Noop,
     /// Target exists and does not match the desired intent.
     Conflict { current: ActualState },
+    /// A rule/config change means this target should now be materialized
+    /// differently than it currently is (symlink ↔ checkout, file-level ↔
+    /// directory-level symlink — #129), reconstructed from `ActualState`
+    /// (plus git inspection when a checkout is involved) rather than an
+    /// implicit delete/recreate or a blunt [`Operation::Conflict`].
+    Migrate {
+        from: MaterializationIntent,
+        to: MaterializationIntent,
+        /// `None`: safe to perform automatically. `Some(reason)`: the
+        /// migration is understood but can't proceed yet (e.g. a dirty
+        /// checkout) — never executed, even under `--force`
+        /// ([`super::Plan::execute`] skips it exactly like `Noop`), but
+        /// still reported so it isn't silently invisible like a bare
+        /// `Noop` would be.
+        blocked: Option<String>,
+    },
     /// No registered [`crate::materialize::Materializer`] claims this
     /// entry's intent. Unreachable in practice since #110 gave every intent
     /// (including [`MaterializationIntent::Checkout`]) a real backend, but
@@ -35,6 +44,20 @@ pub enum Operation {
     /// something sensible instead of panicking; [`super::Plan::execute`]
     /// never acts on it.
     Deferred,
+}
+
+/// Short, human-readable word for a [`MaterializationIntent`], used only by
+/// [`Operation::Migrate`]'s `Display` rendering (`<from> -> <to>`) — not a
+/// full description of the intent's fields, just enough to name the shape
+/// that changed.
+fn intent_label(intent: &MaterializationIntent) -> &'static str {
+    match intent {
+        MaterializationIntent::Directory => "directory",
+        MaterializationIntent::SymlinkFile { .. } => "symlink",
+        MaterializationIntent::SymlinkDirectory { .. } => "directory symlink",
+        MaterializationIntent::Checkout => "checkout",
+        MaterializationIntent::PartialFile { .. } => "partial file",
+    }
 }
 
 /// One [`DesiredEntry`] paired with the [`Operation`] needed to reconcile it
@@ -172,6 +195,39 @@ impl fmt::Display for PlanStep {
                     current,
                 )
             }
+            (
+                _,
+                Operation::Migrate {
+                    from,
+                    to,
+                    blocked: None,
+                },
+            ) => write!(
+                f,
+                "{} {} {} ({} -> {})",
+                emojis::MIGRATE,
+                style::white("migrate:"),
+                target,
+                intent_label(from),
+                intent_label(to),
+            ),
+            (
+                _,
+                Operation::Migrate {
+                    from,
+                    to,
+                    blocked: Some(reason),
+                },
+            ) => write!(
+                f,
+                "{} {} {} ({} -> {}, {})",
+                emojis::WARNING,
+                style::yellow("migrate blocked:"),
+                target,
+                intent_label(from),
+                intent_label(to),
+                reason,
+            ),
             // Every intent has a registered `Materializer` since #110; no
             // step should ever classify as `Deferred` anymore — unreachable
             // in practice, but a clear fallback beats a silently wrong line.
@@ -339,6 +395,46 @@ mod tests {
         let s = format!("{step}");
         assert!(s.contains("conflict:"));
         assert!(s.contains("aliases"));
+    }
+
+    #[test]
+    fn migrate_symlink_to_checkout_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::Checkout),
+            operation: Operation::Migrate {
+                from: MaterializationIntent::SymlinkDirectory {
+                    source: PathBuf::from("/repo/ov/app"),
+                    link_type: LinkType::Soft,
+                },
+                to: MaterializationIntent::Checkout,
+                blocked: None,
+            },
+        };
+        let s = format!("{step}");
+        assert!(s.contains("migrate:"));
+        assert!(s.contains("directory symlink -> checkout"));
+    }
+
+    #[test]
+    fn migrate_checkout_to_symlink_blocked_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::SymlinkDirectory {
+                source: PathBuf::from("/repo/ov/app"),
+                link_type: LinkType::Soft,
+            }),
+            operation: Operation::Migrate {
+                from: MaterializationIntent::Checkout,
+                to: MaterializationIntent::SymlinkDirectory {
+                    source: PathBuf::from("/repo/ov/app"),
+                    link_type: LinkType::Soft,
+                },
+                blocked: Some("has uncommitted changes".to_string()),
+            },
+        };
+        let s = format!("{step}");
+        assert!(s.contains("migrate blocked:"));
+        assert!(s.contains("checkout -> directory symlink"));
+        assert!(s.contains("has uncommitted changes"));
     }
 
     #[test]

--- a/src/status/git.rs
+++ b/src/status/git.rs
@@ -80,7 +80,13 @@ pub fn inspect(entry: &DesiredEntry) -> Result<Status> {
 /// *files* (not directories) redirecting to the shared bare repo are
 /// followed transparently by `Repository::open`, so this same logic covers
 /// both plain and worktree checkouts.
-fn inspect_checkout(path: &Path) -> Result<Status> {
+///
+/// `pub(crate)`: reused directly by `materialize::symlink` (#129) to detect
+/// a `checkout -> symlink` rule-change migration from a bare `&Path`,
+/// without needing a `Provenance::Git`-carrying `DesiredEntry` — the exact
+/// same safety gate `CheckoutMaterializer::classify` already relies on via
+/// [`inspect`], not re-derived.
+pub(crate) fn inspect_checkout(path: &Path) -> Result<Status> {
     if !path.exists() {
         return Ok(Status::Missing);
     }

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -184,6 +184,12 @@ impl Report {
                 (_, Operation::Create) => Status::Missing,
                 (_, Operation::Conflict { .. }) => Status::Conflict,
                 (intent, Operation::Noop) => classify_noop(intent),
+                // A pending rule-change migration (#129, blocked or not):
+                // target exists and doesn't match desired intent — `status`
+                // has no dedicated vocabulary for "migration pending", but
+                // `Conflict` is accurate (and an improvement over silently
+                // misclassifying these as `Noop`, as happened before #129).
+                (_, Operation::Migrate { .. }) => Status::Conflict,
                 (_, Operation::Deferred) => {
                     unreachable!("only Checkout entries ever classify as Deferred")
                 }
@@ -253,6 +259,29 @@ pub(crate) fn classify_noop(intent: &MaterializationIntent) -> Status {
         }
         _ => Status::Applied,
     }
+}
+
+/// Short, human-readable reason a checkout isn't safe to migrate away from
+/// yet — used by [`Operation::Migrate`](crate::plan::Operation)'s `blocked`
+/// field (#129). `unapply`'s own `status_word` stays separate (its own
+/// taxonomy, ADR-013); this is a full phrase, not a single word.
+pub(crate) fn describe(status: &Status) -> String {
+    match status {
+        Status::Applied => "is applied".to_string(),
+        Status::Missing => "is missing".to_string(),
+        Status::Modified => "has uncommitted changes".to_string(),
+        Status::Broken => "isn't a valid git repository".to_string(),
+        Status::Conflict => "has a merge/rebase/cherry-pick in progress".to_string(),
+        Status::Ahead(n) => format!("is {n} commit{} ahead of its upstream", plural(*n)),
+        Status::Behind(n) => format!("is {n} commit{} behind its upstream", plural(*n)),
+        Status::Diverged { ahead, behind } => {
+            format!("has diverged from its upstream ({ahead} ahead, {behind} behind)")
+        }
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
 }
 
 #[cfg(test)]
@@ -541,6 +570,37 @@ mod tests {
             .find(|e| matches!(e.entry.intent, MaterializationIntent::Checkout))
             .unwrap();
         assert_eq!(checkout_status.status, Status::Missing);
+    }
+
+    #[test]
+    fn describe_covers_every_status_variant() {
+        assert_eq!(describe(&Status::Applied), "is applied");
+        assert_eq!(describe(&Status::Missing), "is missing");
+        assert_eq!(describe(&Status::Modified), "has uncommitted changes");
+        assert_eq!(describe(&Status::Broken), "isn't a valid git repository");
+        assert_eq!(
+            describe(&Status::Conflict),
+            "has a merge/rebase/cherry-pick in progress"
+        );
+        assert_eq!(
+            describe(&Status::Ahead(1)),
+            "is 1 commit ahead of its upstream"
+        );
+        assert_eq!(
+            describe(&Status::Ahead(2)),
+            "is 2 commits ahead of its upstream"
+        );
+        assert_eq!(
+            describe(&Status::Behind(1)),
+            "is 1 commit behind its upstream"
+        );
+        assert_eq!(
+            describe(&Status::Diverged {
+                ahead: 2,
+                behind: 3
+            }),
+            "has diverged from its upstream (2 ahead, 3 behind)"
+        );
     }
 
     #[test]

--- a/src/ui/emojis.rs
+++ b/src/ui/emojis.rs
@@ -13,6 +13,7 @@ pub static MOVE_FILE: Emoji<'_, '_> = Emoji("📃", "");
 pub static WARNING: Emoji<'_, '_> = Emoji("⚠️", "");
 pub static TRASH: Emoji<'_, '_> = Emoji("🗑️", "");
 pub static BLOCK: Emoji<'_, '_> = Emoji("🧩", "");
+pub static MIGRATE: Emoji<'_, '_> = Emoji("🔀", "");
 // static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍  ", "");
 // static TRUCK: Emoji<'_, '_> = Emoji("🚚  ", "");
 // static CLIP: Emoji<'_, '_> = Emoji("🔗  ", "");

--- a/src/unapply/mod.rs
+++ b/src/unapply/mod.rs
@@ -201,6 +201,13 @@ impl Report {
                 (_, Operation::Conflict { current }) => Outcome::NotOwned {
                     current: current.clone(),
                 },
+                // A pending rule-change migration (#129, blocked or not):
+                // never remove something mid-migration — leave it alone
+                // and report it exactly like any other not-plain-owned
+                // entry, same as a `Conflict`.
+                (_, Operation::Migrate { .. }) => Outcome::NotOwned {
+                    current: actual::inspect(&step.entry.target)?,
+                },
                 // Every intent has a registered `Materializer` since #110;
                 // no step should ever classify as `Deferred` — unreachable
                 // in practice, but treated as "leave it alone" rather than
@@ -848,6 +855,34 @@ mod tests {
             Outcome::CheckoutNotClean {
                 status: Status::Modified
             }
+        ));
+        assert!(report.needs_attention());
+    }
+
+    #[test]
+    fn pending_migration_is_never_removed() {
+        // A clean git checkout sits where a directory symlink is now
+        // desired (#129, a rule/`overlay.git` change) — `Plan::build`
+        // classifies this as `Operation::Migrate`. Unapply must never
+        // remove something mid-migration, safe or not.
+        let td = TempDir::new().unwrap();
+        init_committed_repo(td.path());
+        let entry = DesiredEntry {
+            target: td.path().to_path_buf(),
+            provenance: Provenance::Overlay {
+                overlay: "ov".to_string(),
+                source: PathBuf::from("/repo/ov"),
+            },
+            intent: MaterializationIntent::SymlinkDirectory {
+                source: PathBuf::from("/repo/ov"),
+                link_type: LinkType::Soft,
+            },
+        };
+        let desired = DesiredTree::from_entries(vec![entry]);
+        let report = Report::build(&desired).unwrap();
+        assert!(matches!(
+            report.entries()[0].outcome,
+            Outcome::NotOwned { .. }
         ));
         assert!(report.needs_attention());
     }


### PR DESCRIPTION
Implements #129: when the materialization resolved for a target (rules,
`defaults`, or `overlay.git`) changes between runs, `over apply` now plans
and executes an explicit migration instead of silently getting stuck or
routing the change through the generic conflict-resolution UI.

Four transitions are covered:
- symlink -> checkout: the stale symlink is removed and the repository is
  cloned in its place. Always safe, since it never touches overlay source
  content.
- checkout -> symlink/directory: only migrates once the checkout is fully
  in sync with its upstream. A dirty, ahead, behind, diverged, or
  mid-merge checkout is reported as a blocked migration instead - never
  silently discarded, and never force-deletable.
- directory-level symlink -> recursed directory, and the reverse: the
  reverse direction only collapses a directory into a single symlink when
  every entry underneath it is provably a symlink the overlay would
  itself have created, so nothing foreign or irreplaceable is ever lost.

`over apply --dry-run`/`--verbose` report pending and blocked migrations
in the plan summary, and `status`/`diff`/`unapply` map the new operation
onto their own existing vocabularies rather than growing new ones.

Closes #129
