### PR TITLE
feat(materialize): migrate legacy symlink-only installations with no prior XDG state

### DIFF
--- a/src/actions/git/mod.rs
+++ b/src/actions/git/mod.rs
@@ -18,8 +18,10 @@ use tokio::{
     task::spawn_blocking,
 };
 
+use crate::actions::fs::remove_target;
 use crate::actions::git::config::{GitRepoConfig, ROOT_PATH};
 use crate::overlays::Overlay;
+use crate::plan::actual::{self, ActualState};
 use crate::{
     exec::{Action, Ctx},
     ui::{self, emojis, style},
@@ -101,6 +103,54 @@ impl fmt::Display for EnsureGitRepository {
     }
 }
 
+/// Remove whatever legacy, symlink-only content already sits at `path` so a
+/// fresh clone can proceed — or refuse outright when it holds anything that
+/// isn't reconstructible (#130).
+///
+/// `Overlay::apply_inner` calls [`clone_repositories`] directly, *before*
+/// building/classifying a [`crate::plan::Plan`] — so a real `over apply`
+/// never actually goes through `CheckoutMaterializer::classify`'s
+/// `Operation::Migrate` detection (#129); it needs the identical reasoning
+/// inline here instead, or a legacy install would just make `git2`'s clone
+/// fail outright (destination already exists) with a confusing raw error.
+/// A stale symlink (a `SymlinkFile`/`SymlinkDirectory` rule that used to
+/// resolve this path) or a whole directory populated file-by-file with
+/// individual symlinks (ADR-006's original default, predating rules and
+/// checkouts entirely) holds no data of its own — removing either is
+/// always safe. A real file anywhere in the way means that can't be
+/// proven, and must never be silently discarded.
+///
+/// A pre-existing *empty* directory is left untouched (not evidence of
+/// anything legacy — just a placeholder `git2` already clones into fine),
+/// and an already-established checkout (`path/.git` exists) is left alone
+/// entirely — the `exists` check just below handles it as a normal,
+/// already-applied repository, exactly like before this function existed.
+fn remove_legacy_materialization(path: &Path) -> Result<()> {
+    match actual::inspect(path)? {
+        ActualState::Missing => Ok(()),
+        ActualState::Symlink { .. } => remove_target(path),
+        ActualState::File => Err(anyhow!(
+            "refusing to clone into '{}': a file already exists there \
+             (not a reconstructible legacy `over` installation)",
+            path.display(),
+        )),
+        ActualState::Directory => {
+            if path.join(".git").exists() || std::fs::read_dir(path)?.next().is_none() {
+                return Ok(());
+            }
+            if actual::is_symlink_only(path)? {
+                remove_target(path)
+            } else {
+                Err(anyhow!(
+                    "refusing to clone into '{}': contains real content that isn't a \
+                     reconstructible legacy `over` installation — move it aside and rerun",
+                    path.display(),
+                ))
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl Action for EnsureGitRepository {
     async fn execute(&self, ctx: Ctx) -> Result<()> {
@@ -111,17 +161,26 @@ impl Action for EnsureGitRepository {
         pb.set_style(CLONE_PROGRESS_STYLE.clone());
         pb.set_prefix(self.short_name());
 
-        let repo_path = if self.config.worktree || self.config.worktrees.is_some() {
-            self.path.join(".git")
-        } else {
-            self.path.clone()
-        };
-
         // For bare repos (worktree mode), repo_path is `path/.git` which is
         // specific enough. For normal repos, check for `.git` inside the
         // directory so a pre-existing empty directory isn't mistaken for a repo
         // (e.g. the target root created by overlay apply before cloning).
         let is_bare = self.config.worktree || self.config.worktrees.is_some();
+
+        // Bare/worktree repos are out of scope (#130): no version of `over`
+        // that predates this feature could ever have produced one, so
+        // there's nothing legacy to detect here.
+        if !is_bare && !ctx.dry_run {
+            let path = self.path.clone();
+            spawn_blocking(move || remove_legacy_materialization(&path)).await??;
+        }
+
+        let repo_path = if is_bare {
+            self.path.join(".git")
+        } else {
+            self.path.clone()
+        };
+
         let exists = if is_bare {
             repo_path.exists()
         } else {
@@ -1364,6 +1423,175 @@ mod tests {
         assert!(display.contains("/home/user/repos/repo"));
         assert!(display.contains("https://github.com/user/repo.git"));
         assert!(display.contains(" -> "));
+    }
+
+    // ── legacy symlink-only installation migration (#130) ───────────────
+    //
+    // `Overlay::apply_inner` calls `clone_repositories` (and so
+    // `EnsureGitRepository::execute`) directly, *before* `Plan::build`
+    // classifies anything — this is the actual `over apply` path a legacy
+    // install with zero prior XDG state hits, distinct from
+    // `materialize::checkout`'s classify-only tests, which only cover
+    // `over status`/`over diff`/`--dry-run` previews.
+
+    fn git_config(url: &str) -> GitRepoConfig {
+        GitRepoConfig {
+            url: url.to_string(),
+            branch: None,
+            tag: None,
+            rev: None,
+            recurse_submodules: false,
+            worktree: false,
+            per_worktree_config: false,
+            worktrees: None,
+            remotes: None,
+            config: None,
+            worktree_config: None,
+        }
+    }
+
+    fn multiprogress_ctx() -> crate::exec::Ctx {
+        use crate::exec::Context;
+        use crate::overlays::Repository;
+        Context::builder()
+            .repository(Repository::new(std::env::temp_dir()))
+            .build()
+            .with_multiprogress(MultiProgress::new())
+    }
+
+    #[tokio::test]
+    async fn execute_removes_legacy_symlink_before_cloning() {
+        let (source_td, _source_repo) = create_source_repo();
+        let dest_td = TempDir::new().unwrap();
+        let stale_source = dest_td.path().join("stale_source");
+        fs::create_dir_all(&stale_source).unwrap();
+        let target = dest_td.path().join("checkout");
+        symlink::symlink_dir(&stale_source, &target).unwrap();
+
+        let action = EnsureGitRepository::new(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+            "ov".to_string(),
+        );
+        action.execute(multiprogress_ctx()).await.unwrap();
+
+        assert!(!target.is_symlink(), "stale symlink should be gone");
+        assert!(target.join(".git").exists());
+        assert!(target.join("README.md").exists());
+    }
+
+    #[tokio::test]
+    async fn execute_removes_legacy_symlink_only_directory_before_cloning() {
+        // The actual shape a legacy `over` install predating rules/checkout
+        // produces: every file recursed and symlinked individually
+        // (ADR-006), not a single top-level symlink.
+        let (source_td, _source_repo) = create_source_repo();
+        let dest_td = TempDir::new().unwrap();
+
+        let legacy_source = dest_td.path().join("legacy_source");
+        fs::create_dir_all(&legacy_source).unwrap();
+        fs::write(legacy_source.join("a.txt"), "a").unwrap();
+
+        let target = dest_td.path().join("checkout");
+        fs::create_dir_all(&target).unwrap();
+        symlink::symlink_file(legacy_source.join("a.txt"), target.join("a.txt")).unwrap();
+
+        let action = EnsureGitRepository::new(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+            "ov".to_string(),
+        );
+        action.execute(multiprogress_ctx()).await.unwrap();
+
+        assert!(target.join(".git").exists());
+        assert!(target.join("README.md").exists());
+        assert!(
+            !target.join("a.txt").is_symlink(),
+            "legacy symlink-only directory should have been replaced wholesale"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_refuses_to_clone_over_real_file() {
+        let (source_td, _source_repo) = create_source_repo();
+        let dest_td = TempDir::new().unwrap();
+        let target = dest_td.path().join("checkout");
+        fs::write(&target, "not from over").unwrap();
+
+        let action = EnsureGitRepository::new(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+            "ov".to_string(),
+        );
+        let result = action.execute(multiprogress_ctx()).await;
+
+        assert!(result.is_err());
+        assert_eq!(fs::read_to_string(&target).unwrap(), "not from over");
+    }
+
+    #[tokio::test]
+    async fn execute_refuses_to_clone_over_dirty_directory() {
+        let (source_td, _source_repo) = create_source_repo();
+        let dest_td = TempDir::new().unwrap();
+
+        let legacy_source = dest_td.path().join("legacy_source");
+        fs::create_dir_all(&legacy_source).unwrap();
+        fs::write(legacy_source.join("a.txt"), "a").unwrap();
+
+        let target = dest_td.path().join("checkout");
+        fs::create_dir_all(&target).unwrap();
+        symlink::symlink_file(legacy_source.join("a.txt"), target.join("a.txt")).unwrap();
+        fs::write(target.join("foreign.txt"), "not from over").unwrap();
+
+        let action = EnsureGitRepository::new(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+            "ov".to_string(),
+        );
+        let result = action.execute(multiprogress_ctx()).await;
+
+        assert!(result.is_err());
+        assert!(
+            target.join("foreign.txt").exists(),
+            "conflicting content must remain untouched"
+        );
+        assert!(
+            target.join("a.txt").is_symlink(),
+            "pre-existing symlink must remain untouched"
+        );
+        assert!(!target.join(".git").exists());
+    }
+
+    #[tokio::test]
+    async fn execute_dry_run_never_touches_a_legacy_symlink_or_directory() {
+        let (source_td, _source_repo) = create_source_repo();
+        let dest_td = TempDir::new().unwrap();
+        let stale_source = dest_td.path().join("stale_source");
+        fs::create_dir_all(&stale_source).unwrap();
+        let target = dest_td.path().join("checkout");
+        symlink::symlink_dir(&stale_source, &target).unwrap();
+
+        let action = EnsureGitRepository::new(
+            target.clone(),
+            git_config(source_td.path().to_str().unwrap()),
+            "ov".to_string(),
+        );
+        let ctx = {
+            use crate::exec::Context;
+            use crate::overlays::Repository;
+            Context::builder()
+                .repository(Repository::new(std::env::temp_dir()))
+                .dry_run(true)
+                .build()
+                .with_multiprogress(MultiProgress::new())
+        };
+        action.execute(ctx).await.unwrap();
+
+        assert!(
+            target.is_symlink(),
+            "dry-run must never remove the legacy symlink"
+        );
+        assert_eq!(fs::read_link(&target).unwrap(), stale_source);
     }
 
     // ── CloneState::update_bar ──────────────────────────────────────────

--- a/src/materialize/checkout.rs
+++ b/src/materialize/checkout.rs
@@ -16,9 +16,10 @@
 //! This materializer's `materialize` is therefore a correctness fallback
 //! (any other caller of `Plan::execute`, e.g. tests), not the primary path.
 
+use std::fs;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use tokio::task::spawn_blocking;
 
@@ -68,19 +69,55 @@ impl Materializer for CheckoutMaterializer {
     /// clean/dirty/ahead/behind/conflict detection — the same read-only
     /// inspection `over status`/`over diff` already rely on.
     fn classify(&self, entry: &DesiredEntry) -> Result<Operation> {
+        let actual = actual::inspect(&entry.target)?;
+
         // A stale symlink here (left by a `SymlinkFile`/`SymlinkDirectory`
-        // rule that used to resolve this path, #126) would otherwise make
-        // `status::git::inspect`'s `Repository::open` fail below ->
-        // `Status::Broken` -> collapse to `Noop`, silently stuck forever
-        // (the exact bug #129 fixes). Check `ActualState` first so a
-        // `symlink -> checkout` rule-change migration is detected instead.
-        // Always safe: removing a symlink never touches overlay source
-        // content, unlike a git checkout's own uncommitted work.
-        if let ActualState::Symlink { points_to } = actual::inspect(&entry.target)? {
+        // rule that used to resolve this path, #126, or a legacy `over`
+        // install predating XDG state tracking entirely, #130) would
+        // otherwise make `status::git::inspect`'s `Repository::open` fail
+        // below -> `Status::Broken` -> collapse to `Noop`, silently stuck
+        // forever (the exact bug #129 fixes). Check `ActualState` first so
+        // a `symlink -> checkout` migration is detected instead. Always
+        // safe: removing a symlink never touches overlay source content,
+        // unlike a git checkout's own uncommitted work.
+        if let ActualState::Symlink { points_to } = &actual {
             return Ok(Operation::Migrate {
-                from: reconstruct_symlink_intent(&points_to),
+                from: reconstruct_symlink_intent(points_to),
                 to: MaterializationIntent::Checkout,
                 blocked: None,
+            });
+        }
+
+        // A real, *non-empty* directory with no `.git`: the shape a legacy
+        // `over` install predating rules/checkouts actually produces —
+        // every file under this path recursed and symlinked individually
+        // (ADR-006's original default), not a single directory-level
+        // symlink (#130). An *empty* directory is deliberately left to the
+        // fallback below (unchanged from before this branch existed): it's
+        // indistinguishable from a plain placeholder directory created for
+        // this same target root before its first-ever clone, not evidence
+        // of anything legacy.
+        //
+        // Only auto-adopt when every leaf, recursively, is a symlink —
+        // nothing `over` didn't put there, so nothing is lost by removing
+        // it (`actual::is_symlink_only`, the same reasoning the branch
+        // above already applies to a single symlink). A real file mixed in
+        // means that can't be proven: surfaced as a conflict, never
+        // silently swallowed as `Noop` like it used to be.
+        if matches!(actual, ActualState::Directory)
+            && !entry.target.join(".git").exists()
+            && fs::read_dir(&entry.target)?.next().is_some()
+        {
+            return Ok(if actual::is_symlink_only(&entry.target)? {
+                Operation::Migrate {
+                    from: MaterializationIntent::Directory,
+                    to: MaterializationIntent::Checkout,
+                    blocked: None,
+                }
+            } else {
+                Operation::Conflict {
+                    current: ActualState::Directory,
+                }
             });
         }
 
@@ -101,12 +138,28 @@ impl Materializer for CheckoutMaterializer {
     }
 
     /// Invoked for `Operation::Create` (repository doesn't exist yet) and
-    /// for an unblocked `Operation::Migrate` (#129: a stale symlink sits
-    /// where a checkout is now desired) — the latter first removes the
-    /// symlink, then falls through to the same clone logic. Delegates to
-    /// the same, unchanged `EnsureGitRepository` action
-    /// `actions::git::clone_repositories` already runs per entry.
+    /// for an unblocked `Operation::Migrate` (#129: a stale symlink or a
+    /// legacy symlink-only directory, #130, sits where a checkout is now
+    /// desired) — the latter first removes what's there, then falls
+    /// through to the same clone logic. Delegates to the same, unchanged
+    /// `EnsureGitRepository` action `actions::git::clone_repositories`
+    /// already runs per entry.
     async fn materialize(&self, ctx: Ctx, step: &PlanStep) -> Result<()> {
+        // `classify` now returns this for a real file mixed into what
+        // would otherwise be a legacy symlink-only directory (#130) —
+        // previously unreachable for this materializer. Must never fall
+        // through to unconditionally cloning over it: there's no
+        // "absorb-diff"-style resolution for a checkout the way there is
+        // for symlinks/files, so this is the only safe response.
+        if let Operation::Conflict { current } = &step.operation {
+            return Err(anyhow!(
+                "refusing to clone into '{}': found {}, not a reconstructible \
+                 legacy `over` installation — move it aside and rerun",
+                step.entry.target.display(),
+                current,
+            ));
+        }
+
         let Provenance::Git {
             config, overlay, ..
         } = &step.entry.provenance
@@ -290,6 +343,117 @@ mod tests {
             }
             other => panic!("expected Migrate, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn classify_legacy_symlink_only_directory_is_migrate_to_checkout() {
+        // The actual shape a legacy `over` install predates rules/checkout
+        // with: every file recursed and symlinked individually (ADR-006),
+        // not a single top-level symlink — #130's primary scenario.
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let source = td.child("source_dir");
+        source.create_dir_all().unwrap();
+        source.child("a.txt").write_str("a").unwrap();
+        source.child("sub").create_dir_all().unwrap();
+        source.child("sub/b.txt").write_str("b").unwrap();
+
+        let target = td.child("target_dir");
+        target.create_dir_all().unwrap();
+        fs::create_dir_all(target.path().join("sub")).unwrap();
+        symlink::symlink_file(source.path().join("a.txt"), target.path().join("a.txt")).unwrap();
+        symlink::symlink_file(
+            source.path().join("sub/b.txt"),
+            target.path().join("sub/b.txt"),
+        )
+        .unwrap();
+
+        let e = entry(target.path().to_path_buf(), git_config(""));
+        match m.classify(&e).unwrap() {
+            Operation::Migrate { from, to, blocked } => {
+                assert!(matches!(from, MaterializationIntent::Directory));
+                assert!(matches!(to, MaterializationIntent::Checkout));
+                assert!(blocked.is_none());
+            }
+            other => panic!("expected Migrate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_directory_with_foreign_file_is_conflict_not_noop() {
+        // A real file mixed into what would otherwise be a legacy
+        // symlink-only directory can't be proven safe to discard — must
+        // surface as a conflict, never silently as `Noop` (the exact bug
+        // #130 fixes for this shape).
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let source = td.child("source.txt");
+        source.write_str("content").unwrap();
+
+        let target = td.child("target_dir");
+        target.create_dir_all().unwrap();
+        symlink::symlink_file(source.path(), target.path().join("linked.txt")).unwrap();
+        fs::write(target.path().join("foreign.txt"), "not from over").unwrap();
+
+        let e = entry(target.path().to_path_buf(), git_config(""));
+        assert!(matches!(
+            m.classify(&e).unwrap(),
+            Operation::Conflict {
+                current: ActualState::Directory
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_empty_directory_is_still_noop() {
+        // An empty directory with no `.git` is indistinguishable from a
+        // plain placeholder created before its first-ever clone — must
+        // not be treated as a legacy symlink-only install (regression
+        // guard for `classify_broken_checkout_is_noop`'s exact shape).
+        let m = CheckoutMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("empty_dir");
+        target.create_dir_all().unwrap();
+
+        let e = entry(target.path().to_path_buf(), git_config(""));
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[tokio::test]
+    async fn materialize_rejects_conflict() {
+        // `classify` can now return `Operation::Conflict` (#130) —
+        // `materialize` must refuse it outright rather than silently
+        // cloning over real content, and must touch nothing on disk.
+        use crate::exec::Context;
+
+        let td = TempDir::new().unwrap();
+        let source = td.child("source.txt");
+        source.write_str("content").unwrap();
+        let target = td.child("target_dir");
+        target.create_dir_all().unwrap();
+        symlink::symlink_file(source.path(), target.path().join("linked.txt")).unwrap();
+        fs::write(target.path().join("foreign.txt"), "not from over").unwrap();
+
+        let m = CheckoutMaterializer;
+        let e = entry(target.path().to_path_buf(), git_config(""));
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Conflict {
+                current: ActualState::Directory,
+            },
+        };
+        let ctx = Context::builder().build();
+        let result = m.materialize(ctx, &step).await;
+
+        assert!(result.is_err());
+        assert!(
+            target.path().join("foreign.txt").exists(),
+            "conflicting content must remain untouched"
+        );
+        assert!(
+            target.path().join("linked.txt").exists(),
+            "existing symlink must remain untouched"
+        );
     }
 
     #[tokio::test]

--- a/src/plan/actual.rs
+++ b/src/plan/actual.rs
@@ -72,6 +72,34 @@ pub fn inspect(path: &Path) -> Result<ActualState> {
     })
 }
 
+/// Whether `path` is, recursively, nothing but symlinks (or doesn't exist
+/// at all) — no real file/directory content anywhere underneath.
+///
+/// A symlink never holds unique data of its own — removing one is always
+/// safe (`CheckoutMaterializer::classify`'s stale-symlink branch, #129,
+/// already relies on exactly this reasoning for a single symlink). A
+/// directory built entirely of symlinks is safe to discard for the exact
+/// same reason, generalized: nothing is lost that `over` didn't put there
+/// in the first place. This is the primitive that recognizes a legacy
+/// `over` symlink-only installation with zero prior XDG state (#130) as
+/// safe to remove and replace with a checkout — a single real file
+/// anywhere underneath means that can't be proven, and must never be
+/// silently discarded.
+pub fn is_symlink_only(path: &Path) -> Result<bool> {
+    match inspect(path)? {
+        ActualState::Missing | ActualState::Symlink { .. } => Ok(true),
+        ActualState::File => Ok(false),
+        ActualState::Directory => {
+            for entry in fs::read_dir(path)? {
+                if !is_symlink_only(&entry?.path())? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,5 +171,77 @@ mod tests {
             ActualState::Symlink { points_to } => assert_eq!(points_to, source),
             other => panic!("expected Symlink, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn missing_path_is_symlink_only() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("does-not-exist");
+        assert!(is_symlink_only(&path).unwrap());
+    }
+
+    #[test]
+    fn a_single_symlink_is_symlink_only() {
+        let td = TempDir::new().unwrap();
+        let source = td.child("source.txt");
+        source.write_str("content").unwrap();
+        let link = td.path().join("link.txt");
+        symlink::symlink_file(source.path(), &link).unwrap();
+        assert!(is_symlink_only(&link).unwrap());
+    }
+
+    #[test]
+    fn a_real_file_is_not_symlink_only() {
+        let td = TempDir::new().unwrap();
+        let file = td.child("afile.txt");
+        file.write_str("content").unwrap();
+        assert!(!is_symlink_only(file.path()).unwrap());
+    }
+
+    #[test]
+    fn a_directory_of_only_symlinks_is_symlink_only() {
+        let td = TempDir::new().unwrap();
+        let source = td.child("source_dir");
+        source.create_dir_all().unwrap();
+        source.child("a.txt").write_str("a").unwrap();
+        source.child("sub").create_dir_all().unwrap();
+        source.child("sub/b.txt").write_str("b").unwrap();
+
+        let target = td.child("target_dir");
+        target.create_dir_all().unwrap();
+        fs::create_dir_all(target.path().join("sub")).unwrap();
+        symlink::symlink_file(source.path().join("a.txt"), target.path().join("a.txt")).unwrap();
+        symlink::symlink_file(
+            source.path().join("sub/b.txt"),
+            target.path().join("sub/b.txt"),
+        )
+        .unwrap();
+
+        assert!(is_symlink_only(target.path()).unwrap());
+    }
+
+    #[test]
+    fn a_directory_with_one_real_file_is_not_symlink_only() {
+        let td = TempDir::new().unwrap();
+        let source = td.child("source.txt");
+        source.write_str("content").unwrap();
+
+        let target = td.child("target_dir");
+        target.create_dir_all().unwrap();
+        symlink::symlink_file(source.path(), target.path().join("linked.txt")).unwrap();
+        fs::write(target.path().join("foreign.txt"), "not from over").unwrap();
+
+        assert!(!is_symlink_only(target.path()).unwrap());
+    }
+
+    #[test]
+    fn a_real_file_nested_in_a_subdirectory_is_not_symlink_only() {
+        let td = TempDir::new().unwrap();
+        let target = td.child("target_dir");
+        target.create_dir_all().unwrap();
+        target.child("sub").create_dir_all().unwrap();
+        fs::write(target.path().join("sub/foreign.txt"), "not from over").unwrap();
+
+        assert!(!is_symlink_only(target.path()).unwrap());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -941,6 +941,120 @@ fn sync_dry_run_reports_without_mutating() -> TestResult {
     Ok(())
 }
 
+// ── legacy symlink-only installation migration integration tests (#130) ───
+//
+// A legacy `over` install predates rules/checkout entirely: every file
+// recursed and symlinked individually (ADR-006's original default), no
+// `.git`, and — the scenario this issue is about — zero `$XDG_STATE_HOME`
+// tracking of any kind. `Overlay::apply_inner` clones git repositories
+// *before* `Plan::build` ever classifies anything (see
+// `actions::git::EnsureGitRepository::execute`'s `remove_legacy_materialization`,
+// #130), so this exercises the real `over apply` path end to end, not just
+// `over status`/`--dry-run` previews.
+
+#[test]
+#[cfg(unix)]
+fn legacy_symlink_only_installation_migrates_to_checkout_with_no_prior_xdg_state() -> TestResult {
+    let tmp = TempDir::new()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
+    let origin = canonical_tmp.join("origin");
+    setup_git_origin(&origin);
+    setup_git_overlay(&canonical_tmp, "legacy", &origin);
+
+    let root = TempDir::new()?;
+    let target = canonical_for_matching(root.path())?;
+
+    // Simulate what a pre-rules/pre-checkout `over` left behind at this
+    // same target root: content recursed and symlinked file by file, with
+    // no `.git` and no XDG state ever written for it.
+    let legacy_source = canonical_tmp.join("legacy_source");
+    fs::create_dir_all(legacy_source.join("sub"))?;
+    fs::write(legacy_source.join("a.txt"), "a")?;
+    fs::write(legacy_source.join("sub/b.txt"), "b")?;
+    fs::create_dir_all(target.join("sub"))?;
+    std::os::unix::fs::symlink(legacy_source.join("a.txt"), target.join("a.txt"))?;
+    std::os::unix::fs::symlink(legacy_source.join("sub/b.txt"), target.join("sub/b.txt"))?;
+
+    // A fresh, empty `$XDG_STATE_HOME` — the issue's explicit requirement:
+    // no prior `over` state directory of any kind, not even an empty one
+    // `over` itself created.
+    let xdg_state_home = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["apply", "legacy", "--root"])
+        .arg(&target)
+        .env("XDG_STATE_HOME", xdg_state_home.path())
+        .assert()
+        .success();
+
+    assert!(
+        target.join(".git").exists(),
+        "legacy install should have been migrated to a checkout"
+    );
+    assert!(
+        !target.join("a.txt").is_symlink(),
+        "legacy symlinks should be gone, replaced by the checkout"
+    );
+    assert!(
+        !target.join("sub/b.txt").is_symlink(),
+        "legacy symlinks should be gone, replaced by the checkout"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn legacy_symlink_installation_with_drift_is_reported_as_conflict_not_replaced() -> TestResult {
+    let tmp = TempDir::new()?;
+    let canonical_tmp = canonical_for_matching(tmp.path())?;
+    let origin = canonical_tmp.join("origin");
+    setup_git_origin(&origin);
+    setup_git_overlay(&canonical_tmp, "legacy2", &origin);
+
+    let root = TempDir::new()?;
+    let target = canonical_for_matching(root.path())?;
+
+    let legacy_source = canonical_tmp.join("legacy_source2");
+    fs::create_dir_all(&legacy_source)?;
+    fs::write(legacy_source.join("a.txt"), "a")?;
+    std::os::unix::fs::symlink(legacy_source.join("a.txt"), target.join("a.txt"))?;
+    // A real, non-symlink file mixed in — drift from what a legacy `over`
+    // install alone would ever have produced. Must never be silently
+    // discarded/replaced.
+    fs::write(target.join("foreign.txt"), "not from over")?;
+
+    let xdg_state_home = TempDir::new()?;
+
+    Command::cargo_bin("over")?
+        .arg("--home")
+        .arg(&canonical_tmp)
+        .args(["apply", "legacy2", "--root"])
+        .arg(&target)
+        .env("XDG_STATE_HOME", xdg_state_home.path())
+        .assert()
+        .failure();
+
+    assert!(
+        !target.join(".git").exists(),
+        "conflicting install must never be migrated"
+    );
+    assert!(
+        target.join("foreign.txt").exists(),
+        "conflicting content must remain untouched"
+    );
+    assert_eq!(
+        fs::read_to_string(target.join("foreign.txt"))?,
+        "not from over"
+    );
+    assert!(
+        target.join("a.txt").is_symlink(),
+        "pre-existing legacy symlink must remain untouched"
+    );
+    Ok(())
+}
+
 // ── unapply integration tests ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Detects an overlay subtree that was materialized as individual symlinks by
a version of `over` predating XDG state tracking, and migrates it to a
checkout automatically -- no unapply/reapply cycle, no reinstalling the overlay.

## What changed

- `plan::actual::is_symlink_only`: recognizes a directory built entirely of symlinks (the shape `over` produced before rules/checkout existed) as safe to discard, generalizing the "a symlink never holds unique data" reasoning #129 already applies to a single stale symlink.
- `CheckoutMaterializer::classify` uses it to detect this legacy shape as a migration instead of silently collapsing to `Noop` forever, and reports a real file mixed into the directory as a conflict instead of swallowing it.
- `EnsureGitRepository::execute` gets the identical detection inline: since `Overlay::apply_inner` clones repositories *before* `Plan::build` ever classifies anything, a real `over apply` never actually went through `CheckoutMaterializer`'s migration logic for a legacy install -- only `over status`/`over diff`/`--dry-run` previews did. This is the fix that makes the real `apply` path safe: it removes a clean legacy install before cloning, or refuses outright (leaving everything untouched) when real content is in the way.

No XDG state is read or written anywhere in this path, consistent with `over`'s existing "reconstructible, never authoritative" design.

Closes #130
