### PR TITLE
feat(desired): add file permission metadata resolved via hierarchical rules for partial files

### DIFF
--- a/docs/adr/020-file-permissions-are-hierarchical-rules-scoped-to-partial-files.md
+++ b/docs/adr/020-file-permissions-are-hierarchical-rules-scoped-to-partial-files.md
@@ -1,0 +1,90 @@
+# ADR-020: File permissions are hierarchical rules scoped to `PartialFile` entries
+
+**Status:** accepted
+
+## Context
+
+#107 deliberately left `DesiredEntry` without a `permissions` field,
+anticipating this issue (#65) rather than guessing its shape. Two things
+make permission metadata harder than it first looks, given ADR-006's
+symlink-first architecture:
+
+- Almost every `DesiredEntry` (`SymlinkFile`/`SymlinkDirectory`) is a
+  symlink to a file still tracked in the overlay's own source tree. A
+  symlink shares its target's inode: there is no independent "permission of
+  the target" to set — the only real mode is the overlay source file's own,
+  visible through the link. Managing it would mean `over` chmod'ing its own
+  tracked source file as a side effect of `apply`/`status`/`diff`, which are
+  otherwise all read-only-until-`execute` (`Plan::build`, `status::Report`,
+  `diff::Report` never mutate anything) — a much bigger, more surprising
+  commitment than this issue asks for.
+- Git only tracks a single executable bit (`100644` vs `100755`), not
+  arbitrary mode bits — a `0600` SSH key or credential file committed to an
+  overlay repo will not keep that mode across a clone. Nothing in `over`
+  today re-asserts a declared permission policy after materialization.
+- #113/ADR-017 already generalized `link_dirs` into a `defaults`/`rules`
+  hierarchical override model for materialization strategy, resolved
+  path-by-path while walking the overlay tree.
+
+## Decision
+
+Mirror ADR-017's `defaults`/`rules` shape for permissions
+(`src/overlays/permissions.rs`: `FileMode`, `PermissionRule`, `resolve`),
+but scope it to the one intent where `over` writes real, target-owned
+content directly today:
+[`MaterializationIntent::PartialFile`](../../src/desired/entry.rs) (#66).
+Every other intent (`Directory`, `Checkout`, `SymlinkFile`,
+`SymlinkDirectory`) always carries `DesiredEntry.permissions: None` and is
+never compared or enforced this way — see the regression test
+`symlinked_file_never_carries_a_permission_even_with_a_matching_rule` in
+`src/desired/tree.rs`.
+
+- `Overlay::permissions: Option<Vec<PermissionRule>>` (`[[permissions]]
+  path = "...", mode = "..."`) and `Overlay::defaults.mode: Option<FileMode>`
+  cascade through the same descriptor chain as every other field
+  (ADR-002), resolved with the same specificity precedence as
+  `MaterializationRule` (most specific match, else `defaults.mode`, else
+  `None` — unmanaged).
+- Resolution matches against a `PartialFile` entry's own sidecar-relative
+  stem (e.g. `ssh/agent` for `ssh/agent.partial.toml`), the same identity
+  `.link.*`/`.partial.*` sidecars already use elsewhere — not the rendered,
+  possibly-external `target` path, and not a path walked from the overlay's
+  own file tree the way `MaterializationRule` is.
+- A mismatch on an otherwise-correctly-materialized entry (content already
+  matches, only the mode differs) is a new `Operation::Repair { current,
+  desired }` — actionable like an unblocked `Migrate` (no prompt, no
+  `--force`), never a `Conflict`: nothing structural is wrong, only a
+  `chmod` is needed. `status` reports it as `Modified`; `diff` reuses the
+  existing line-diff renderer for a trivial `644 -> 600` text diff, exactly
+  like the symlink-target-path case already does — no new `Change` variant.
+- Materialization is a plain `fs::set_permissions` (`actions::fs::
+  SetPermissions`, `#[cfg(unix)]`-gated; a no-op on non-unix, where
+  permission bits aren't a meaningful concept to enforce), applied either
+  right after `EnsurePartialBlock` writes new/updated content, or on its
+  own for a pure `Repair` step.
+
+## Consequences
+
+Permission tracking only ever affects the file `over` itself writes
+content into — a symlinked file's permission remains entirely a function of
+the overlay source file, completely unmanaged by this feature, exactly the
+same as before #65. `#61`'s future rendered whole-file content is a natural
+extension of the same mechanism (another intent that writes real content
+`over` owns) with no redesign needed.
+
+A `permissions`/`defaults.mode` rule whose `path` never actually matches
+any `PartialFile` sidecar's stem silently has no effect — the same class of
+"no-op override" already possible with an unrelated `rules` entry (ADR-017)
+whose glob matches nothing on disk. `over lint` gains matching checks
+(`check_empty_permissions`, `check_invalid_permission_globs`,
+`check_duplicate_permission_rule_paths`), mirroring the existing `rules`
+checks, but deliberately has no "paths exist" check the way
+`check_rules_paths_exist` does: a permission rule's matching key is a
+sidecar stem, not a real path in the walked tree, so "exists on disk"
+doesn't apply the same way.
+
+Because `permissions`/`defaults` are replaced wholesale by the nearest
+config level that defines them, not merged element-wise (the same
+limitation ADR-017 already documents for `rules`), an overlay that defines
+its own `permissions` list loses the repository root's entries entirely
+unless it repeats them.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ by editing the old one. The history is the value.
 | [017](017-materialization-rules-generalize-link-dirs.md) | Materialization rules generalize `link_dirs` into path/subtree overrides, amending ADR-006 |
 | [018](018-root-declared-overlays-extend-descriptor-discovery.md) | Root-declared `overlays:` paths extend descriptor-glob discovery, amending ADR-002 |
 | [019](019-default-overlay-selection-extends-templating-to-overlay-choice.md) | `default_overlay` extends templating to overlay selection, amending ADR-010 |
+| [020](020-file-permissions-are-hierarchical-rules-scoped-to-partial-files.md) | File permissions are hierarchical rules scoped to `PartialFile` entries |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,38 @@ of walked file-by-file) still works and is equivalent to a `rules` entry
 with `materialization = "symlink-directory"` — both resolve through the
 same mechanism. See [ADR-017](adr/017-materialization-rules-generalize-link-dirs.md).
 
+## File Permissions
+
+`defaults.mode` and `permissions` mirror `defaults.materialization`/`rules`
+exactly (same cascading inheritance, same specificity precedence), but
+declare a desired permission mode instead of a materialization strategy:
+
+```toml
+[defaults]
+mode = "644"                          # octal string; applied when no more
+                                       # specific `permissions` entry matches
+
+[[permissions]]
+path = "ssh/agent"                     # matches a partial sidecar's own stem
+mode = "600"
+```
+
+- Only meaningful for [Partial Files](#partial-files) — the one place
+  `over` writes real, target-owned content directly today. Every symlinked
+  file/directory shares its overlay source's inode: there's no independent
+  target permission to set without `over` mutating that tracked source
+  file, which stays out of scope (see
+  [ADR-020](adr/020-file-permissions-are-hierarchical-rules-scoped-to-partial-files.md)).
+- `path` matches a `<name>.partial.{toml,yaml,yml}` sidecar's own stem
+  (e.g. `ssh/agent` for `ssh/agent.partial.toml`), not its rendered
+  `target`.
+- No `permissions`/`defaults.mode` at all (the default) leaves permissions
+  entirely unmanaged — identical to pre-#65 behavior.
+- A drift (the block's content already matches, but the target's actual
+  mode doesn't) is auto-fixed on the next `over apply`, reported by `over
+  status`/`over diff` like any other pending change — never a blocking
+  conflict.
+
 ## Partial Files
 
 A `<name>.partial.{toml,yaml,yml}` sidecar file, placed anywhere in an

--- a/src/actions/fs.rs
+++ b/src/actions/fs.rs
@@ -15,7 +15,7 @@ use tokio::task::spawn_blocking;
 use walkdir::WalkDir;
 
 use crate::exec::{Action, Ctx};
-use crate::overlays::Overlay;
+use crate::overlays::{FileMode, Overlay};
 use crate::ui;
 use crate::ui::style::DialogTheme;
 use crate::ui::{emojis, style};
@@ -506,6 +506,61 @@ impl Action for EnsureDir {
     }
 }
 
+/// Enforce a declared permission mode on an existing target (#65) — the
+/// materialization for `Operation::Repair`, when an entry's content/kind
+/// already matches but its mode doesn't. Never creates or removes
+/// anything; the target must already exist.
+pub struct SetPermissions {
+    pub path: PathBuf,
+    pub mode: FileMode,
+}
+
+impl SetPermissions {
+    pub fn new(path: PathBuf, mode: FileMode) -> Self {
+        Self { path, mode }
+    }
+}
+
+impl fmt::Display for SetPermissions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {} ({})",
+            emojis::LOCK,
+            style::white("set permissions:"),
+            short_path(&self.path.to_string_lossy()),
+            self.mode,
+        )
+    }
+}
+
+#[async_trait]
+impl Action for SetPermissions {
+    async fn execute(&self, ctx: Ctx) -> Result<()> {
+        if ctx.dry_run {
+            return Ok(());
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let path = self.path.clone();
+            let mode = self.mode.bits();
+            spawn_blocking(move || -> Result<()> {
+                fs::set_permissions(&path, fs::Permissions::from_mode(mode))?;
+                Ok(())
+            })
+            .await??;
+        }
+        // Permission bits aren't a meaningful concept to enforce here on
+        // non-unix platforms — nothing to do (see ADR-020).
+        #[cfg(not(unix))]
+        {
+            tracing::debug!(path = %self.path.display(), "permission metadata is not enforced on non-unix platforms");
+        }
+        Ok(())
+    }
+}
+
 pub struct EnsureDirLink {
     pub ctx: Ctx,
     pub source: PathBuf,
@@ -697,6 +752,55 @@ mod tests {
         let action = EnsureDir::new(dir_path.clone());
         action.execute(c.clone()).await.unwrap();
         assert!(dir_path.exists(), "directory should be created");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn set_permissions_changes_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let file = td.child("file.txt");
+        file.write_str("content").unwrap();
+        fs::set_permissions(file.path(), fs::Permissions::from_mode(0o644)).unwrap();
+
+        let action =
+            SetPermissions::new(file.path().to_path_buf(), FileMode::parse("600").unwrap());
+        let ctx = Context::builder().build();
+        action.execute(ctx).await.unwrap();
+
+        let mode = fs::metadata(file.path()).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn set_permissions_dry_run_does_not_touch_filesystem() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let file = td.child("file.txt");
+        file.write_str("content").unwrap();
+        fs::set_permissions(file.path(), fs::Permissions::from_mode(0o644)).unwrap();
+
+        let action =
+            SetPermissions::new(file.path().to_path_buf(), FileMode::parse("600").unwrap());
+        let ctx = Context::builder().dry_run(true).build();
+        action.execute(ctx).await.unwrap();
+
+        let mode = fs::metadata(file.path()).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o644, "dry_run must never touch the filesystem");
+    }
+
+    #[test]
+    fn set_permissions_display() {
+        let action = SetPermissions::new(
+            PathBuf::from("/tmp/file.txt"),
+            FileMode::parse("600").unwrap(),
+        );
+        let s = format!("{action}");
+        assert!(s.contains("set permissions:"));
+        assert!(s.contains("600"));
     }
 
     #[tokio::test]

--- a/src/actions/partial.rs
+++ b/src/actions/partial.rs
@@ -4,10 +4,11 @@
 //! `.link.*` sidecar convention (`src/actions/symlink.rs`) as closely as
 //! possible.
 //!
-//! Deliberately independent of #61 (full file templating) and #113
-//! (hierarchical rules): `content` is used verbatim, never rendered, and
-//! there is no per-path rule resolution here — the sidecar is, like
-//! `.link.*`, today's only per-path configuration mechanism.
+//! Deliberately independent of #61 (full file templating): `content` is
+//! used verbatim, never rendered. #65 does resolve a hierarchical
+//! `permissions`/`defaults.mode` rule for the target's declared mode (see
+//! `crate::overlays::permissions` and ADR-020) — the one hierarchical-rule
+//! concern this module honors, applied via [`EnsurePartialBlock::with_permissions`].
 //!
 //! v1 assumes a `#`-comment target file (shell rc files, ini-style
 //! configs, gitconfig, ssh config...) — the marker line format is fixed,
@@ -29,6 +30,7 @@ use tokio::task::spawn_blocking;
 
 use crate::diff::ContentDiff;
 use crate::exec::{Action, Ctx};
+use crate::overlays::FileMode;
 use crate::plan::actual::{self, ActualState};
 use crate::ui;
 use crate::ui::style::DialogTheme;
@@ -430,6 +432,10 @@ pub struct EnsurePartialBlock {
     pub target: PathBuf,
     pub marker: String,
     pub content: String,
+    /// Desired permission mode (#65), applied to `target` right after any
+    /// write this action performs. `None` (the default via `new`) leaves
+    /// permissions entirely unmanaged, matching pre-#65 behavior.
+    pub permissions: Option<FileMode>,
 }
 
 impl EnsurePartialBlock {
@@ -438,7 +444,16 @@ impl EnsurePartialBlock {
             target,
             marker,
             content,
+            permissions: None,
         }
+    }
+
+    /// Declare the permission mode to enforce on `target` after writing
+    /// (#65) — a builder rather than a `new()` parameter so the ~15
+    /// existing 3-arg call sites (this action predates #65) stay untouched.
+    pub fn with_permissions(mut self, permissions: Option<FileMode>) -> Self {
+        self.permissions = permissions;
+        self
     }
 }
 
@@ -455,6 +470,29 @@ impl fmt::Display for EnsurePartialBlock {
     }
 }
 
+/// Write `data` to `target`, then apply `permissions` (#65) if declared —
+/// factored out since `EnsurePartialBlock::execute` writes the target from
+/// several distinct branches, all of which must apply the same declared
+/// mode.
+fn write_target(
+    target: &Path,
+    data: impl AsRef<[u8]>,
+    permissions: Option<FileMode>,
+) -> Result<()> {
+    fs::write(target, data).with_context(|| format!("failed to write {}", target.display()))?;
+    #[cfg(unix)]
+    if let Some(mode) = permissions {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(target, fs::Permissions::from_mode(mode.bits()))
+            .with_context(|| format!("failed to set permissions on {}", target.display()))?;
+    }
+    // Permission bits aren't a meaningful concept to enforce here on
+    // non-unix platforms (see ADR-020) — `permissions` is simply unused.
+    #[cfg(not(unix))]
+    let _ = permissions;
+    Ok(())
+}
+
 #[async_trait]
 impl Action for EnsurePartialBlock {
     async fn execute(&self, ctx: Ctx) -> Result<()> {
@@ -464,6 +502,7 @@ impl Action for EnsurePartialBlock {
         let target = self.target.clone();
         let marker = self.marker.clone();
         let content = self.content.clone();
+        let permissions = self.permissions;
         let ctx2 = ctx.clone();
         spawn_blocking(move || -> Result<()> {
             match actual::inspect(&target)? {
@@ -476,16 +515,14 @@ impl Action for EnsurePartialBlock {
                             )
                         })?;
                     }
-                    fs::write(&target, block_only(&marker, &content))
-                        .with_context(|| format!("failed to write {}", target.display()))?;
+                    write_target(&target, block_only(&marker, &content), permissions)?;
                     Ok(())
                 }
                 ActualState::Directory | ActualState::Symlink { .. } => {
                     if !resolve_structural_conflict(&ctx2, &target)? {
                         return Ok(()); // Skipped.
                     }
-                    fs::write(&target, block_only(&marker, &content))
-                        .with_context(|| format!("failed to write {}", target.display()))?;
+                    write_target(&target, block_only(&marker, &content), permissions)?;
                     Ok(())
                 }
                 ActualState::File => {
@@ -493,14 +530,21 @@ impl Action for EnsurePartialBlock {
                         .with_context(|| format!("failed to read {}", target.display()))?;
                     match find_block(&current, &marker) {
                         BlockState::Absent => {
-                            fs::write(&target, append_block(&current, &marker, &content))
-                                .with_context(|| format!("failed to write {}", target.display()))?;
+                            write_target(
+                                &target,
+                                append_block(&current, &marker, &content),
+                                permissions,
+                            )?;
                         }
                         BlockState::Found(existing) if existing == content => {
                             // Already correct — `materialize` is only ever
                             // invoked for `Create`/`Conflict` steps, so this
                             // is a defensive no-op against a classify→
-                            // execute race, not the expected path.
+                            // execute race, not the expected path. A
+                            // permission-only drift is never routed through
+                            // here either (`Operation::Repair` bypasses
+                            // `EnsurePartialBlock` entirely — see
+                            // `materialize::partial`).
                         }
                         BlockState::Found(_) | BlockState::Malformed => {
                             if !resolve_block_conflict(&ctx2, &target, &marker, &current, &content)?
@@ -514,8 +558,7 @@ impl Action for EnsurePartialBlock {
                                 // well-formed block after them instead.
                                 _ => append_block(&current, &marker, &content),
                             };
-                            fs::write(&target, updated)
-                                .with_context(|| format!("failed to write {}", target.display()))?;
+                            write_target(&target, updated, permissions)?;
                         }
                     }
                     Ok(())
@@ -928,6 +971,62 @@ mod tests {
             fs::read_to_string(&target).unwrap(),
             "export FOO=bar\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_partial_block_applies_permissions_to_a_new_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string())
+                .with_permissions(Some(FileMode::parse("600").unwrap()));
+        action
+            .execute(ctx_force(false, false, false))
+            .await
+            .unwrap();
+
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn ensure_partial_block_applies_permissions_when_appending_to_an_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        fs::write(&target, "export FOO=bar\n").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string())
+                .with_permissions(Some(FileMode::parse("600").unwrap()));
+        action
+            .execute(ctx_force(false, false, false))
+            .await
+            .unwrap();
+
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[tokio::test]
+    async fn ensure_partial_block_without_declared_permissions_leaves_default_mode() {
+        // No `.with_permissions(...)` call at all — must behave exactly
+        // like before #65 (no permission management whatsoever).
+        let td = TempDir::new().unwrap();
+        let target = td.path().join(".zshrc");
+        let action =
+            EnsurePartialBlock::new(target.clone(), "m".to_string(), "alias x=y".to_string());
+        action
+            .execute(ctx_force(false, false, false))
+            .await
+            .unwrap();
+        assert!(target.exists());
     }
 
     #[tokio::test]

--- a/src/desired/entry.rs
+++ b/src/desired/entry.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use crate::actions::git::config::GitRepoConfig;
 use crate::actions::symlink::LinkType;
+use crate::overlays::FileMode;
 
 /// What kind of filesystem node a [`DesiredEntry`] should be, independent of
 /// *how* it gets there (see [`MaterializationIntent`]).
@@ -109,15 +110,22 @@ pub enum Provenance {
 /// A single desired filesystem node — the canonical unit [`super::DesiredTree`]
 /// is made of.
 ///
-/// Deliberately does not carry rendered content (#61) or permission metadata
-/// (#65): both depend on this type and will extend it rather than have this
-/// issue guess their shape.
+/// Deliberately does not carry rendered content (#61): that depends on this
+/// type and will extend it rather than have this issue guess its shape.
 #[derive(Debug, Clone)]
 pub struct DesiredEntry {
     /// Absolute path this entry should exist at.
     pub target: PathBuf,
     pub provenance: Provenance,
     pub intent: MaterializationIntent,
+    /// Desired permission mode (#65), resolved from `overlay.defaults.mode`/
+    /// `overlay.permissions` — see [`crate::overlays::Overlay::permission_for`].
+    /// `None` for every intent except [`MaterializationIntent::PartialFile`]:
+    /// symlinked entries share their overlay source's inode (there is no
+    /// independent target permission to set without mutating that source,
+    /// out of scope for #65 — see ADR-020), and `Directory`/`Checkout`
+    /// entries have no permission concept here either.
+    pub permissions: Option<FileMode>,
 }
 
 impl DesiredEntry {
@@ -183,6 +191,7 @@ mod tests {
                 source: PathBuf::from("/overlay/file.txt"),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         assert_eq!(entry.kind(), EntryKind::Symlink);
     }

--- a/src/desired/mod.rs
+++ b/src/desired/mod.rs
@@ -40,7 +40,11 @@
 //!   `Overlay::materialization_for`/`crate::overlays::rules` before this
 //!   module ever walks the overlay tree.)
 //! - Rendered file content (`DesiredEntry` has no `content` field) — #61.
-//! - Permission metadata (`DesiredEntry` has no `permissions` field) — #65.
+//! - Permission metadata is present (`DesiredEntry.permissions`, #65) but
+//!   scoped to entries `over` writes content for directly (`PartialFile`
+//!   today) — a symlinked entry shares its overlay source's inode, so
+//!   there's no independent target permission to manage without mutating
+//!   that source, which stays out of scope (see ADR-020).
 //! - Comparing against actual filesystem state and materializing anything —
 //!   that's [`crate::plan`] (#13) and [`crate::materialize`] (#108).
 //!   `DesiredTree` is consumed by those, not a replacement for

--- a/src/desired/tree.rs
+++ b/src/desired/tree.rs
@@ -149,6 +149,7 @@ fn collect_own_entries(
             source: overlay.root.clone(),
         },
         intent: MaterializationIntent::Directory,
+        permissions: None,
     });
 
     // Git-managed paths: materialized by CheckoutMaterializer (#110), which
@@ -169,6 +170,7 @@ fn collect_own_entries(
                     config: Box::new(config.clone()),
                 },
                 intent: MaterializationIntent::Checkout,
+                permissions: None,
             });
         }
     }
@@ -251,6 +253,7 @@ fn walk_overlay_tree(
                     source: path.to_path_buf(),
                     link_type: symlink::LinkType::Soft,
                 },
+                permissions: None,
             });
             walker.skip_current_dir();
             continue;
@@ -264,6 +267,7 @@ fn walk_overlay_tree(
                     source: path.to_path_buf(),
                 },
                 intent: MaterializationIntent::Directory,
+                permissions: None,
             });
         } else {
             entries.push(DesiredEntry {
@@ -276,6 +280,7 @@ fn walk_overlay_tree(
                     source: path.to_path_buf(),
                     link_type: symlink::LinkType::Soft,
                 },
+                permissions: None,
             });
         }
     }
@@ -323,6 +328,10 @@ fn build_symlink_sidecars(
             target: entry_target,
             provenance,
             intent,
+            // Symlink sidecars carry a source outside the overlay's own
+            // walked tree, but the same reasoning applies: no independent
+            // target permission without mutating that source (ADR-020).
+            permissions: None,
         });
     }
     Ok(())
@@ -365,6 +374,12 @@ fn build_partial_sidecars(
         let resolved = symlink::render_symlink_target(&config.target, ctx)?;
         let config_path = partial_sidecar_config_path(&overlay.root, &name);
         let marker = config.marker.unwrap_or_else(|| name.clone());
+        // The only intent `over` writes real target content for directly
+        // (#65) — resolved against the sidecar's own overlay-relative stem
+        // (not the rendered, possibly-external `target`), so `permissions`
+        // rules match the same identity `.link.*`/`.partial.*` naming
+        // already uses elsewhere.
+        let permissions = overlay.permission_for(Path::new(&name));
 
         entries.push(DesiredEntry {
             target: PathBuf::from(resolved),
@@ -376,6 +391,7 @@ fn build_partial_sidecars(
                 content: config.content,
                 marker,
             },
+            permissions,
         });
     }
     Ok(())
@@ -873,6 +889,144 @@ mod tests {
             MaterializationIntent::PartialFile { marker, .. } => assert_eq!(marker, "custom"),
             other => panic!("unexpected intent: {other:?}"),
         }
+    }
+
+    // ── #65: permission resolution ───────────────────────────────────────
+
+    #[rstest]
+    fn partial_sidecar_resolves_permission_from_defaults() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"\n[defaults]\nmode = \"600\"")
+            .unwrap();
+        let target_toml = td
+            .path()
+            .join("out.txt")
+            .to_string_lossy()
+            .replace('\\', "\\\\");
+        overlay_dir
+            .child("aliases.partial.toml")
+            .write_str(&format!("target = \"{}\"\ncontent = \"x\"", target_toml))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == td.path().join("out.txt"))
+            .expect("partial entry present");
+        assert_eq!(
+            entry.permissions,
+            Some(crate::overlays::FileMode::parse("600").unwrap())
+        );
+    }
+
+    #[rstest]
+    fn partial_sidecar_specific_rule_overrides_defaults() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str(
+                "target = \"~\"\n[defaults]\nmode = \"644\"\n\n[[permissions]]\npath = \"aliases\"\nmode = \"600\"",
+            )
+            .unwrap();
+        let target_toml = td
+            .path()
+            .join("out.txt")
+            .to_string_lossy()
+            .replace('\\', "\\\\");
+        overlay_dir
+            .child("aliases.partial.toml")
+            .write_str(&format!("target = \"{}\"\ncontent = \"x\"", target_toml))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == td.path().join("out.txt"))
+            .expect("partial entry present");
+        assert_eq!(
+            entry.permissions,
+            Some(crate::overlays::FileMode::parse("600").unwrap())
+        );
+    }
+
+    #[rstest]
+    fn partial_sidecar_without_any_rule_has_no_permission() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str("target = \"~\"")
+            .unwrap();
+        let target_toml = td
+            .path()
+            .join("out.txt")
+            .to_string_lossy()
+            .replace('\\', "\\\\");
+        overlay_dir
+            .child("aliases.partial.toml")
+            .write_str(&format!("target = \"{}\"\ncontent = \"x\"", target_toml))
+            .unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == td.path().join("out.txt"))
+            .expect("partial entry present");
+        assert_eq!(entry.permissions, None);
+    }
+
+    /// Symlinked entries share their overlay source's inode — there is no
+    /// independent target permission to manage without mutating that
+    /// source (ADR-020), so a `permissions` rule matching a plain file's
+    /// path must never populate `DesiredEntry.permissions` for it, even
+    /// when the rule's `path` matches exactly.
+    #[rstest]
+    fn symlinked_file_never_carries_a_permission_even_with_a_matching_rule() {
+        let (td, repo) = repo_and_root();
+        let overlay_dir = td.child("ov");
+        overlay_dir.create_dir_all().unwrap();
+        overlay_dir
+            .child("over.toml")
+            .write_str(
+                "target = \"~\"\n[defaults]\nmode = \"600\"\n\n[[permissions]]\npath = \"file.txt\"\nmode = \"600\"",
+            )
+            .unwrap();
+        overlay_dir.child("file.txt").write_str("content").unwrap();
+
+        let overlay = repo.get("ov").unwrap();
+        let c = ctx(td.path().to_path_buf(), repo.clone());
+        let tree = DesiredTree::build(&c, &overlay).unwrap();
+
+        let root = td.path().to_path_buf();
+        let file_entry = tree
+            .entries()
+            .iter()
+            .find(|e| e.target == root.join("file.txt"))
+            .expect("file.txt entry present");
+        assert!(matches!(
+            file_entry.intent,
+            MaterializationIntent::SymlinkFile { .. }
+        ));
+        assert_eq!(file_entry.permissions, None);
     }
 
     #[rstest]

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -204,6 +204,14 @@ fn classify_fs(entry: &DesiredEntry, operation: &Operation) -> Result<Change> {
         Operation::Migrate { .. } => Ok(Change::Unexpected {
             actual: actual::inspect(&entry.target)?,
         }),
+        // A permission-only drift (#65): content/kind already matches,
+        // only the mode differs — reuse the line-diff renderer for a
+        // trivial one-line "text" diff (`644` -> `755`), exactly like the
+        // symlink-target-path case above.
+        Operation::Repair { current, desired } => Ok(Change::Modified(ContentDiff::from_texts(
+            &current.to_string(),
+            &desired.to_string(),
+        ))),
         Operation::Deferred => unreachable!(
             "only Checkout entries ever classify as Deferred, and those are \
              routed to classify_checkout before reaching classify_fs"
@@ -492,6 +500,7 @@ mod tests {
                 content: "alias x=y".to_string(),
                 marker: "m".to_string(),
             },
+            permissions: None,
         };
         let change = classify_conflict(&entry, &ActualState::File).unwrap();
         match change {
@@ -529,6 +538,7 @@ mod tests {
                 content: "alias x=y".to_string(),
                 marker: "m".to_string(),
             },
+            permissions: None,
         };
         let result = classify_conflict(&entry, &ActualState::File);
 
@@ -555,6 +565,7 @@ mod tests {
                 content: "alias x=y".to_string(),
                 marker: "m".to_string(),
             },
+            permissions: None,
         };
         let change = classify_conflict(&entry, &ActualState::File).unwrap();
         match change {
@@ -718,6 +729,7 @@ mod tests {
                 source: std::path::PathBuf::from("/does/not/exist/anymore"),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let change = classify_fs(&entry, &Operation::Noop).unwrap();
         assert!(matches!(change, Change::Broken));
@@ -738,6 +750,7 @@ mod tests {
                 source: std::path::PathBuf::from("/repo/ov"),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let operation = Operation::Migrate {
             from: MaterializationIntent::Checkout,
@@ -828,6 +841,7 @@ mod tests {
                 }),
             },
             intent: MaterializationIntent::Checkout,
+            permissions: None,
         };
 
         let change = classify_checkout(&entry).unwrap();

--- a/src/lint/checks.rs
+++ b/src/lint/checks.rs
@@ -22,6 +22,9 @@ pub fn check_overlay(overlay: &Overlay) -> Vec<Diagnostic> {
     diagnostics.extend(check_invalid_rules_globs(overlay));
     diagnostics.extend(check_duplicate_rule_paths(overlay));
     diagnostics.extend(check_rules_paths_exist(overlay));
+    diagnostics.extend(check_empty_permissions(overlay));
+    diagnostics.extend(check_invalid_permission_globs(overlay));
+    diagnostics.extend(check_duplicate_permission_rule_paths(overlay));
     diagnostics.extend(check_git(overlay));
     diagnostics.extend(check_symlinks(overlay));
     diagnostics.extend(check_partials(overlay));
@@ -233,6 +236,72 @@ fn check_rules_paths_exist(overlay: &Overlay) -> Vec<Diagnostic> {
                     ),
                 )
                 .with_hint("remove the rule or fix the path"),
+            );
+        }
+    }
+    diagnostics
+}
+
+// ── permission rules checks (#65) ────────────────────────────────────────
+//
+// No "paths exist" check here (unlike `check_rules_paths_exist`): a
+// `permissions` rule matches a `PartialFile` entry's own sidecar stem, not
+// a real path in the overlay's walked tree, so "exists in the walked
+// tree" doesn't apply the same way.
+
+fn check_empty_permissions(overlay: &Overlay) -> Vec<Diagnostic> {
+    if matches!(&overlay.permissions, Some(list) if list.is_empty()) {
+        vec![
+            Diagnostic::warning(&overlay.name, "empty `permissions` list is redundant")
+                .with_hint("remove the `permissions` field or add path overrides"),
+        ]
+    } else {
+        Vec::new()
+    }
+}
+
+fn check_invalid_permission_globs(overlay: &Overlay) -> Vec<Diagnostic> {
+    let Some(permissions) = &overlay.permissions else {
+        return Vec::new();
+    };
+
+    let mut diagnostics = Vec::new();
+    for rule in permissions {
+        if let Err(err) = GlobBuilder::new(&rule.path).literal_separator(true).build() {
+            diagnostics.push(
+                Diagnostic::error(
+                    &overlay.name,
+                    format!("invalid glob pattern in `permissions`: \"{}\"", rule.path),
+                )
+                .with_hint(format!("{err}")),
+            );
+        }
+    }
+    diagnostics
+}
+
+/// A rule whose `path` exactly duplicates an earlier one always shadows it
+/// (`permissions::resolve` breaks specificity ties by keeping the last
+/// match, mirroring `rules::resolve`), so the earlier entry can never take
+/// effect.
+fn check_duplicate_permission_rule_paths(overlay: &Overlay) -> Vec<Diagnostic> {
+    let Some(permissions) = &overlay.permissions else {
+        return Vec::new();
+    };
+
+    let mut diagnostics = Vec::new();
+    let mut seen = HashSet::new();
+    for rule in permissions {
+        if !seen.insert(&rule.path) {
+            diagnostics.push(
+                Diagnostic::warning(
+                    &overlay.name,
+                    format!(
+                        "duplicate permission rule path \"{}\"; only the last entry ever applies",
+                        rule.path
+                    ),
+                )
+                .with_hint("remove the redundant rule"),
             );
         }
     }
@@ -625,6 +694,54 @@ materialization = "symlink-directory"
         std::fs::create_dir_all(overlay.root.join("present")).unwrap();
         let diags = check_rules_paths_exist(&overlay);
         assert!(diags.is_empty());
+    }
+
+    // ── permission rules checks (#65) ─────────────────────────────────────
+
+    #[rstest]
+    fn test_empty_permissions() {
+        let overlay = setup_overlay("target = \"~\"\npermissions = []");
+        let diags = check_empty_permissions(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+    }
+
+    #[rstest]
+    fn test_invalid_glob_in_permissions() {
+        let overlay =
+            setup_overlay("target = \"~\"\n[[permissions]]\npath = \"[invalid\"\nmode = \"600\"");
+        let diags = check_invalid_permission_globs(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert!(diags[0].message.contains("invalid glob"));
+    }
+
+    #[rstest]
+    fn test_valid_glob_in_permissions() {
+        let overlay =
+            setup_overlay("target = \"~\"\n[[permissions]]\npath = \"secrets/*\"\nmode = \"600\"");
+        let diags = check_invalid_permission_globs(&overlay);
+        assert!(diags.is_empty());
+    }
+
+    #[rstest]
+    fn test_duplicate_permission_rule_paths() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[[permissions]]
+path = "dup"
+mode = "600"
+
+[[permissions]]
+path = "dup"
+mode = "644"
+"#,
+        );
+        let diags = check_duplicate_permission_rule_paths(&overlay);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert!(diags[0].message.contains("duplicate permission rule path"));
     }
 
     // ── git checks ───────────────────────────────────────────────────────

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -254,6 +254,7 @@ const VALID_OVERLAY_KEYS: &[&str] = &[
     "install",
     "link_dirs",
     "overlays",
+    "permissions",
     "rules",
     "target",
     "uses",

--- a/src/materialize/checkout.rs
+++ b/src/materialize/checkout.rs
@@ -225,6 +225,7 @@ mod tests {
                 config: Box::new(config),
             },
             intent: MaterializationIntent::Checkout,
+            permissions: None,
         }
     }
 

--- a/src/materialize/mod.rs
+++ b/src/materialize/mod.rs
@@ -117,6 +117,7 @@ mod tests {
                 source: PathBuf::from("/repo/ov"),
             },
             intent,
+            permissions: None,
         }
     }
 

--- a/src/materialize/partial.rs
+++ b/src/materialize/partial.rs
@@ -9,17 +9,53 @@
 //! [`crate::actions::partial::EnsurePartialBlock`].
 
 use std::fs;
+use std::path::Path;
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 
+use crate::actions::fs::SetPermissions;
 use crate::actions::partial::{BlockState, EnsurePartialBlock, find_block};
 use crate::desired::{DesiredEntry, MaterializationIntent};
 use crate::exec::{Action, Ctx};
+use crate::overlays::FileMode;
 use crate::plan::actual::{self, ActualState};
 use crate::plan::{Operation, PlanStep};
 
 use super::Materializer;
+
+/// Compare `entry`'s declared permission (if any) against what's actually
+/// on disk at `path`, returning `Some((current, desired))` on a mismatch —
+/// `None` either because nothing is declared (unmanaged, pre-#65 behavior)
+/// or because it already matches.
+#[cfg(unix)]
+fn permission_drift(
+    path: &Path,
+    desired: Option<FileMode>,
+) -> Result<Option<(FileMode, FileMode)>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(desired) = desired else {
+        return Ok(None);
+    };
+    let current = FileMode::from_bits(
+        fs::metadata(path)
+            .with_context(|| format!("failed to read metadata for {}", path.display()))?
+            .permissions()
+            .mode(),
+    );
+    Ok((current.bits() != desired.bits()).then_some((current, desired)))
+}
+
+/// Permission bits aren't a meaningful concept to enforce here on
+/// non-unix platforms (see ADR-020) — never any drift to report.
+#[cfg(not(unix))]
+fn permission_drift(
+    _path: &Path,
+    _desired: Option<FileMode>,
+) -> Result<Option<(FileMode, FileMode)>> {
+    Ok(None)
+}
 
 /// Owns [`MaterializationIntent::PartialFile`]. See the module docs for
 /// how this differs from [`super::symlink::SymlinkMaterializer`].
@@ -49,7 +85,15 @@ impl Materializer for PartialFileMaterializer {
                     // No block yet: inserting one is purely additive, same
                     // "nothing here yet" spirit as `Operation::Create`.
                     BlockState::Absent => Operation::Create,
-                    BlockState::Found(existing) if existing == content => Operation::Noop,
+                    // Content already correct — but a declared permission
+                    // (#65) might still be wrong, in which case only a
+                    // `chmod` is needed, not a rewrite.
+                    BlockState::Found(existing) if existing == content => {
+                        match permission_drift(&entry.target, entry.permissions)? {
+                            Some((current, desired)) => Operation::Repair { current, desired },
+                            None => Operation::Noop,
+                        }
+                    }
                     // Drifted (hand-edited, or another overlay's stale
                     // write) or malformed markers: never touched
                     // automatically — surfaced as a conflict exactly like
@@ -68,7 +112,16 @@ impl Materializer for PartialFileMaterializer {
         let MaterializationIntent::PartialFile { content, marker } = &step.entry.intent else {
             unreachable!("MaterializerRegistry only calls materialize() after handles() passed")
         };
+        // Content already matches (#65) — only the permission mode needs
+        // fixing, so skip `EnsurePartialBlock` entirely (it would otherwise
+        // rewrite an already-correct block for no reason).
+        if let Operation::Repair { desired, .. } = &step.operation {
+            return SetPermissions::new(step.entry.target.clone(), *desired)
+                .execute(ctx)
+                .await;
+        }
         EnsurePartialBlock::new(step.entry.target.clone(), marker.clone(), content.clone())
+            .with_permissions(step.entry.permissions)
             .execute(ctx)
             .await
     }
@@ -93,6 +146,19 @@ mod tests {
                 content: content.to_string(),
                 marker: marker.to_string(),
             },
+            permissions: None,
+        }
+    }
+
+    fn entry_with_permissions(
+        target: PathBuf,
+        content: &str,
+        marker: &str,
+        mode: &str,
+    ) -> DesiredEntry {
+        DesiredEntry {
+            permissions: Some(FileMode::parse(mode).unwrap()),
+            ..entry(target, content, marker)
         }
     }
 
@@ -218,5 +284,111 @@ mod tests {
             fs::read_to_string(&target).unwrap(),
             "# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n"
         );
+    }
+
+    // ── #65: permission classification/materialization ──────────────────
+
+    #[test]
+    fn classify_matching_block_without_declared_permission_is_noop() {
+        // No `permissions` declared at all — must behave exactly like
+        // before #65, regardless of the target's actual mode.
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target
+            .write_str("# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n")
+            .unwrap();
+        let e = entry(target.path().to_path_buf(), "alias x=y", "m");
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn classify_matching_block_with_correct_permission_is_noop() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target
+            .write_str("# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n")
+            .unwrap();
+        fs::set_permissions(target.path(), fs::Permissions::from_mode(0o600)).unwrap();
+        let e = entry_with_permissions(target.path().to_path_buf(), "alias x=y", "m", "600");
+        assert!(matches!(m.classify(&e).unwrap(), Operation::Noop));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn classify_matching_block_with_wrong_permission_is_repair() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        target
+            .write_str("# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\n")
+            .unwrap();
+        fs::set_permissions(target.path(), fs::Permissions::from_mode(0o644)).unwrap();
+        let e = entry_with_permissions(target.path().to_path_buf(), "alias x=y", "m", "600");
+        match m.classify(&e).unwrap() {
+            Operation::Repair { current, desired } => {
+                assert_eq!(current.bits(), 0o644);
+                assert_eq!(desired.bits(), 0o600);
+            }
+            other => panic!("expected Repair, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn materialize_repair_only_changes_permission_not_content() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.child("file.txt");
+        let original = "before\n# >>> over: m >>>\nalias x=y\n# <<< over: m <<<\nafter\n";
+        target.write_str(original).unwrap();
+        fs::set_permissions(target.path(), fs::Permissions::from_mode(0o644)).unwrap();
+
+        let e = entry_with_permissions(target.path().to_path_buf(), "alias x=y", "m", "600");
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Repair {
+                current: FileMode::parse("644").unwrap(),
+                desired: FileMode::parse("600").unwrap(),
+            },
+        };
+        let ctx = crate::exec::Context::builder().build();
+        m.materialize(ctx, &step).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(target.path()).unwrap(),
+            original,
+            "Repair must never touch content"
+        );
+        let mode = fs::metadata(target.path()).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn materialize_create_applies_declared_permission() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let m = PartialFileMaterializer;
+        let td = TempDir::new().unwrap();
+        let target = td.path().join("file.txt");
+        let e = entry_with_permissions(target.clone(), "alias x=y", "m", "600");
+        let step = PlanStep {
+            entry: e,
+            operation: Operation::Create,
+        };
+        let ctx = crate::exec::Context::builder().build();
+        m.materialize(ctx, &step).await.unwrap();
+
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o7777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/src/materialize/symlink.rs
+++ b/src/materialize/symlink.rs
@@ -331,6 +331,7 @@ mod tests {
                 source: PathBuf::from("/repo/ov"),
             },
             intent,
+            permissions: None,
         }
     }
 
@@ -431,6 +432,7 @@ mod tests {
                 source: PathBuf::from("/repo/ov"),
             },
             intent: MaterializationIntent::Directory,
+            permissions: None,
         };
         let ctx = Context::builder().build();
         let action = build_action(ctx, &entry);
@@ -524,6 +526,7 @@ mod tests {
                 source: source.path().to_path_buf(),
             },
             intent: MaterializationIntent::Directory,
+            permissions: None,
         };
         match m.classify(&e).unwrap() {
             Operation::Migrate { from, to, blocked } => {
@@ -557,6 +560,7 @@ mod tests {
                 source: PathBuf::from("/repo/ov/somewhere-else"),
             },
             intent: MaterializationIntent::Directory,
+            permissions: None,
         };
         assert!(matches!(
             m.classify(&e).unwrap(),
@@ -591,6 +595,7 @@ mod tests {
                 source: source.path().to_path_buf(),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         match m.classify(&e).unwrap() {
             Operation::Migrate { from, to, blocked } => {
@@ -625,6 +630,7 @@ mod tests {
                 source: source.path().to_path_buf(),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         assert!(matches!(
             m.classify(&e).unwrap(),
@@ -654,6 +660,7 @@ mod tests {
                 source: source.path().to_path_buf(),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let step = PlanStep {
             entry: e,
@@ -699,6 +706,7 @@ mod tests {
                 source: source.clone(),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let step = PlanStep {
             entry: e,
@@ -739,6 +747,7 @@ mod tests {
                 source: PathBuf::from("/opt/x"),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let ctx = Context::builder().build();
         let action = build_action(ctx, &entry);

--- a/src/overlays/mod.rs
+++ b/src/overlays/mod.rs
@@ -15,11 +15,13 @@ pub(crate) const EXTENSIONS: &[&str] = &["yml", "yaml", "toml"];
 
 pub mod discovery;
 pub mod overlay;
+pub mod permissions;
 pub mod repository;
 pub mod rules;
 
 pub use discovery::OverlayDeclaration;
 pub use overlay::Overlay;
+pub use permissions::{FileMode, PermissionRule};
 pub use repository::Repository;
 pub use rules::{Defaults, MaterializationKind, MaterializationRule};
 

--- a/src/overlays/overlay.rs
+++ b/src/overlays/overlay.rs
@@ -17,6 +17,7 @@ use crate::plan::Plan;
 use crate::ui;
 use crate::ui::{emojis, style};
 
+use super::permissions::{self, FileMode, PermissionRule};
 use super::rules::{self, Defaults, MaterializationKind, MaterializationRule};
 use super::{DEFAULT_TARGET, Repository};
 
@@ -104,6 +105,13 @@ pub struct Overlay {
     /// `materialization: symlink-directory` (ADR-017) — prefer `rules`
     /// for new configs; both resolve through [`rules::resolve`].
     pub link_dirs: Option<Vec<String>>,
+
+    /// Path/subtree permission overrides (#65); most specific match wins —
+    /// see [`permissions::resolve`]. Only meaningful for entries `over`
+    /// writes content for directly (`PartialFile` today); symlinked
+    /// entries share their source's permission and are never looked up
+    /// this way (ADR-020).
+    pub permissions: Option<Vec<PermissionRule>>,
 }
 
 impl fmt::Display for Overlay {
@@ -204,6 +212,15 @@ impl Overlay {
     /// (#113/#126) — see [`Self::materialization_for`].
     pub fn is_link_dir(&self, rel_path: &Path) -> bool {
         self.materialization_for(rel_path) == MaterializationKind::SymlinkDirectory
+    }
+
+    /// Resolve the effective desired [`FileMode`] for `rel_path` (most
+    /// specific `permissions` entry, else `defaults.mode`, else `None`) —
+    /// see [`permissions::resolve`]. Only meaningful for entries `over`
+    /// writes content for directly (`PartialFile`, #65); symlinked entries
+    /// share their source's permission and are never looked up this way.
+    pub fn permission_for(&self, rel_path: &Path) -> Option<FileMode> {
+        permissions::resolve(self, rel_path)
     }
 
     /// Check if a relative path matches any `exclude` glob pattern.

--- a/src/overlays/permissions.rs
+++ b/src/overlays/permissions.rs
@@ -1,0 +1,243 @@
+//! File permission rules (#65): a default permission mode plus
+//! path/subtree overrides, resolved into a [`FileMode`] for entries `over`
+//! writes real content for directly.
+//!
+//! Mirrors [`super::rules`] structurally (same `defaults`/`rules`-shaped
+//! config, same specificity precedence), but resolves against a
+//! [`crate::desired::MaterializationIntent::PartialFile`] entry's own
+//! sidecar-relative path (its stem), not a path walked from the overlay's
+//! own file tree — symlinked entries share their source's inode and have
+//! no independent permission of their own to manage this way (see
+//! ADR-020).
+
+use std::fmt;
+use std::num::ParseIntError;
+use std::path::Path;
+
+use globset::GlobBuilder;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::overlay::Overlay;
+
+/// A desired unix permission mode: the low 12 bits (`rwxrwxrwx` plus
+/// setuid/setgid/sticky), declared in config as an octal string (`"644"`,
+/// `"0755"`, `"4755"`) and enforced only for entries `over` writes real
+/// content for (currently `MaterializationIntent::PartialFile`, #65).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileMode(u32);
+
+impl FileMode {
+    /// Parse an octal permission string, masked to the low 12 bits so a
+    /// stray leading digit (or an accidentally-decimal value) can never
+    /// escape into filetype bits `std::fs::Permissions` doesn't expose
+    /// anyway.
+    pub fn parse(s: &str) -> Result<Self, ParseIntError> {
+        let trimmed = s.trim_start_matches("0o");
+        let value = u32::from_str_radix(trimmed, 8)?;
+        Ok(Self(value & 0o7777))
+    }
+
+    /// Build a `FileMode` from raw mode bits (e.g. `Permissions::mode()`),
+    /// masking to the same low 12 bits `parse` does.
+    pub fn from_bits(bits: u32) -> Self {
+        Self(bits & 0o7777)
+    }
+
+    pub fn bits(&self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for FileMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:o}", self.0)
+    }
+}
+
+impl Serialize for FileMode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for FileMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FileMode::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A single path/subtree permission override. `path` matches a
+/// [`MaterializationIntent::PartialFile`](crate::desired::MaterializationIntent::PartialFile)
+/// entry's own sidecar stem (e.g. `ssh/agent` for `ssh/agent.partial.toml`),
+/// not a real file in the overlay's walked tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionRule {
+    pub path: String,
+    pub mode: FileMode,
+}
+
+impl PermissionRule {
+    /// Whether `rel_path` matches this rule's `path` glob. A malformed
+    /// glob never matches — mirrors `MaterializationRule::matches`.
+    fn matches(&self, rel_path: &Path) -> bool {
+        GlobBuilder::new(&self.path)
+            .literal_separator(true)
+            .build()
+            .ok()
+            .is_some_and(|glob| glob.compile_matcher().is_match(rel_path))
+    }
+
+    /// Same specificity ranking as `MaterializationRule::specificity`: a
+    /// literal pattern always outranks a glob, and within the same tier a
+    /// longer pattern is more specific.
+    fn specificity(&self) -> (bool, usize) {
+        let is_literal = !self.path.contains(['*', '?', '[', '{']);
+        (is_literal, self.path.len())
+    }
+}
+
+/// Resolve the effective [`FileMode`] for `rel_path`, in precedence order:
+///
+/// 1. the most specific matching `permissions` entry;
+/// 2. `defaults.mode`;
+/// 3. `None` — no declared permission, left entirely unmanaged (today's
+///    behavior for anyone who hasn't opted in).
+pub(super) fn resolve(overlay: &Overlay, rel_path: &Path) -> Option<FileMode> {
+    let rules = overlay.permissions.iter().flatten();
+    let best = rules
+        .filter(|rule| rule.matches(rel_path))
+        .max_by_key(|rule| rule.specificity());
+    match best {
+        Some(rule) => Some(rule.mode),
+        None => overlay.defaults.and_then(|d| d.mode),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overlays::Repository;
+    use assert_fs::TempDir;
+    use assert_fs::prelude::*;
+    use rstest::rstest;
+
+    fn setup_overlay(toml_content: &str) -> Overlay {
+        let td = TempDir::new().unwrap();
+        let repo = Repository::new(td.path().to_path_buf());
+        let ov = td.child("ov");
+        ov.create_dir_all().unwrap();
+        ov.child("over.toml").write_str(toml_content).unwrap();
+        let overlay = repo.get("ov").unwrap();
+        // Keep `td` alive for the overlay's lifetime (test-only leak).
+        Box::leak(Box::new(td));
+        overlay
+    }
+
+    #[rstest]
+    #[case("644")]
+    #[case("0644")]
+    fn file_mode_parses_octal_strings_with_and_without_a_leading_zero(#[case] input: &str) {
+        assert_eq!(FileMode::parse(input).unwrap().bits(), 0o644);
+    }
+
+    #[test]
+    fn file_mode_display_renders_octal_without_leading_zero() {
+        assert_eq!(FileMode::parse("755").unwrap().to_string(), "755");
+    }
+
+    #[test]
+    fn file_mode_masks_extraneous_high_bits() {
+        // A raw `st_mode` value carries file-type bits above the
+        // permission bits (e.g. `0o100644` for a regular file) — only the
+        // low 12 bits are ever meaningful here.
+        assert_eq!(FileMode::from_bits(0o100644).bits(), 0o644);
+    }
+
+    #[test]
+    fn file_mode_invalid_octal_string_is_an_error() {
+        assert!(FileMode::parse("not-octal").is_err());
+        assert!(FileMode::parse("999").is_err());
+    }
+
+    #[rstest]
+    fn no_defaults_no_rules_resolves_to_none() {
+        let overlay = setup_overlay("target = \"~\"");
+        assert_eq!(resolve(&overlay, Path::new("anything")), None);
+    }
+
+    #[rstest]
+    fn defaults_mode_applies_to_every_unmatched_path() {
+        let overlay = setup_overlay("target = \"~\"\n[defaults]\nmode = \"600\"");
+        assert_eq!(
+            resolve(&overlay, Path::new("any/path")),
+            Some(FileMode::parse("600").unwrap())
+        );
+    }
+
+    #[rstest]
+    fn a_rule_overrides_the_default_for_its_own_path_only() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[defaults]
+mode = "644"
+
+[[permissions]]
+path = "secrets"
+mode = "600"
+"#,
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("secrets")),
+            Some(FileMode::parse("600").unwrap())
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("other")),
+            Some(FileMode::parse("644").unwrap())
+        );
+    }
+
+    #[rstest]
+    fn a_literal_rule_wins_over_an_overlapping_glob_rule() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[[permissions]]
+path = "ssh/*"
+mode = "644"
+
+[[permissions]]
+path = "ssh/agent"
+mode = "600"
+"#,
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("ssh/agent")),
+            Some(FileMode::parse("600").unwrap())
+        );
+        assert_eq!(
+            resolve(&overlay, Path::new("ssh/config")),
+            Some(FileMode::parse("644").unwrap())
+        );
+    }
+
+    #[rstest]
+    fn no_matching_rule_and_no_defaults_is_none_even_with_other_rules_present() {
+        let overlay = setup_overlay(
+            r#"
+target = "~"
+[[permissions]]
+path = "secrets"
+mode = "600"
+"#,
+        );
+        assert_eq!(resolve(&overlay, Path::new("unrelated")), None);
+    }
+}

--- a/src/overlays/rules.rs
+++ b/src/overlays/rules.rs
@@ -19,6 +19,7 @@ use globset::GlobBuilder;
 use serde::{Deserialize, Serialize};
 
 use super::overlay::Overlay;
+use super::permissions::FileMode;
 
 /// How a directory-shaped entry should be materialized once a `rules`/
 /// `defaults` entry has been resolved for it (or none matched).
@@ -43,15 +44,22 @@ impl fmt::Display for MaterializationKind {
     }
 }
 
-/// Repository- or overlay-level default materialization, applied when no
-/// `rules` entry matches a given path. Inherited through the same
-/// cascading descriptor chain as every other overlay field (ADR-002): a
-/// root `over.toml` sets a repository-wide baseline, and any ancestor
-/// down to the overlay's own directory can override it.
+/// Repository- or overlay-level default materialization (and, since #65,
+/// default permission mode), applied when no more specific override
+/// matches a given path. Inherited through the same cascading descriptor
+/// chain as every other overlay field (ADR-002): a root `over.toml` sets a
+/// repository-wide baseline, and any ancestor down to the overlay's own
+/// directory can override it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Defaults {
     #[serde(default)]
     pub materialization: MaterializationKind,
+    /// Default permission mode for entries `over` writes content for
+    /// directly (`PartialFile`, #65) with no more specific `permissions`
+    /// rule — see [`super::permissions::resolve`]. `None` (the default)
+    /// leaves permissions entirely unmanaged, matching pre-#65 behavior.
+    #[serde(default)]
+    pub mode: Option<FileMode>,
 }
 
 /// A single path/subtree materialization override.

--- a/src/plan/reconcile.rs
+++ b/src/plan/reconcile.rs
@@ -16,7 +16,7 @@ use super::step::{Operation, PlanStep};
 /// does too (#129) — a blocked one doesn't, exactly like `Noop`/`Deferred`.
 fn is_actionable(operation: &Operation) -> bool {
     match operation {
-        Operation::Create | Operation::Conflict { .. } => true,
+        Operation::Create | Operation::Conflict { .. } | Operation::Repair { .. } => true,
         Operation::Migrate { blocked, .. } => blocked.is_none(),
         Operation::Noop | Operation::Deferred => false,
     }
@@ -170,17 +170,23 @@ impl fmt::Display for Plan {
             .iter()
             .filter(|s| matches!(s.operation, Operation::Deferred))
             .count();
+        let repair = self
+            .steps
+            .iter()
+            .filter(|s| matches!(s.operation, Operation::Repair { .. }))
+            .count();
 
         writeln!(
             f,
             "{} {} to create, {} unchanged, {} conflict(s), {} to migrate, \
-             {} migration(s) blocked, {} deferred",
+             {} migration(s) blocked, {} to repair, {} deferred",
             style::white_b("Plan:"),
             create,
             noop,
             conflicts,
             migrate,
             blocked,
+            repair,
             deferred,
         )?;
         for step in self
@@ -447,6 +453,15 @@ mod tests {
     }
 
     #[test]
+    fn repair_is_actionable() {
+        let op = Operation::Repair {
+            current: crate::overlays::FileMode::parse("644").unwrap(),
+            desired: crate::overlays::FileMode::parse("600").unwrap(),
+        };
+        assert!(is_actionable(&op));
+    }
+
+    #[test]
     fn blocked_migrate_is_not_actionable() {
         let op = Operation::Migrate {
             from: MaterializationIntent::Checkout,
@@ -471,6 +486,7 @@ mod tests {
                 source: PathBuf::from("/src"),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let plan = Plan {
             steps: vec![PlanStep {

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::desired::{DesiredEntry, MaterializationIntent};
+use crate::overlays::FileMode;
 use crate::ui::{emojis, style};
 use crate::utils::short_path;
 
@@ -44,6 +45,17 @@ pub enum Operation {
     /// something sensible instead of panicking; [`super::Plan::execute`]
     /// never acts on it.
     Deferred,
+    /// Target already matches desired content/kind, but its permission mode
+    /// differs from what's declared (#65) — auto-fixable, unlike a real
+    /// `Conflict`: nothing structural is wrong, only a `chmod` is needed.
+    /// Only ever produced for
+    /// [`MaterializationIntent::PartialFile`](crate::desired::MaterializationIntent::PartialFile)
+    /// entries with a declared `permissions` (ADR-020); every other intent's
+    /// permission is unmanaged and never classifies this way.
+    Repair {
+        current: FileMode,
+        desired: FileMode,
+    },
 }
 
 /// Short, human-readable word for a [`MaterializationIntent`], used only by
@@ -232,6 +244,15 @@ impl fmt::Display for PlanStep {
             // step should ever classify as `Deferred` anymore — unreachable
             // in practice, but a clear fallback beats a silently wrong line.
             (_, Operation::Deferred) => write!(f, "{} deferred: {}", emojis::WARNING, target),
+            (_, Operation::Repair { current, desired }) => write!(
+                f,
+                "{} {} {} ({} -> {})",
+                emojis::LOCK,
+                style::yellow("repair permissions:"),
+                target,
+                current,
+                desired,
+            ),
         }
     }
 }
@@ -251,6 +272,7 @@ mod tests {
                 source: PathBuf::from("/repo/ov/app"),
             },
             intent,
+            permissions: None,
         }
     }
 
@@ -435,6 +457,23 @@ mod tests {
         assert!(s.contains("migrate blocked:"));
         assert!(s.contains("checkout -> directory symlink"));
         assert!(s.contains("has uncommitted changes"));
+    }
+
+    #[test]
+    fn repair_permissions_display() {
+        let step = PlanStep {
+            entry: entry(MaterializationIntent::PartialFile {
+                content: "alias x=y".to_string(),
+                marker: "aliases".to_string(),
+            }),
+            operation: Operation::Repair {
+                current: FileMode::parse("644").unwrap(),
+                desired: FileMode::parse("600").unwrap(),
+            },
+        };
+        let s = format!("{step}");
+        assert!(s.contains("repair permissions:"));
+        assert!(s.contains("644 -> 600"));
     }
 
     #[test]

--- a/src/status/git.rs
+++ b/src/status/git.rs
@@ -209,6 +209,7 @@ mod tests {
                 config: Box::new(config),
             },
             intent: crate::desired::MaterializationIntent::Checkout,
+            permissions: None,
         }
     }
 

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -30,7 +30,9 @@ pub enum Status {
     Applied,
     /// Target doesn't exist yet.
     Missing,
-    /// A git checkout has uncommitted changes.
+    /// A git checkout has uncommitted changes, or a filesystem entry's
+    /// content/kind already matches but its permission mode differs (#65,
+    /// `Operation::Repair`) — auto-fixable on the next `apply`.
     Modified,
     /// A dangling soft symlink (correctly pointed, but its source
     /// disappeared), or a checkout path that isn't a valid git repo.
@@ -190,6 +192,11 @@ impl Report {
                 // `Conflict` is accurate (and an improvement over silently
                 // misclassifying these as `Noop`, as happened before #129).
                 (_, Operation::Migrate { .. }) => Status::Conflict,
+                // A permission-only drift (#65): content/kind already
+                // matches, only the mode needs fixing — auto-fixable, not a
+                // real conflict, so it's reported the same way a dirty git
+                // checkout is.
+                (_, Operation::Repair { .. }) => Status::Modified,
                 (_, Operation::Deferred) => {
                     unreachable!("only Checkout entries ever classify as Deferred")
                 }
@@ -446,6 +453,7 @@ mod tests {
                         source: std::path::PathBuf::from("/repo/ov"),
                     },
                     intent: MaterializationIntent::Directory,
+                    permissions: None,
                 },
                 status,
             }
@@ -491,6 +499,7 @@ mod tests {
                         source: std::path::PathBuf::from("/repo/ov"),
                     },
                     intent: MaterializationIntent::Directory,
+                    permissions: None,
                 },
                 status,
             }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -458,6 +458,7 @@ mod tests {
                 config: Box::new(config),
             },
             intent: MaterializationIntent::Checkout,
+            permissions: None,
         }
     }
 

--- a/src/ui/emojis.rs
+++ b/src/ui/emojis.rs
@@ -14,6 +14,7 @@ pub static WARNING: Emoji<'_, '_> = Emoji("⚠️", "");
 pub static TRASH: Emoji<'_, '_> = Emoji("🗑️", "");
 pub static BLOCK: Emoji<'_, '_> = Emoji("🧩", "");
 pub static MIGRATE: Emoji<'_, '_> = Emoji("🔀", "");
+pub static LOCK: Emoji<'_, '_> = Emoji("🔒", "");
 // static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍  ", "");
 // static TRUCK: Emoji<'_, '_> = Emoji("🚚  ", "");
 // static CLIP: Emoji<'_, '_> = Emoji("🔗  ", "");

--- a/src/unapply/mod.rs
+++ b/src/unapply/mod.rs
@@ -197,7 +197,11 @@ impl Report {
                     other => Outcome::CheckoutNotClean { status: other },
                 },
                 (_, Operation::Create) => Outcome::AlreadyAbsent,
-                (_, Operation::Noop) => Outcome::Removed,
+                // A permission-only drift (#65) doesn't change ownership:
+                // the content is still exactly what this overlay put
+                // there, only its mode needs a `chmod` — just as safe to
+                // remove as a plain `Noop`.
+                (_, Operation::Noop | Operation::Repair { .. }) => Outcome::Removed,
                 (_, Operation::Conflict { current }) => Outcome::NotOwned {
                     current: current.clone(),
                 },
@@ -533,6 +537,7 @@ mod tests {
                 source,
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let desired = DesiredTree::from_entries(vec![entry]);
         let report = Report::build(&desired).unwrap();
@@ -558,6 +563,7 @@ mod tests {
                 content: content.to_string(),
                 marker: marker.to_string(),
             },
+            permissions: None,
         }
     }
 
@@ -831,6 +837,7 @@ mod tests {
                 }),
             },
             intent: MaterializationIntent::Checkout,
+            permissions: None,
         }
     }
 
@@ -877,6 +884,7 @@ mod tests {
                 source: PathBuf::from("/repo/ov"),
                 link_type: LinkType::Soft,
             },
+            permissions: None,
         };
         let desired = DesiredTree::from_entries(vec![entry]);
         let report = Report::build(&desired).unwrap();
@@ -1120,6 +1128,7 @@ mod tests {
                         source: PathBuf::from("/repo/ov/target"),
                         link_type: LinkType::Soft,
                     },
+                    permissions: None,
                 },
                 outcome,
             }


### PR DESCRIPTION
`DesiredEntry` now carries an optional permission mode (#65), preserved in
the desired-state model and compared against actual permissions during
`over apply`/`over status`/`over diff`.

Permissions are declared the same way materialization rules already are
(ADR-017): a `defaults.mode` baseline plus `[[permissions]] path/mode`
path/subtree overrides, cascading through the same overlay descriptor
chain and resolved with the same specificity precedence.

This is scoped to `PartialFile` entries — the one place `over` writes real,
target-owned content directly today. A symlinked file/directory shares its
overlay source's inode: there is no independent target permission to set
without `over` mutating that tracked source file, which stays out of scope
(see ADR-020 for the reasoning).

A permission-only drift on an otherwise-correctly-materialized entry
(content already matches, only the mode differs) is a new, auto-fixable
`Operation::Repair` — never a blocking conflict. `over status` reports it
as `modified`, `over diff` shows a `644 -> 600`-style change, and `over
apply` fixes it on the next run.

`over lint` gains matching checks for the new `permissions` field,
mirroring the existing `rules` checks.

Closes #65
